### PR TITLE
feat: add Google OAuth login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,16 @@ ALLOWED_ORIGINS=http://localhost:3000,http://localhost:7860
 # Optional — defaults to 72
 # JWT_EXPIRY_HOURS=72
 
+# Google OAuth client ID for backend ID-token verification.
+# Use the same OAuth web client ID as NEXT_PUBLIC_GOOGLE_CLIENT_ID.
+# Optional — required only for Google sign-in.
+# GOOGLE_CLIENT_ID=your_google_oauth_client_id.apps.googleusercontent.com
+
+# Google OAuth client ID exposed to the Next.js frontend for Google Identity Services.
+# Add the frontend origin to your OAuth web client's authorized JavaScript origins.
+# Optional — required only for Google sign-in.
+# NEXT_PUBLIC_GOOGLE_CLIENT_ID=your_google_oauth_client_id.apps.googleusercontent.com
+
 # ── File Upload ─────────────────────────────────────────────
 
 # Directory where uploaded documents (PDFs, DOCXs, etc.) are stored.
@@ -131,5 +141,4 @@ HF_TOKEN=your_huggingface_token_here
 # They are ignored by the new FastAPI backend.
 
 # MONGO_URI=mongodb://localhost:27017/pdf_assistant
-# GOOGLE_CLIENT_ID=your_google_client_id
 # GOOGLE_CLIENT_SECRET=your_google_client_secret

--- a/README.md
+++ b/README.md
@@ -461,6 +461,8 @@ docker compose up --build
 | `DATABASE_URL` | ❌ | `sqlite:///./data/app.db` | SQLAlchemy database connection string. | SQLite (default), or your Postgres/MySQL connection string |
 | `JWT_ALGORITHM` | ❌ | `HS256` | JWT signing algorithm. | — |
 | `JWT_EXPIRY_HOURS` | ❌ | `72` | JWT token lifetime in hours before re-login is required. | — |
+| `GOOGLE_CLIENT_ID` | ❌ | — | Google OAuth web client ID used by FastAPI to verify ID tokens. | [Google Cloud Console](https://console.cloud.google.com/apis/credentials) |
+| `NEXT_PUBLIC_GOOGLE_CLIENT_ID` | ❌ | — | Google OAuth web client ID exposed to the Next.js Google sign-in button. | [Google Cloud Console](https://console.cloud.google.com/apis/credentials) |
 | `UPLOAD_DIR` | ❌ | `./data/uploads` | Local directory for storing uploaded documents. | — |
 | `MAX_FILE_SIZE_MB` | ❌ | `50` | Maximum allowed upload file size in MB. | — |
 | `ALLOWED_EXTENSIONS` | ❌ | `pdf,docx,txt,md` | Comma-separated list of permitted file extensions. | — |

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -22,6 +22,7 @@ class Settings(BaseSettings):
     JWT_ALGORITHM: str = "HS256"
     JWT_ACCESS_EXPIRY_MINUTES: int = 15
     JWT_REFRESH_EXPIRY_DAYS: int = 7
+    GOOGLE_CLIENT_ID: str = ""
 
     # ── File Upload ──────────────────────────────────────
     UPLOAD_DIR: str = "./data/uploads"

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -1,18 +1,97 @@
 """
 Auth API routes — register, login, and user profile.
 """
+import re
+import secrets
+
 from fastapi import APIRouter, Depends, HTTPException, status
 from langsmith import expect
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 from sqlalchemy import select
+from app.config import get_settings
 from app.database import get_db
 from app.models import User
-from app.schemas import UserRegister, UserLogin, TokenResponse, UserResponse, RefreshRequest, UserUpdate, \
-    UserUpdateResponse, UpdatePassword, UpdatePasswordResponse
+from app.schemas import (
+    GoogleLoginRequest,
+    RefreshRequest,
+    TokenResponse,
+    UpdatePassword,
+    UpdatePasswordResponse,
+    UserLogin,
+    UserRegister,
+    UserResponse,
+    UserUpdate,
+    UserUpdateResponse,
+)
 from app.auth import hash_password, verify_password, create_access_token, create_refresh_token, get_current_user, decode_token
 
 router = APIRouter(prefix="/auth", tags=["Authentication"])
+settings = get_settings()
+
+
+def _create_token_response(user: User) -> TokenResponse:
+    access_token = create_access_token(user.id)
+    refresh_token = create_refresh_token(user.id)
+
+    return TokenResponse(
+        access_token=access_token,
+        refresh_token=refresh_token,
+        user=UserResponse.model_validate(user),
+    )
+
+
+def _verify_google_token(id_token_value: str) -> dict:
+    if not settings.GOOGLE_CLIENT_ID:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Google sign-in is not configured",
+        )
+
+    try:
+        from google.auth.transport.requests import Request
+        from google.oauth2 import id_token
+    except ImportError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Google authentication dependency is not installed",
+        ) from exc
+
+    try:
+        google_payload = id_token.verify_oauth2_token(
+            id_token_value,
+            Request(),
+            settings.GOOGLE_CLIENT_ID,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid Google credential",
+        ) from exc
+
+    email = google_payload.get("email")
+    if not email or not google_payload.get("email_verified"):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Google account email is not verified",
+        )
+
+    return google_payload
+
+
+def _unique_google_username(email: str, db: Session) -> str:
+    local_part = email.split("@", 1)[0]
+    base = re.sub(r"[^a-zA-Z0-9_-]+", "-", local_part).strip("-_").lower() or "google-user"
+    base = base[:70]
+    candidate = base
+    suffix = 1
+
+    while db.query(User).filter(User.username == candidate).first():
+        suffix += 1
+        suffix_text = f"-{suffix}"
+        candidate = f"{base[:80 - len(suffix_text)]}{suffix_text}"
+
+    return candidate
 
 
 @router.post("/register", response_model=TokenResponse, status_code=status.HTTP_201_CREATED)
