### PR TITLE
docs(frontend): add Swagger/OpenAPI link to landing page

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -71,6 +71,7 @@ export default function HomePage() {
               href="/docs"
               target="_blank"
               rel="noopener noreferrer"
+              aria-label="Open Developer API Swagger documentation"
             >
               <Button size="lg" variant="secondary" className="px-8 text-base h-12">
                 Developer API

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -54,17 +54,28 @@ export default function HomePage() {
             accurate, cited insights powered by advanced AI retrieval.
           </p>
 
-          <div className="flex gap-4 justify-center">
+          <div className="flex gap-4 justify-center flex-wrap">
             <Link href="/register">
               <Button size="lg" className="px-8 text-base h-12">
                 Get Started Free
               </Button>
             </Link>
+
             <Link href="/login">
               <Button size="lg" variant="outline" className="px-8 text-base h-12">
                 Sign In
               </Button>
             </Link>
+
+            <a
+              href="/docs"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <Button size="lg" variant="secondary" className="px-8 text-base h-12">
+                Developer API
+              </Button>
+            </a>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary

Added a "Developer API" button to the landing page that links to the FastAPI Swagger/OpenAPI documentation (`/docs`).

## Changes Made

* Added Developer API button on landing page
* Linked button to `/docs`
* Added external link security attributes

Closes #131
