### PR TITLE
fix: auto-resize chat textarea

### DIFF
--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -35,8 +35,21 @@ export default function ChatPanel({ activeDoc, onCitationClick }: Props) {
   const [messages, setMessages] = useState<ChatMsg[]>([]);
   const [input, setInput] = useState("");
   const [streaming, setStreaming] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
   const prevDocId = useRef<string | null>(null);
+
+  useEffect(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+
+    textarea.style.height = "auto";
+    const maxHeight = 128;
+    const nextHeight = Math.min(textarea.scrollHeight, maxHeight);
+    textarea.style.height = `${nextHeight}px`;
+    textarea.style.overflowY =
+      textarea.scrollHeight > maxHeight ? "auto" : "hidden";
+  }, [input]);
 
   // Auto-scroll to bottom whenever messages change
   useEffect(() => {
@@ -205,6 +218,7 @@ export default function ChatPanel({ activeDoc, onCitationClick }: Props) {
       <div className="border-t border-border/50 p-4 bg-card/30 backdrop-blur-sm">
         <div className="max-w-3xl mx-auto flex gap-2 items-end">
           <Textarea
+            ref={textareaRef}
             id="chat-input"
             value={input}
             onChange={(e) => setInput(e.target.value)}

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -44,7 +44,12 @@ export default function ChatPanel({ activeDoc, onCitationClick }: Props) {
     if (!textarea) return;
 
     textarea.style.height = "auto";
-    const maxHeight = 128;
+    const computedMaxHeight = Number.parseFloat(
+      window.getComputedStyle(textarea).maxHeight
+    );
+    const maxHeight = Number.isFinite(computedMaxHeight)
+      ? computedMaxHeight
+      : textarea.scrollHeight;
     const nextHeight = Math.min(textarea.scrollHeight, maxHeight);
     textarea.style.height = `${nextHeight}px`;
     textarea.style.overflowY =

--- a/frontend/src/components/ui/textarea.tsx
+++ b/frontend/src/components/ui/textarea.tsx
@@ -2,9 +2,13 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+const Textarea = React.forwardRef<
+  HTMLTextAreaElement,
+  React.ComponentProps<"textarea">
+>(({ className, ...props }, ref) => {
   return (
     <textarea
+      ref={ref}
       data-slot="textarea"
       className={cn(
         "flex field-sizing-content min-h-16 w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-base transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
@@ -13,6 +17,8 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
       {...props}
     />
   )
-}
+})
+
+Textarea.displayName = "Textarea"
 
 export { Textarea }


### PR DESCRIPTION
## Summary

- Make the chat textarea grow with multi-line input up to the existing `max-h-32` limit.
- Reset the textarea height when the input is cleared after sending.

## Related Issue

Closes #13.

## Changes

- Added a textarea ref in `ChatPanel`.
- Recalculate the textarea height whenever `input` changes.
- Keep scrolling available after the textarea reaches the 128px maximum height.

## Validation

- `npm ci`
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`
- `git diff --check`
- `git diff --cached --check`
- `gitleaks protect --staged --no-banner --redact`

## Notes

`npm ci` reported existing dependency audit findings, but this PR does not change dependencies or lockfiles.