@@ -63,15 +142,7 @@ def register(payload: UserRegister, db: Session = Depends(get_db)):
     db.commit()
     db.refresh(user)
 
-    # Generate token
-    access_token = create_access_token(user.id)
-    refresh_token = create_refresh_token(user.id)
-
-    return TokenResponse(
-        access_token=access_token,
-        refresh_token=refresh_token,
-        user=UserResponse.model_validate(user),
-    )
+    return _create_token_response(user)
 
 
 @router.post("/login", response_model=TokenResponse)
@@ -105,14 +176,33 @@ def login(payload: UserLogin, db: Session = Depends(get_db)):
             detail="Invalid email or password",
         )
 
-    access_token = create_access_token(user.id)
-    refresh_token = create_refresh_token(user.id)
+    return _create_token_response(user)
 
-    return TokenResponse(
-        access_token=access_token,
-        refresh_token=refresh_token,
-        user=UserResponse.model_validate(user),
-    )
+
+@router.post("/google", response_model=TokenResponse)
+def login_with_google(payload: GoogleLoginRequest, db: Session = Depends(get_db)):
+    """
+    Authenticate with a Google Identity Services ID token.
+
+    Existing users are matched by verified email. New Google users get an
+    internal username derived from the email prefix and an unusable random
+    password hash so password login remains opt-in through the normal flow.
+    """
+    google_payload = _verify_google_token(payload.id_token)
+    email = str(google_payload["email"]).lower()
+
+    user = db.query(User).filter(User.email == email).first()
+    if not user:
+        user = User(
+            username=_unique_google_username(email, db),
+            email=email,
+            hashed_password=hash_password(secrets.token_urlsafe(32)),
+        )
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+
+    return _create_token_response(user)
 
 
 @router.post("/refresh", response_model=TokenResponse)
@@ -153,14 +243,7 @@ def refresh_token(payload: RefreshRequest, db: Session = Depends(get_db)):
             detail="User not found",
         )
         
