### PR TITLE
fix: show backend offline error message

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/lib/auth";
-import { api } from "@/lib/api";
+import { api, CONNECTION_ERROR_BANNER_MESSAGE, CONNECTION_ERROR_MESSAGE } from "@/lib/api";
 import Header from "@/components/layout/Header";
 import DocumentSidebar from "@/components/document/DocumentSidebar";
 import ChatPanel from "@/components/chat/ChatPanel";
@@ -29,6 +29,7 @@ export default function DashboardPage() {
   const [pdfPage, setPdfPage] = useState(1);
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const [viewerOpen, setViewerOpen] = useState(true);
+  const [connectionError, setConnectionError] = useState("");
 
   // Auth guard
   useEffect(() => {
@@ -40,8 +41,14 @@ export default function DashboardPage() {
     try {
       const data = await api.get<{ documents: DocInfo[] }>("/api/v1/documents/");
       setDocuments(data.documents);
-    } catch {
-      // silently fail
+      setConnectionError("");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : CONNECTION_ERROR_MESSAGE;
+      setConnectionError(
+        message === CONNECTION_ERROR_MESSAGE
+          ? CONNECTION_ERROR_BANNER_MESSAGE
+          : `⚠️ ${message}`
+      );
     }
   }, []);
 
@@ -80,6 +87,15 @@ export default function DashboardPage() {
         viewerOpen={viewerOpen}
         onToggleViewer={() => setViewerOpen(!viewerOpen)}
       />
+
+      {connectionError && (
+        <div
+          role="alert"
+          className="border-b border-destructive/30 bg-destructive/10 px-4 py-2 text-sm text-destructive"
+        >
+          {connectionError}
+        </div>
+      )}
 
       <div className="flex-1 flex overflow-hidden">
         {/* ── Left: Document Sidebar ──────────────── */}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4,6 +4,8 @@
  */
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || "";
+const CONNECTION_ERROR_MESSAGE = "Could not connect to the server. Please try again later.";
+const CONNECTION_ERROR_BANNER_MESSAGE = `⚠️ ${CONNECTION_ERROR_MESSAGE}`;
 
 interface FetchOptions extends RequestInit {
   token?: string;
@@ -34,23 +36,71 @@ class ApiClient {
     return headers;
   }
 
+  private async fetchWithConnectionError(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+    try {
+      return await fetch(input, init);
+    } catch (error) {
+      if (error instanceof TypeError) {
+        throw new Error(CONNECTION_ERROR_MESSAGE);
+      }
+      throw error;
+    }
+  }
+
+  private getPayloadMessage(payload: unknown): string | null {
+    if (typeof payload === "string" && payload.trim()) {
+      return payload;
+    }
+
+    if (Array.isArray(payload)) {
+      const messages = payload
+        .map((item) => {
+          if (typeof item === "string") return item;
+          if (item && typeof item === "object" && "msg" in item && typeof item.msg === "string") {
+            return item.msg;
+          }
+          return null;
+        })
+        .filter((message): message is string => Boolean(message));
+
+      return messages.length > 0 ? messages.join(", ") : null;
+    }
+
+    return null;
+  }
+
+  private async getErrorMessage(res: Response, fallback: string): Promise<string> {
+    const payload = await res.json().catch(() => null);
+
+    if (payload && typeof payload === "object") {
+      const errorPayload = payload as { detail?: unknown; error?: unknown; message?: unknown };
+      return (
+        this.getPayloadMessage(errorPayload.detail) ||
+        this.getPayloadMessage(errorPayload.message) ||
+        this.getPayloadMessage(errorPayload.error) ||
+        fallback
+      );
+    }
+
+    return this.getPayloadMessage(payload) || fallback;
+  }
+
   async get<T>(path: string, options?: FetchOptions): Promise<T> {
-    const res = await fetch(`${this.baseUrl}${path}`, {
+    const res = await this.fetchWithConnectionError(`${this.baseUrl}${path}`, {
       method: "GET",
       headers: this.getHeaders(options?.token),
       ...options,
     });
 
     if (!res.ok) {
-      const error = await res.json().catch(() => ({ detail: res.statusText }));
-      throw new Error(error.detail || "Request failed");
+      throw new Error(await this.getErrorMessage(res, res.statusText || "Request failed"));
     }
 
     return res.json();
   }
 
   async post<T>(path: string, body?: unknown, options?: FetchOptions): Promise<T> {
-    const res = await fetch(`${this.baseUrl}${path}`, {
+    const res = await this.fetchWithConnectionError(`${this.baseUrl}${path}`, {
       method: "POST",
       headers: this.getHeaders(options?.token),
       body: body ? JSON.stringify(body) : undefined,
@@ -58,8 +108,7 @@ class ApiClient {
     });
 
     if (!res.ok) {
-      const error = await res.json().catch(() => ({ detail: res.statusText }));
-      throw new Error(error.detail || "Request failed");
+      throw new Error(await this.getErrorMessage(res, res.statusText || "Request failed"));
     }
 
     return res.json();
@@ -73,7 +122,7 @@ class ApiClient {
     }
     // Don't set Content-Type — browser sets multipart boundary automatically
 
-    const res = await fetch(`${this.baseUrl}${path}`, {
+    const res = await this.fetchWithConnectionError(`${this.baseUrl}${path}`, {
       method: "POST",
       headers,
       body: formData,
@@ -81,23 +130,21 @@ class ApiClient {
     });
 
     if (!res.ok) {
-      const error = await res.json().catch(() => ({ detail: res.statusText }));
-      throw new Error(error.detail || "Upload failed");
+      throw new Error(await this.getErrorMessage(res, res.statusText || "Upload failed"));
     }
 
     return res.json();
   }
 
   async delete<T>(path: string, options?: FetchOptions): Promise<T> {
-    const res = await fetch(`${this.baseUrl}${path}`, {
+    const res = await this.fetchWithConnectionError(`${this.baseUrl}${path}`, {
       method: "DELETE",
       headers: this.getHeaders(options?.token),
       ...options,
     });
 
     if (!res.ok) {
-      const error = await res.json().catch(() => ({ detail: res.statusText }));
-      throw new Error(error.detail || "Delete failed");
+      throw new Error(await this.getErrorMessage(res, res.statusText || "Delete failed"));
     }
 
     return res.json();
@@ -108,15 +155,14 @@ class ApiClient {
    * Yields parsed SSE data objects.
    */
   async *streamPost(path: string, body: unknown): AsyncGenerator<{ type: string; data?: unknown }> {
-    const res = await fetch(`${this.baseUrl}${path}`, {
+    const res = await this.fetchWithConnectionError(`${this.baseUrl}${path}`, {
       method: "POST",
       headers: this.getHeaders(),
       body: JSON.stringify(body),
     });
 
     if (!res.ok) {
-      const error = await res.json().catch(() => ({ detail: res.statusText }));
-      throw new Error(error.detail || "Stream request failed");
+      throw new Error(await this.getErrorMessage(res, res.statusText || "Stream request failed"));
     }
 
     const reader = res.body?.getReader();
@@ -153,4 +199,4 @@ class ApiClient {
 }
 
 export const api = new ApiClient(API_BASE);
-export { API_BASE };
+export { API_BASE, CONNECTION_ERROR_BANNER_MESSAGE, CONNECTION_ERROR_MESSAGE };


### PR DESCRIPTION
## 📋 PR Checklist

> Thank you for contributing to **PDF-Assistant-RAG**! 🎉
> Please fill out this template before submitting. PRs without it filled in will be closed.

---

### 🔗 Related Issue
Closes #11

---

### 📝 What does this PR do?
Adds a focused frontend fallback for backend connection failures.

- Converts failed `fetch` network calls in the shared API client into `Could not connect to the server. Please try again later.`
- Shows the requested dashboard alert banner when document loading cannot reach the backend.
- Keeps backend JSON error handling readable by avoiding raw object/array payloads in UI-facing messages.

---

### 🗂️ Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔧 Refactor / code cleanup
- [ ] 📝 Documentation update
- [x] 🎨 UI / styling change
- [ ] ⚙️ CI / tooling / config change
- [ ] 🧪 Tests

---

### 🧪 How was this tested?
- [ ] Ran the backend locally (`uvicorn app.main:app --reload`)
- [ ] Ran the frontend locally (`npm run dev` inside `frontend/`)
- [ ] Tested the affected API endpoints manually
- [ ] Added / updated tests

Additional validation:

- `npm ci` completed successfully. It reported existing audit findings: 6 vulnerabilities (4 moderate, 2 high); this PR does not change dependencies.
- `npx tsc --noEmit`
- `npm run lint`
- `NEXT_PUBLIC_API_URL=http://localhost:8000 npm run build`
- `git diff --check HEAD~1 HEAD`
- `git diff HEAD~1 HEAD | gitleaks stdin --no-banner --redact`

---

### 📸 Screenshots (if UI change)
Not captured. The change is limited to the existing dashboard error area and was verified with type-check, lint, and production build.

---

### ⚠️ Anything to flag for reviewers?
This does not add a full React error boundary. It keeps the change scoped to API-client network failures and the dashboard document-load banner requested in the issue.

---

### ✅ Self-Review Checklist
- [x] My branch is based on **`dev`**, not `main`
- [x] I have not added any secrets / API keys
- [x] I have not modified `main` branch or any HuggingFace deployment config
- [x] My code follows the existing style (no unnecessary formatting changes)
- [x] I have updated relevant docs / comments if needed
