### PR TITLE
chore: add Dependabot update schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,75 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    target-branch: dev
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Kolkata
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - python
+    groups:
+      root-python-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: pip
+    directory: /backend
+    target-branch: dev
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:15"
+      timezone: Asia/Kolkata
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - python
+      - backend
+    groups:
+      backend-python-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: npm
+    directory: /frontend
+    target-branch: dev
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:30"
+      timezone: Asia/Kolkata
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - javascript
+      - frontend
+    groups:
+      frontend-npm-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    target-branch: dev
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:45"
+      timezone: Asia/Kolkata
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions
+    groups:
+      github-actions-minor-patch:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Summary
- add Dependabot configuration for root Python, backend Python, frontend npm, and GitHub Actions manifests
- schedule weekly update checks against the dev branch with small grouped update PRs
- add dependency-focused labels and pull request limits per ecosystem

## Validation
- ruby -e "require 'yaml'; data = YAML.load_file('.github/dependabot.yml'); abort('missing updates') unless data['updates'].size == 4; puts 'dependabot yaml ok'"\n- git diff --check\n\nCloses #57