### PR TITLE
fix(cors): restrict CORS origins via ALLOWED_ORIGINS env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,12 @@
 SECRET_KEY=change-me-in-production
 DATABASE_URL=sqlite:///./data/app.db
 
+# ── Environment & CORS ──────────────────────────────
+ENVIRONMENT=development
+# In production, set ENVIRONMENT=production and list your allowed origins:
+# ALLOWED_ORIGINS=https://yourapp.com,https://www.yourapp.com
+ALLOWED_ORIGINS=http://localhost:3000,http://localhost:7860
+
 # ── HuggingFace (Required for LLM) ──────────────────
 HF_TOKEN=your_huggingface_token_here
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -12,6 +12,8 @@ class Settings(BaseSettings):
     APP_NAME: str = "Document AI Analyst"
     SECRET_KEY: str = "change-me-in-production-please"
     DEBUG: bool = False
+    ENVIRONMENT: str = "development"
+    ALLOWED_ORIGINS: str = "http://localhost:3000,http://localhost:7860"
 
     # ── Database ─────────────────────────────────────────
     DATABASE_URL: str = "sqlite:///./data/app.db"
@@ -46,6 +48,13 @@ class Settings(BaseSettings):
 
     # ── Reranker ─────────────────────────────────────────
     RERANKER_MODEL: str = "cross-encoder/ms-marco-MiniLM-L-6-v2"
+
+
+    @property
+    def cors_origins(self) -> list[str]:
+        if self.ENVIRONMENT == "production":
+            return [o.strip() for o in self.ALLOWED_ORIGINS.split(",")]
+        return ["*"]
 
     class Config:
         env_file = ".env"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -63,11 +63,12 @@ app = FastAPI(
 # ── CORS (allow frontend dev server) ─────────────────
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:3000", "http://localhost:7860", "*"],
+    allow_origins=settings.cors_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
 )
+logger.info(f"CORS origins: {settings.cors_origins}")
 
 # ── Mount API Routes ─────────────────────────────────
 from app.routes.auth import router as auth_router


### PR DESCRIPTION
## Summary
Closes #65

The previous CORS configuration hardcoded `["*"]` as an allowed origin,
giving no way to restrict access in production.

## Changes
- Added `ENVIRONMENT` (default: `development`) and `ALLOWED_ORIGINS`
  (default: localhost origins) to `Settings` in `config.py`
- Added `cors_origins` property that returns `["*"]` in development
  and parses `ALLOWED_ORIGINS` as a comma-separated list in production
- Updated `CORSMiddleware` in `main.py` to use `settings.cors_origins`
- Added startup log showing which origins are active
- Updated `.env.example` to document both new variables

## How to use in production
Set these in your `.env`:
ENVIRONMENT=production
ALLOWED_ORIGINS=url