### PR TITLE
fix(source-card): display 1-indexed page numbers instead of 0-indexed

### DIFF
--- a/frontend/src/components/chat/SourceCard.tsx
+++ b/frontend/src/components/chat/SourceCard.tsx
@@ -42,9 +42,9 @@ export default function SourceCard({ sources, onPageClick }: Props) {
               key={i}
               variant="secondary"
               className="text-[10px] h-5 cursor-pointer hover:bg-primary/20 transition-colors"
-              onClick={() => onPageClick(src.page)}
+              onClick={() => onPageClick(src.page + 1)}
             >
-              p.{src.page} • {src.confidence}%
+              p.{src.page + 1} • {src.confidence}%
             </Badge>
           ))}
         </div>
@@ -64,7 +64,7 @@ export default function SourceCard({ sources, onPageClick }: Props) {
                     {src.filename}
                   </span>
                   <Badge variant="outline" className="text-[9px] h-4 px-1.5">
-                    Page {src.page}
+                    Page {src.page + 1}
                   </Badge>
                   <Badge
                     variant="secondary"
@@ -83,7 +83,7 @@ export default function SourceCard({ sources, onPageClick }: Props) {
                   variant="ghost"
                   size="sm"
                   className="h-6 px-2 text-[10px]"
-                  onClick={() => onPageClick(src.page)}
+                  onClick={() => onPageClick(src.page + 1)}
                 >
                   <Eye className="w-3 h-3 mr-1" />
                   View


### PR DESCRIPTION
## Summary

Fixes #19

Source citation cards showed page numbers offset by one (e.g., "Page 0" for content from the first page) because the backend returns 0-indexed page numbers from the PDF parser but the UI should display 1-indexed values to users.

## Root Cause

The `SourceCard` component in `frontend/src/components/chat/SourceCard.tsx` rendered `src.page` directly without adding 1. The PDF viewer (`PDFViewer.tsx`) uses 1-indexed navigation (`currentPage >= 1`), so both display labels and `onPageClick` navigation needed the same correction.

## Fix

Added `+ 1` to `src.page` in all four locations where page numbers are referenced:
- Collapsed badge display: `p.{src.page + 1}`
- Collapsed badge click handler: `onPageClick(src.page + 1)`
- Expanded source card label: `Page {src.page + 1}`
- Expanded View button handler: `onPageClick(src.page + 1)`

## Changes

- `frontend/src/components/chat/SourceCard.tsx`: 4 display/navigation spots corrected (`+4 -4` lines)

## Testing

- First page content: Source card now shows "Page 1" instead of "Page 0" ✅
- Multi-page document citation: Each citation shows correct 1-indexed page number ✅
- Click navigation from source card: PDF viewer opens correct 1-indexed page ✅
- Collapsed badge view: Displays correct page number and navigates correctly ✅