### PR TITLE
feat/Implement-document-list-pagination

### DIFF
--- a/backend/app/routes/documents.py
+++ b/backend/app/routes/documents.py
@@ -7,7 +7,7 @@ import uuid
 import logging
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, UploadFile, File, BackgroundTasks, status
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, File, BackgroundTasks, status, Query
 from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session
 
@@ -154,20 +154,38 @@ async def upload_document(
 
 @router.get("/", response_model=DocumentListResponse)
 def list_documents(
+    page: int = Query(1, ge=1),
+    per_page: int = Query(20, ge=1),
     user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """List all documents for the authenticated user."""
+    """Number of rows to skip"""
+    skip: int = (page - 1) * per_page
+
+    """Total Pages"""
+    totalDocuments = (
+        db.query(Document)
+        .filter(Document.user_id == user.id)
+        .count()
+    )
+    """Total Pages"""
+    pages = (totalDocuments + per_page - 1) // per_page
+    
+    """List all documents for the authenticated user in Paginated form"""
     docs = (
         db.query(Document)
         .filter(Document.user_id == user.id)
         .order_by(Document.uploaded_at.desc())
+        .offset(skip)
+        .limit(per_page)
         .all()
     )
 
     return DocumentListResponse(
-        documents=[DocumentResponse.model_validate(d) for d in docs],
-        total=len(docs),
+        items=[DocumentResponse.model_validate(d) for d in docs],
+        total=totalDocuments,
+        page=page,
+        pages=pages
     )
 
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -58,8 +58,10 @@ class DocumentResponse(BaseModel):
 
 
 class DocumentListResponse(BaseModel):
-    documents: List[DocumentResponse]
+    items: List[DocumentResponse]
     total: int
+    page: int
+    pages: int
 
 
 # ── Chat ─────────────────────────────────────────────


### PR DESCRIPTION

## 📝 What does this PR do?

Implements pagination for the document list endpoint (`GET /documents/`). Users can now retrieve documents in smaller batches using `page` and `per_page` query parameters, improving performance and user experience when dealing with large document collections.

**Key Changes:**
- Added `page` (default: 1) and `per_page` (default: 20) query parameters to `/documents/` endpoint
- Implemented offset/limit logic in database query for efficient pagination
- Calculate total pages and include in response for frontend navigation
- Return paginated results in `DocumentListResponse` model

---

## 🗂️ Type of Change
- [x] ✨ New feature

---

## 🧪 How was this tested?
- [x] Ran the backend locally (`uvicorn app.main:app --reload`)
- [x] Tested the affected API endpoints manually with various page/per_page values
- [x] Verified pagination calculations (offset, total pages, edge cases)

---

## ✅ Self-Review Checklist
- [x] My branch is based on **`dev`**, not `main`
- [x] I have not added any secrets / API keys
- [x] I have not modified `main` branch or any HuggingFace deployment config
- [x] My code follows the existing style (no unnecessary formatting changes)
- [x] I have updated relevant docs / comments if needed

### closes #31