### PR TITLE
refactor(frontend): migrate auth and chat state to Zustand

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,7 +22,8 @@
         "remark-gfm": "^4.0.1",
         "shadcn": "^4.3.1",
         "tailwind-merge": "^3.5.0",
-        "tw-animate-css": "^1.4.0"
+        "tw-animate-css": "^1.4.0",
+        "zustand": "^5.0.13"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -76,6 +77,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -669,6 +671,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1106,9 +1109,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1124,9 +1124,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1144,9 +1141,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1162,9 +1156,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1182,9 +1173,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1200,9 +1188,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1220,9 +1205,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1239,9 +1221,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1257,9 +1236,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1283,9 +1259,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1307,9 +1280,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1333,9 +1303,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1357,9 +1324,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1383,9 +1347,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1408,9 +1369,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1432,9 +1390,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1856,9 +1811,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1878,9 +1830,6 @@
       "integrity": "sha512-Z+6nyLdJXWzLPVxi4H6g9TJop4DwN3KSgHWto5JCbZV5/uKoVqcSynPs0tGlUHOoWI8S8tEvJspz51GQkvr07w==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1902,9 +1851,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1925,9 +1871,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1947,9 +1890,6 @@
       "integrity": "sha512-f3Uz2P0RgrtBHISxZqr6yiYXJlTDyCVBumDacxo+4AmSg7z0HiqYZKGWC/gszq3fbPhyQUya1W2AEteKxT9Y6A==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2072,9 +2012,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2090,9 +2027,6 @@
       "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2110,9 +2044,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2128,9 +2059,6 @@
       "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2178,6 +2106,7 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -2446,9 +2375,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2466,9 +2392,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2486,9 +2409,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2506,9 +2426,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2749,6 +2666,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2758,6 +2676,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2844,6 +2763,7 @@
       "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.0",
         "@typescript-eslint/types": "8.59.0",
@@ -3206,9 +3126,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3223,9 +3140,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3240,9 +3154,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3257,9 +3168,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3274,9 +3182,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3291,9 +3196,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3308,9 +3210,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3325,9 +3224,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3412,6 +3308,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3866,6 +3763,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4917,6 +4815,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5102,6 +5001,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5401,6 +5301,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -6172,6 +6073,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -7288,9 +7190,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7312,9 +7211,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7336,9 +7232,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7360,9 +7253,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9521,6 +9411,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9530,6 +9421,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10810,6 +10702,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11078,6 +10971,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11737,6 +11631,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -11761,6 +11656,35 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.13.tgz",
+      "integrity": "sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     },
     "node_modules/zwitch": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,8 @@
     "remark-gfm": "^4.0.1",
     "shadcn": "^4.3.1",
     "tailwind-merge": "^3.5.0",
-    "tw-animate-css": "^1.4.0"
+    "tw-animate-css": "^1.4.0",
+    "zustand": "^5.0.13"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -3,27 +3,12 @@
 import { useState, useRef, useEffect } from "react";
 import type { DocInfo } from "@/app/dashboard/page";
 import { api, API_BASE } from "@/lib/api";
+import { useChatStore, type ChatMsg, type SourceChunk } from "@/store/chat-store";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import MessageBubble from "./MessageBubble";
 import SourceCard from "./SourceCard";
 import { Send, Loader2, Trash2, MessageSquare, Download } from "lucide-react";
