### PR TITLE
feat(ui): add skeleton loaders for document fetching 

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -3,11 +3,17 @@
 import { useEffect, useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/lib/auth";
-import { api, CONNECTION_ERROR_BANNER_MESSAGE, CONNECTION_ERROR_MESSAGE } from "@/lib/api";
+import {
+  api,
+  CONNECTION_ERROR_BANNER_MESSAGE,
+  CONNECTION_ERROR_MESSAGE,
+} from "@/lib/api";
+
 import Header from "@/components/layout/Header";
 import DocumentSidebar from "@/components/document/DocumentSidebar";
 import ChatPanel from "@/components/chat/ChatPanel";
 import PDFViewer from "@/components/document/PDFViewer";
+import { Skeleton } from "@/components/ui/skeleton";
 
 export interface DocInfo {
   id: string;
@@ -20,6 +26,23 @@ export interface DocInfo {
   uploaded_at: string;
 }
 
+function DocumentSkeleton() {
+  return (
+    <div className="w-72 flex-shrink-0 border-r border-border/50 p-4 space-y-4">
+      {[1, 2, 3, 4].map((item) => (
+        <div
+          key={item}
+          className="rounded-lg border border-border/50 p-4 space-y-3"
+        >
+          <Skeleton className="h-4 w-[180px]" />
+          <Skeleton className="h-3 w-[120px]" />
+          <Skeleton className="h-3 w-[90px]" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
 export default function DashboardPage() {
   const { user, loading } = useAuth();
   const router = useRouter();
@@ -30,6 +53,7 @@ export default function DashboardPage() {
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const [viewerOpen, setViewerOpen] = useState(true);
   const [connectionError, setConnectionError] = useState("");
+  const [documentsLoading, setDocumentsLoading] = useState(true);
 
   // Auth guard
   useEffect(() => {
@@ -39,24 +63,31 @@ export default function DashboardPage() {
   // Load documents
   const loadDocuments = useCallback(async () => {
     try {
+      setDocumentsLoading(true);
+
       const data = await api.get<{ documents?: DocInfo[]; items?: DocInfo[] }>(
         "/api/v1/documents/"
       );
+
       setDocuments(data?.documents ?? data?.items ?? []);
       setConnectionError("");
     } catch (err) {
-      const message = err instanceof Error ? err.message : CONNECTION_ERROR_MESSAGE;
+      const message =
+        err instanceof Error ? err.message : CONNECTION_ERROR_MESSAGE;
+
       setConnectionError(
         message === CONNECTION_ERROR_MESSAGE
           ? CONNECTION_ERROR_BANNER_MESSAGE
           : `⚠️ ${message}`
       );
+    } finally {
+      setDocumentsLoading(false);
     }
   }, []);
 
   useEffect(() => {
     if (!user) return;
-    // Use IIFE so setState calls happen in async callback, not effect body directly
+
     void (async () => {
       await loadDocuments();
     })();
@@ -67,9 +98,11 @@ export default function DashboardPage() {
     const hasPending = (documents || []).some(
       (d) => d.status === "pending" || d.status === "processing"
     );
+
     if (!hasPending) return;
 
     const interval = setInterval(loadDocuments, 3000);
+
     return () => clearInterval(interval);
   }, [documents, loadDocuments]);
 
@@ -100,20 +133,23 @@ export default function DashboardPage() {
       )}
 
       <div className="flex-1 flex overflow-hidden">
-        {/* ── Left: Document Sidebar ──────────────── */}
-        {sidebarOpen && (
-          <div className="w-72 flex-shrink-0 border-r border-border/50 overflow-hidden animate-fade-in-up">
-            <DocumentSidebar
-              documents={documents}
-              activeDoc={activeDoc}
-              onSelectDoc={(doc) => {
-                setActiveDoc(doc);
-                setPdfPage(1);
-              }}
-              onDocumentsChange={loadDocuments}
-            />
-          </div>
-        )}
+        {/* ── Left: Document Sidebar / Skeleton ──────────────── */}
+        {sidebarOpen &&
+          (documentsLoading ? (
+            <DocumentSkeleton />
+          ) : (
+            <div className="w-72 flex-shrink-0 border-r border-border/50 overflow-hidden animate-fade-in-up">
+              <DocumentSidebar
+                documents={documents}
+                activeDoc={activeDoc}
+                onSelectDoc={(doc) => {
+                  setActiveDoc(doc);
+                  setPdfPage(1);
+                }}
+                onDocumentsChange={loadDocuments}
+              />
+            </div>
+          ))}
 
         {/* ── Center: Chat Panel ─────────────────── */}
         <div className="flex-1 min-w-0 flex flex-col">
@@ -121,22 +157,25 @@ export default function DashboardPage() {
             activeDoc={activeDoc}
             onCitationClick={(page) => {
               setPdfPage(page);
+
               if (!viewerOpen) setViewerOpen(true);
             }}
           />
         </div>
 
         {/* ── Right: PDF Viewer ──────────────────── */}
-        {viewerOpen && activeDoc && activeDoc.original_name.endsWith(".pdf") && (
-          <div className="w-[480px] flex-shrink-0 border-l border-border/50 overflow-hidden animate-fade-in-up">
-            <PDFViewer
-              documentId={activeDoc.id}
-              currentPage={pdfPage}
-              onPageChange={setPdfPage}
-              totalPages={activeDoc.page_count}
-            />
-          </div>
-        )}
+        {viewerOpen &&
+          activeDoc &&
+          activeDoc.original_name.endsWith(".pdf") && (
+            <div className="w-[480px] flex-shrink-0 border-l border-border/50 overflow-hidden animate-fade-in-up">
+              <PDFViewer
+                documentId={activeDoc.id}
+                currentPage={pdfPage}
+                onPageChange={setPdfPage}
+                totalPages={activeDoc.page_count}
+              />
+            </div>
+          )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Implemented skeleton loaders for the dashboard document fetching state using Shadcn UI Skeleton components.

## Changes Made

* Added animated skeleton placeholders while documents are loading
* Replaced blank sidebar loading state with 4 responsive skeleton rows
* Added dedicated `documentsLoading` state handling
* Improved dashboard loading UX and perceived performance

## Tech Stack

* Next.js
* Shadcn UI Skeleton
* Tailwind CSS

## Issue Fixed

Closes #132
