### PR TITLE
Feat/document pagination

### DIFF
--- a/backend/app/routes/documents.py
+++ b/backend/app/routes/documents.py
@@ -21,7 +21,7 @@ from app.auth import get_current_user
 from app.config import get_settings
 from app.rag.chunker import chunk_document, get_page_count
 from app.rag.vectorstore import store_chunks, delete_document_chunks
-
+from sqlalchemy import select
 logger = logging.getLogger(__name__)
 settings = get_settings()
 
@@ -233,13 +233,8 @@ def list_documents(
     
     """List all documents for the authenticated user in Paginated form"""
     docs = (
-        db.query(Document)
-        .filter(Document.user_id == user.id)
-        .order_by(Document.uploaded_at.desc())
-        .offset(skip)
-        .limit(per_page)
-        .all()
-    )
+            db.execute(select(Document).where(Document.user_id == user.id).limit(per_page).offset(skip))
+        ).scalars().all()
 
     return DocumentListResponse(
         items=[DocumentResponse.model_validate(d) for d in docs],

--- a/backend/app/routes/documents.py
+++ b/backend/app/routes/documents.py
@@ -232,9 +232,13 @@ def list_documents(
     pages = (totalDocuments + per_page - 1) // per_page
     
     """List all documents for the authenticated user in Paginated form"""
-    docs = (
-            db.execute(select(Document).where(Document.user_id == user.id).limit(per_page).offset(skip))
-        ).scalars().all()
+    docs = ((
+            db.execute(select(Document)
+            .where(Document.user_id == user.id)
+            .order_by(Document.uploaded_at.desc())
+            .limit(per_page).offset(skip))
+            )
+            .scalars().all())
 
     return DocumentListResponse(
         items=[DocumentResponse.model_validate(d) for d in docs],


### PR DESCRIPTION

### Document list Pagination
Closes #101 

---

### 📝 What does this PR do?
<!-- A clear and concise description of the changes. -->
- Added page (default: 1) and per_page (default: 20) query parameters to /documents/ endpoint
- Implemented offset/limit logic in database query for efficient pagination
- Calculate total pages and include in response for frontend navigation
- Return paginated results in DocumentListResponse model

---

### 🗂️ Type of Change
<!-- Check all that apply -->
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [x] 🔧 Refactor / code cleanup
- [ ] 📝 Documentation update
- [ ] 🎨 UI / styling change
- [ ] ⚙️ CI / tooling / config change
- [ ] 🧪 Tests

---

### 🧪 How was this tested?
<!-- Describe how you verified your changes work. -->
- [x] Ran the backend locally (`uvicorn app.main:app --reload`)
- [ ] Ran the frontend locally (`npm run dev` inside `frontend/`)
- [x] Tested the affected API endpoints manually
- [ ] Added / updated tests

---


### ✅ Self-Review Checklist
- [x] My branch is based on **`dev`**, not `main`
- [x] I have not added any secrets / API keys
- [x] I have not modified `main` branch or any HuggingFace deployment config
- [x] My code follows the existing style (no unnecessary formatting changes)
- [x] I have updated relevant docs / comments if needed