-
-export interface SourceChunk {
-  text: string;
-  filename: string;
-  page: number;
-  score: number;
-  confidence: number;
-}
-
-export interface ChatMsg {
-  id: string;
-  role: "user" | "assistant";
-  content: string;
-  sources: SourceChunk[];
-  isStreaming?: boolean;
-}
 
 interface Props {
   activeDoc: DocInfo | null;
@@ -31,10 +16,15 @@ interface Props {
 }
 
 export default function ChatPanel({ activeDoc, onCitationClick }: Props) {
-  const [messages, setMessages] = useState<ChatMsg[]>([]);
-  const [input, setInput] = useState("");
-  const [streaming, setStreaming] = useState(false);
-  const [isTyping, setIsTyping] = useState(false);
+  const messages = useChatStore((state) => state.messages);
+  const input = useChatStore((state) => state.input);
+  const streaming = useChatStore((state) => state.streaming);
+  const isTyping = useChatStore((state) => state.isTyping);
+  const setMessages = useChatStore((state) => state.setMessages);
+  const setInput = useChatStore((state) => state.setInput);
+  const setStreaming = useChatStore((state) => state.setStreaming);
+  const setIsTyping = useChatStore((state) => state.setIsTyping);
+  const resetChat = useChatStore((state) => state.resetChat);
   const [showExportMenu, setShowExportMenu] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
@@ -62,6 +52,12 @@ export default function ChatPanel({ activeDoc, onCitationClick }: Props) {
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages]);
+
+  useEffect(() => {
+    return () => {
+      resetChat();
+    };
+  }, [resetChat]);
 
   // Load history on doc change
   useEffect(() => {
@@ -102,7 +98,7 @@ export default function ChatPanel({ activeDoc, onCitationClick }: Props) {
     return () => {
       cancelled = true;
     };
-  }, [activeDoc]);
+  }, [activeDoc, resetChat, setMessages]);
 
   const handleSend = async () => {
     if (!input.trim() || streaming) return;

--- a/frontend/src/components/chat/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble.tsx
@@ -3,7 +3,7 @@
 import { useState, useRef } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import type { ChatMsg } from "./ChatPanel";
+import type { ChatMsg } from "@/store/chat-store";
 import { Brain, User, Copy, Check } from "lucide-react";
 import { Button } from "@/components/ui/button";
 

--- a/frontend/src/components/chat/SourceCard.tsx
+++ b/frontend/src/components/chat/SourceCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import type { SourceChunk } from "./ChatPanel";
+import type { SourceChunk } from "@/store/chat-store";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ChevronDown, ChevronUp, FileText, Eye } from "lucide-react";

--- a/frontend/src/lib/auth.tsx
+++ b/frontend/src/lib/auth.tsx
@@ -1,73 +1,24 @@
 "use client";
 
-import React, { createContext, useContext, useEffect, useState, useCallback } from "react";
-import { api } from "./api";
-
-interface User {
-  id: string;
-  username: string;
-  email: string;
-  is_admin: boolean;
-  created_at: string;
-}
-
-interface AuthContextType {
-  user: User | null;
-  token: string | null;
-  loading: boolean;
-  login: (email: string, password: string) => Promise<void>;
-  register: (username: string, email: string, password: string) => Promise<void>;
-  logout: () => void;
-}
-
-const AuthContext = createContext<AuthContextType | undefined>(undefined);
+import React, { useEffect } from "react";
+import { useAuthStore } from "@/store/auth-store";
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
-  const [user, setUser] = useState<User | null>(null);
-  // Lazy initializer reads localStorage once — avoids setState-in-effect lint error
-  const [token, setToken] = useState<string | null>(
-    () => (typeof window !== "undefined" ? localStorage.getItem("token") : null)
-  );
-  // loading=true only when a token exists and needs server validation.
-  // If there's no token we're already done — no effect setState needed.
-  const [loading, setLoading] = useState<boolean>(
-    () => typeof window !== "undefined" && !!localStorage.getItem("token")
-  );
+  const initializeAuth = useAuthStore((state) => state.initializeAuth);
+  const syncTokensRefreshed = useAuthStore((state) => state.syncTokensRefreshed);
+  const syncLoggedOut = useAuthStore((state) => state.syncLoggedOut);
 
-  // ── Validate saved token on mount ─────────────────
-  // NOTE: no synchronous setState here — setLoading/setUser/setToken are
-  // only called inside async callbacks (.then / .catch / .finally).
   useEffect(() => {
-    if (!token) return; // loading is already false when token is null
-    api
-      .get<User>("/api/v1/auth/me", { token })
-      .then(setUser)
-      .catch(() => {
-        localStorage.removeItem("token");
-        localStorage.removeItem("refresh_token");
-        setToken(null);
-      })
-      .finally(() => setLoading(false));
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []); // intentionally runs once on mount only
+    void initializeAuth();
+  }, [initializeAuth]);
 
-  // ── Listen for token refresh events from ApiClient ──
-  // When the API client auto-refreshes tokens, it dispatches custom events
-  // so this context stays in sync without prop drilling.
   useEffect(() => {
     const handleTokensRefreshed = (e: Event) => {
-      const detail = (e as CustomEvent).detail;
-      if (detail?.accessToken) {
-        setToken(detail.accessToken);
-      }
-      if (detail?.user) {
-        setUser(detail.user);
-      }
+      syncTokensRefreshed((e as CustomEvent).detail);
     };
 
     const handleLoggedOut = () => {
-      setToken(null);
-      setUser(null);
+      syncLoggedOut();
     };
 
     window.addEventListener("auth:tokens-refreshed", handleTokensRefreshed);
@@ -77,46 +28,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       window.removeEventListener("auth:tokens-refreshed", handleTokensRefreshed);
       window.removeEventListener("auth:logged-out", handleLoggedOut);
     };
-  }, []);
+  }, [syncLoggedOut, syncTokensRefreshed]);
 