-    new_access_token = create_access_token(user.id)
-    new_refresh_token = create_refresh_token(user.id)
-
-    return TokenResponse(
-        access_token=new_access_token,
-        refresh_token=new_refresh_token,
-        user=UserResponse.model_validate(user),
-    )
+    return _create_token_response(user)
 
 
 @router.get("/me", response_model=UserResponse)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -18,6 +18,11 @@ class UserLogin(BaseModel):
     email: EmailStr
     password: str
 
+
+class GoogleLoginRequest(BaseModel):
+    id_token: str = Field(..., min_length=10)
+
+
 class UserUpdate(BaseModel):
     email: Optional[EmailStr] = None
     username:Optional[str] = None

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,6 +13,7 @@ aiosqlite
 pyjwt
 passlib[bcrypt]
 python-dotenv
+google-auth
 
 # Config
 pydantic-settings

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/lib/auth";
 import { Button } from "@/components/ui/button";
@@ -8,6 +8,7 @@ import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Brain, Eye, EyeOff } from "lucide-react";
 import Link from "next/link";
+import GoogleSignInButton from "@/components/auth/GoogleSignInButton";
 
 export default function LoginPage() {
   const { login } = useAuth();
@@ -17,6 +18,10 @@ export default function LoginPage() {
   const [showPw, setShowPw] = useState(false);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
+
+  const handleGoogleSuccess = useCallback(() => {
+    router.replace("/dashboard");
+  }, [router]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -51,6 +56,13 @@ export default function LoginPage() {
         </CardHeader>
 
         <CardContent>
+          <div className="mb-4">
+            <GoogleSignInButton
+              onError={setError}
+              onSuccess={handleGoogleSuccess}
+            />
+          </div>
+
           <form onSubmit={handleSubmit} className="space-y-4">
             {error && (
               <div className="p-3 rounded-lg bg-destructive/10 border border-destructive/30 text-sm text-destructive">

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/lib/auth";
 import { Button } from "@/components/ui/button";
@@ -8,6 +8,7 @@ import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Brain, Eye, EyeOff } from "lucide-react";
 import Link from "next/link";
+import GoogleSignInButton from "@/components/auth/GoogleSignInButton";
 
 export default function RegisterPage() {
   const { register } = useAuth();
@@ -18,6 +19,10 @@ export default function RegisterPage() {
   const [showPw, setShowPw] = useState(false);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
+
+  const handleGoogleSuccess = useCallback(() => {
+    router.replace("/dashboard");
+  }, [router]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -51,6 +56,13 @@ export default function RegisterPage() {
         </CardHeader>
 
         <CardContent>
+          <div className="mb-4">
+            <GoogleSignInButton
+              onError={setError}
+              onSuccess={handleGoogleSuccess}
+            />
+          </div>
+
           <form onSubmit={handleSubmit} className="space-y-4">
             {error && (
               <div className="p-3 rounded-lg bg-destructive/10 border border-destructive/30 text-sm text-destructive">

--- a/frontend/src/components/auth/GoogleSignInButton.tsx
+++ b/frontend/src/components/auth/GoogleSignInButton.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useAuth } from "@/lib/auth";
+
+type GoogleCredentialResponse = {
+  credential?: string;
+};
+
+type GoogleAccountsId = {
+  initialize: (options: {
+    client_id: string;
+    callback: (response: GoogleCredentialResponse) => void | Promise<void>;
+  }) => void;
+  renderButton: (element: HTMLElement, options: Record<string, string | number | boolean>) => void;
+};
+
+declare global {
+  interface Window {
+    google?: {
+      accounts?: {
+        id?: GoogleAccountsId;
+      };
+    };
+  }
+}
+
+type GoogleSignInButtonProps = {
+  onError: (message: string) => void;
+  onSuccess: () => void;
+};
+
+const GOOGLE_SCRIPT_ID = "google-identity-services";
+const GOOGLE_SCRIPT_SRC = "https://accounts.google.com/gsi/client";
+
+export default function GoogleSignInButton({ onError, onSuccess }: GoogleSignInButtonProps) {
+  const buttonRef = useRef<HTMLDivElement>(null);
+  const { loginWithGoogle } = useAuth();
+  const clientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID;
+
+  useEffect(() => {
+    if (!clientId || !buttonRef.current) return;
+
+    let cancelled = false;
+
+    const renderButton = () => {
+      if (cancelled || !buttonRef.current || !window.google?.accounts?.id) return;
+
+      window.google.accounts.id.initialize({
+        client_id: clientId,
+        callback: async (response) => {
+          if (!response.credential) {
+            onError("Google did not return a sign-in credential");
+            return;
+          }
+
+          try {
+            await loginWithGoogle(response.credential);
+            onSuccess();
+          } catch (error) {
+            onError(error instanceof Error ? error.message : "Google sign-in failed");
+          }
+        },
+      });
+
+      window.google.accounts.id.renderButton(buttonRef.current, {
+        theme: "outline",
+        size: "large",
+        text: "continue_with",
+        shape: "rectangular",
+        width: 360,
+      });
+    };
+
+    const existingScript = document.getElementById(GOOGLE_SCRIPT_ID) as HTMLScriptElement | null;
+    if (existingScript) {
+      if (window.google?.accounts?.id) renderButton();
+      existingScript.addEventListener("load", renderButton, { once: true });
+      return () => {
+        cancelled = true;
+        existingScript.removeEventListener("load", renderButton);
+      };
+    }
+
+    const script = document.createElement("script");
+    script.id = GOOGLE_SCRIPT_ID;
+    script.src = GOOGLE_SCRIPT_SRC;
+    script.async = true;
+    script.defer = true;
+    script.onload = renderButton;
+    script.onerror = () => onError("Google sign-in could not be loaded");
+    document.head.appendChild(script);
+
+    return () => {
+      cancelled = true;
+      script.onload = null;
+      script.onerror = null;
+    };
+  }, [clientId, loginWithGoogle, onError, onSuccess]);
+
+  if (!clientId) return null;
+
+  return <div className="flex justify-center" ref={buttonRef} />;
+}

--- a/frontend/src/lib/auth.tsx
+++ b/frontend/src/lib/auth.tsx
@@ -16,6 +16,7 @@ interface AuthContextType {
   token: string | null;
   loading: boolean;
   login: (email: string, password: string) => Promise<void>;
+  loginWithGoogle: (idToken: string) => Promise<void>;
   register: (username: string, email: string, password: string) => Promise<void>;
   logout: () => void;
 }
@@ -90,6 +91,17 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     setUser(data.user);
   }, []);
 
+  const loginWithGoogle = useCallback(async (idToken: string) => {
+    const data = await api.post<{ access_token: string; refresh_token: string; user: User }>(
+      "/api/v1/auth/google",
+      { id_token: idToken }
+    );
+    localStorage.setItem("token", data.access_token);
+    localStorage.setItem("refresh_token", data.refresh_token);
+    setToken(data.access_token);
+    setUser(data.user);
+  }, []);
+
   const register = useCallback(async (username: string, email: string, password: string) => {
     const data = await api.post<{ access_token: string; refresh_token: string; user: User }>(
       "/api/v1/auth/register",
@@ -109,7 +121,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   return (
-    <AuthContext.Provider value={{ user, token, loading, login, register, logout }}>
+    <AuthContext.Provider value={{ user, token, loading, login, loginWithGoogle, register, logout }}>
       {children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
## Summary
- add `/api/v1/auth/google` to verify Google Identity Services ID tokens against `GOOGLE_CLIENT_ID`
- reuse existing users by verified email and create new Google users with unique internal usernames plus random password hashes
- add a Google sign-in button to login/register pages, wired through `NEXT_PUBLIC_GOOGLE_CLIENT_ID`
- document the required Google OAuth environment variables and add `google-auth` to backend dependencies

## Validation
- `python3 -m py_compile backend/app/config.py backend/app/schemas.py backend/app/routes/auth.py`
- AST route check for `POST /auth/google`
- `npm run lint` (passes with existing ContributorsPanel `<img>` warning)
- `npx tsc --noEmit`
- `npm run build`
- `git diff --check`

Closes #123