### PR TITLE
fix: clear chat messages on document switch

### DIFF
--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -45,14 +45,26 @@ export default function ChatPanel({ activeDoc, onCitationClick }: Props) {
 
   // Load history on doc change
   useEffect(() => {
-    if (!activeDoc || activeDoc.id === prevDocId.current) return;
-    prevDocId.current = activeDoc.id;
+    if (!activeDoc) {
+      prevDocId.current = null;
+      setMessages([]);
+      return;
+    }
+
+    if (activeDoc.id === prevDocId.current) return;
+
+    const documentId = activeDoc.id;
+    prevDocId.current = documentId;
+    setMessages([]);
+    let cancelled = false;
 
     api
       .get<{ messages: Array<{ id: string; role: string; content: string; sources?: SourceChunk[] }> }>(
-        `/api/v1/chat/history/${activeDoc.id}`
+        `/api/v1/chat/history/${documentId}`
       )
       .then((data) => {
+        if (cancelled || prevDocId.current !== documentId) return;
+
         setMessages(
           data.messages.map((m) => ({
             id: m.id,
@@ -62,7 +74,14 @@ export default function ChatPanel({ activeDoc, onCitationClick }: Props) {
           }))
         );
       })
-      .catch(() => setMessages([]));
+      .catch(() => {
+        if (cancelled || prevDocId.current !== documentId) return;
+        setMessages([]);
+      });
+
+    return () => {
+      cancelled = true;
+    };
   }, [activeDoc]);
 
   const handleSend = async () => {


### PR DESCRIPTION
## Summary

- Clears the chat panel immediately when switching to a different document.
- Guards the async history response so an older document's request cannot repopulate messages after a newer selection.

Closes #15.

## Validation

- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`
- `git diff --check`
- `git diff --cached --check`
- `gitleaks detect --pipe --redact --no-banner`
- `gitleaks protect --staged --redact --no-banner`

## Notes

- No dependency changes.
- I did not add a component test because this repo does not appear to have frontend component test coverage set up.