-  const login = useCallback(async (email: string, password: string) => {
-    const data = await api.post<{ access_token: string; refresh_token: string; user: User }>(
-      "/api/v1/auth/login",
-      { email, password }
-    );
-    localStorage.setItem("token", data.access_token);
-    localStorage.setItem("refresh_token", data.refresh_token);
-    setToken(data.access_token);
-    setUser(data.user);
-  }, []);
-
-  const register = useCallback(async (username: string, email: string, password: string) => {
-    const data = await api.post<{ access_token: string; refresh_token: string; user: User }>(
-      "/api/v1/auth/register",
-      { username, email, password }
-    );
-    localStorage.setItem("token", data.access_token);
-    localStorage.setItem("refresh_token", data.refresh_token);
-    setToken(data.access_token);
-    setUser(data.user);
-  }, []);
-
-  const logout = useCallback(() => {
-    localStorage.removeItem("token");
-    localStorage.removeItem("refresh_token");
-    setToken(null);
-    setUser(null);
-  }, []);
-
-  return (
-    <AuthContext.Provider value={{ user, token, loading, login, register, logout }}>
-      {children}
-    </AuthContext.Provider>
-  );
+  return <>{children}</>;
 }
 
 export function useAuth() {
-  const ctx = useContext(AuthContext);
-  if (!ctx) throw new Error("useAuth must be used within AuthProvider");
-  return ctx;
+  return useAuthStore();
 }

--- a/frontend/src/store/auth-store.ts
+++ b/frontend/src/store/auth-store.ts
@@ -1,0 +1,124 @@
+"use client";
+
+import { create } from "zustand";
+import { api } from "@/lib/api";
+
+export interface AuthUser {
+  id: string;
+  username: string;
+  email: string;
+  is_admin: boolean;
+  created_at: string;
+}
+
+interface AuthStore {
+  user: AuthUser | null;
+  token: string | null;
+  loading: boolean;
+  initialized: boolean;
+  login: (email: string, password: string) => Promise<void>;
+  register: (username: string, email: string, password: string) => Promise<void>;
+  logout: () => void;
+  initializeAuth: () => Promise<void>;
+  syncTokensRefreshed: (detail?: { accessToken?: string; user?: AuthUser | null }) => void;
+  syncLoggedOut: () => void;
+}
+
+const getStoredToken = () =>
+  typeof window !== "undefined" ? localStorage.getItem("token") : null;
+
+const clearStoredTokens = () => {
+  if (typeof window === "undefined") return;
+  localStorage.removeItem("token");
+  localStorage.removeItem("refresh_token");
+};
+
+export const useAuthStore = create<AuthStore>((set, get) => ({
+  user: null,
+  token: getStoredToken(),
+  loading: !!getStoredToken(),
+  initialized: false,
+
+  async login(email, password) {
+    const data = await api.post<{ access_token: string; refresh_token: string; user: AuthUser }>(
+      "/api/v1/auth/login",
+      { email, password }
+    );
+
+    localStorage.setItem("token", data.access_token);
+    localStorage.setItem("refresh_token", data.refresh_token);
+    set({
+      token: data.access_token,
+      user: data.user,
+      loading: false,
+      initialized: true,
+    });
+  },
+
+  async register(username, email, password) {
+    const data = await api.post<{ access_token: string; refresh_token: string; user: AuthUser }>(
+      "/api/v1/auth/register",
+      { username, email, password }
+    );
+
+    localStorage.setItem("token", data.access_token);
+    localStorage.setItem("refresh_token", data.refresh_token);
+    set({
+      token: data.access_token,
+      user: data.user,
+      loading: false,
+      initialized: true,
+    });
+  },
+
+  logout() {
+    clearStoredTokens();
+    set({
+      token: null,
+      user: null,
+      loading: false,
+      initialized: true,
+    });
+  },
+
+  async initializeAuth() {
+    const { initialized, token } = get();
+    if (initialized) return;
+
+    const storedToken = token ?? getStoredToken();
+    if (!storedToken) {
+      set({ token: null, user: null, loading: false, initialized: true });
+      return;
+    }
+
+    set({ token: storedToken, loading: true });
+
+    try {
+      const user = await api.get<AuthUser>("/api/v1/auth/me", { token: storedToken });
+      set({ user, token: storedToken, loading: false, initialized: true });
+    } catch {
+      clearStoredTokens();
+      set({ user: null, token: null, loading: false, initialized: true });
+    }
+  },
+
+  syncTokensRefreshed(detail) {
+    if (!detail) return;
+
+    set((state) => ({
+      token: detail.accessToken ?? state.token,
+      user: detail.user ?? state.user,
+      loading: false,
+      initialized: true,
+    }));
+  },
+
+  syncLoggedOut() {
+    set({
+      token: null,
+      user: null,
+      loading: false,
+      initialized: true,
+    });
+  },
+}));

