### PR TITLE
feat(api): add SlowAPI rate limiting

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,11 +9,15 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, JSONResponse
 from sqlalchemy import select
 from sqlalchemy.exc import SQLAlchemyError
 
+from slowapi.errors import RateLimitExceeded
+from slowapi.middleware import SlowAPIMiddleware
+
 from app.config import get_settings
+from app.rate_limit import limiter
 from app.database import init_db, get_db
 from app.rag.vectorstore import get_chroma_client
 
@@ -62,6 +66,16 @@ app = FastAPI(
     version="2.0.0",
     lifespan=lifespan,
 )
+
+app.state.limiter = limiter
+app.add_exception_handler(
+    RateLimitExceeded,
+    lambda request, exc: JSONResponse(
+        status_code=429,
+        content={"detail": "Rate limit exceeded. Please try again later."},
+    ),
+)
+app.add_middleware(SlowAPIMiddleware)
 
 # ── CORS (allow frontend dev server) ─────────────────
 app.add_middleware(

--- a/backend/app/rate_limit.py
+++ b/backend/app/rate_limit.py
@@ -1,0 +1,24 @@
+"""
+SlowAPI rate limiting configuration.
+"""
+from fastapi import Request
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+
+def rate_limit_key_func(request: Request) -> str:
+    """Use authenticated user id when available, otherwise fall back to client IP."""
+    authorization = request.headers.get("authorization", "")
+    if authorization.lower().startswith("bearer "):
+        try:
+            from app.auth import decode_token
+
+            user_id = decode_token(authorization.split(" ", 1)[1])
+            if user_id:
+                return f"user:{user_id}"
+        except Exception:
+            pass
+    return f"ip:{get_remote_address(request)}"
+
+
+limiter = Limiter(key_func=rate_limit_key_func)

--- a/backend/app/routes/chat.py
+++ b/backend/app/routes/chat.py
@@ -5,7 +5,7 @@ import json
 import logging
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
 
@@ -14,6 +14,7 @@ from app.models import User, ChatMessage, Document
 from app.schemas import ChatRequest, ChatResponse, ChatMessageResponse, ChatHistoryResponse, SourceChunk
 from app.auth import get_current_user
 from app.rag.agent import generate_answer, generate_answer_stream
+from app.rate_limit import limiter
 
 logger = logging.getLogger(__name__)
 
@@ -21,7 +22,9 @@ router = APIRouter(prefix="/chat", tags=["Chat"])
 
 
 @router.post("/ask", response_model=ChatResponse)
+@limiter.limit("10/minute")
 def ask_question(
+    request: Request,
     payload: ChatRequest,
     user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
@@ -88,7 +91,9 @@ def ask_question(
 
 
 @router.post("/ask/stream")
+@limiter.limit("10/minute")
 def ask_question_stream(
+    request: Request,
     payload: ChatRequest,
     user: User = Depends(get_current_user),
     db: Session = Depends(get_db),

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -40,6 +40,7 @@ huggingface-hub
 
 # Production
 gunicorn
+slowapi
 
 # File Validation
 #sudo apt-get install libmagic1 // for Debian/Ubuntu


### PR DESCRIPTION
### 🔗 Related Issue
Closes #124

---

### 📝 What does this PR do?
Adds SlowAPI-based rate limiting to protect backend chat generation endpoints from abuse.

Changes include:
- Added `slowapi` to backend requirements
- Added centralized rate-limit configuration in `backend/app/rate_limit.py`
- Configured SlowAPI middleware and 429 response handling in FastAPI app startup
- Uses authenticated user ID as the rate-limit key when a valid bearer token is available
- Falls back to client IP-based limiting when user authentication cannot be resolved
- Applies `10/minute` limit to chat generation endpoints:
  - `POST /api/v1/chat/ask`
  - `POST /api/v1/chat/ask/stream`

---

### 🗂️ Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🔧 Refactor / code cleanup
- [ ] 📝 Documentation update
- [ ] 🎨 UI / styling change
- [ ] ⚙️ CI / tooling / config change
- [ ] 🧪 Tests

---

### 🧪 How was this tested?
- [ ] Ran the backend locally (`uvicorn app.main:app --reload`)
- [ ] Ran the frontend locally (`npm run dev` inside `frontend/`)
- [ ] Tested the affected API endpoints manually
- [ ] Added / updated tests

Verified with:
- `python3 -m py_compile backend/app/main.py backend/app/routes/chat.py backend/app/rate_limit.py`

---

### 📸 Screenshots (if UI change)
No UI changes.

---

### ⚠️ Anything to flag for reviewers?
The issue mentions `/api/v1/chat/generate`, but the current backend exposes chat generation through `/api/v1/chat/ask` and `/api/v1/chat/ask/stream`, so this PR protects both actual generation endpoints.

---

### ✅ Self-Review Checklist
- [x] My branch is based on **`dev`**, not `main`
- [x] I have not added any secrets / API keys
- [x] I have not modified `main` branch or any HuggingFace deployment config
- [x] My code follows the existing style (no unnecessary formatting changes)
- [x] I have updated relevant docs / comments if needed