--- a/frontend/src/store/chat-store.ts
+++ b/frontend/src/store/chat-store.ts
@@ -1,0 +1,68 @@
+"use client";
+
+import { create } from "zustand";
+
+export interface SourceChunk {
+  text: string;
+  filename: string;
+  page: number;
+  score: number;
+  confidence: number;
+}
+
+export interface ChatMsg {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  sources: SourceChunk[];
+  isStreaming?: boolean;
+}
+
+type Setter<T> = T | ((prev: T) => T);
+
+interface ChatStore {
+  messages: ChatMsg[];
+  input: string;
+  streaming: boolean;
+  isTyping: boolean;
+  setMessages: (value: Setter<ChatMsg[]>) => void;
+  setInput: (value: Setter<string>) => void;
+  setStreaming: (value: Setter<boolean>) => void;
+  setIsTyping: (value: Setter<boolean>) => void;
+  resetChat: () => void;
+}
+
+const resolveValue = <T,>(value: Setter<T>, current: T): T =>
+  typeof value === "function" ? (value as (prev: T) => T)(current) : value;
+
+export const useChatStore = create<ChatStore>((set) => ({
+  messages: [],
+  input: "",
+  streaming: false,
+  isTyping: false,
+
+  setMessages(value) {
+    set((state) => ({ messages: resolveValue(value, state.messages) }));
+  },
+
+  setInput(value) {
+    set((state) => ({ input: resolveValue(value, state.input) }));
+  },
+
+  setStreaming(value) {
+    set((state) => ({ streaming: resolveValue(value, state.streaming) }));
+  },
+
+  setIsTyping(value) {
+    set((state) => ({ isTyping: resolveValue(value, state.isTyping) }));
+  },
+
+  resetChat() {
+    set({
+      messages: [],
+      input: "",
+      streaming: false,
+      isTyping: false,
+    });
+  },
+}));


### PR DESCRIPTION
### 🔗 Related Issue
Closes #127

---

### 📝 What does this PR do?
Migrates frontend authentication and chat state management from React Context/local component state to Zustand.

Changes include:
- Installed `zustand`
- Added a global auth store for user, token, loading state, login, register, logout, and auth initialization
- Kept the existing `useAuth` API so current pages/components continue working
- Preserved token validation and auth refresh/logout event syncing
- Added a global chat store for messages, input, streaming, and typing state
- Updated chat type imports for `MessageBubble` and `SourceCard`

---

### 🗂️ Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🔧 Refactor / code cleanup
- [ ] 📝 Documentation update
- [ ] 🎨 UI / styling change
- [ ] ⚙️ CI / tooling / config change
- [ ] 🧪 Tests

---

### 🧪 How was this tested?
- [ ] Ran the backend locally (`uvicorn app.main:app --reload`)
- [ ] Ran the frontend locally (`npm run dev` inside `frontend/`)
- [ ] Tested the affected API endpoints manually
- [ ] Added / updated tests

Verified with:
- `npm --prefix frontend run lint`
  - Passed with one existing `<img>` warning in `ContributorsPanel.tsx`
- `npm --prefix frontend run build`
  - Passed successfully

---

### 📸 Screenshots (if UI change)
No UI changes.

---

### ⚠️ Anything to flag for reviewers?
This PR keeps `AuthProvider` as a lightweight initializer/listener wrapper so existing layout usage remains compatible while auth state is managed by Zustand.

---

### ✅ Self-Review Checklist
- [x] My branch is based on **`dev`**, not `main`
- [x] I have not added any secrets / API keys
- [x] I have not modified `main` branch or any HuggingFace deployment config
- [x] My code follows the existing style (no unnecessary formatting changes)
- [x] I have updated relevant docs / comments if needed