### PR TITLE
feat/Added doc summary genration

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -49,10 +49,11 @@ class Settings(BaseSettings):
     CHROMA_PERSIST_DIR: str = "./data/chroma_db"
 
     # ── LLM (HuggingFace Inference API) ──────────────────
-    HF_TOKEN: str = ""
+    HF_TOKEN: str = os.getenv("HF_TOKEN", "")  # HuggingFace API token (set in .env)
     LLM_MODEL: str = "Qwen/Qwen2.5-72B-Instruct"
     LLM_MAX_NEW_TOKENS: int = 1024
     LLM_TEMPERATURE: float = 0.3
+    SUMMARY_MAX_TOKENS: int = 512
 
     # ── Reranker ─────────────────────────────────────────
     RERANKER_MODEL: str = "cross-encoder/ms-marco-MiniLM-L-6-v2"

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -40,6 +40,7 @@ class Document(Base):
     status = Column(String(20), default="pending")         # pending | processing | ready | failed
     error_message = Column(Text, nullable=True)
     uploaded_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
+    summary = Column(Text, nullable=True)  # Optional summary of the document's content
 
     # Relationships
     owner = relationship("User", back_populates="documents")

--- a/backend/app/rag/summarizer.py
+++ b/backend/app/rag/summarizer.py
@@ -1,0 +1,59 @@
+import logging
+from app.config import get_settings
+import os
+
+from app.rag.agent import get_llm_client
+
+logger = logging.getLogger(__name__)
+settings = get_settings()
+
+def generate_document_summary(filePath: str, max_sentences: int = 3) -> str | None:
+    """
+    Extract text from the first few chunks of the document and ask LLM to summarise.
+    Returns a short summary string, or None on failure.
+
+    Args:
+        filePath (str): Path to the document file.
+        max_sentences (int): Maximum number of sentences in the summary.
+    
+    Returns:
+        str | None: Summary text or None if summarisation fails.
+    
+    Note:
+        - This function is designed to be called after a document is uploaded and processed.
+        - It uses the first few chunks of the document to generate a summary, which is then stored in the database.        
+    """
+    from app.rag.chunker import chunk_document
+
+    try:
+        chunks = chunk_document(filePath)
+
+        if not chunks:
+            logger.warning(f"No chunks extracted from {filePath}, cannot summarise.")
+            return None
+        
+        # Extract text from each chunk and concatenate for summarisation
+        chunk_texts = []
+        for chunk in chunks[:10]:  # Use first 10 chunks to limit input size
+            text = chunk.get("text")
+            chunk_texts.append(text) 
+
+        text_to_summarise = " ".join(chunk_texts)
+
+        llm = get_llm_client()
+
+        prompt = f"Summarise the following text in {max_sentences} sentences:\n\n{text_to_summarise}"
+
+        response = llm.chat_completion(
+            messages=[{"role": "user", "content": prompt}],
+            model=settings.LLM_MODEL,
+            max_tokens=settings.SUMMARY_MAX_TOKENS,
+            temperature=settings.LLM_TEMPERATURE,
+        )
+        summary = response.choices[0].message.content.strip() if response.choices else None
+
+        return summary if summary else None
+
+    except Exception as e:
+        logger.error(f"Summary generation failed for {filePath}: {e}")
+        return None

--- a/backend/app/routes/documents.py
+++ b/backend/app/routes/documents.py
@@ -115,13 +115,15 @@ async def validate_upload(file: UploadFile):
 
 def _ingest_document(document_id: str, filepath: str, original_name: str, user_id: str):
     """
-    Process a document in the background: chunk document, generate embeddings, and store in ChromaDB.
+    Process a document in the background: chunk document, generate embeddings, and store in ChromaDB,
+    calls document summary function, and update the database record.
 
     This function is intended to be run as a background task. 
     It creates its own database session, updates the
     document status, extracts text, splits into chunks, generates embeddings,
-    stores everything in ChromaDB, and marks the document as 'ready'. On
-    failure, it sets status to 'failed' and records the error message.
+    stores everything in ChromaDB, calls summary function, updates the document record with page count,
+    chunk count, and summary, and marks the document as 'ready'. 
+    On failure, it sets status to 'failed' and records the error message.
 
     Args:
         document_id: Unique identifier of the document in the database.
@@ -169,6 +171,18 @@ def _ingest_document(document_id: str, filepath: str, original_name: str, user_i
             filename=original_name,
             user_id=user_id,
         )
+
+        # Generate summary and update document record
+        try:
+            from app.rag.summarizer import generate_document_summary
+
+            summary = generate_document_summary(filepath, max_sentences=2)
+            if summary:
+                doc.summary = summary
+                db.commit() # Update document record with summary                
+        except Exception as e:
+            logger.warning(f"Could not import summarizer for document {document_id}: {e}")
+            doc.summary = None
 
         # Update document record
         doc.chunk_count = chunk_count

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -70,6 +70,7 @@ class DocumentResponse(BaseModel):
     status: str
     error_message: Optional[str] = None
     uploaded_at: datetime
+    summary: Optional[str] = None # New field for document summary
 
     class Config:
         from_attributes = True

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -10,6 +10,7 @@ import ChatPanel from "@/components/chat/ChatPanel";
 import PDFViewer from "@/components/document/PDFViewer";
 
 export interface DocInfo {
+  summary: string;
   id: string;
   original_name: string;
   file_size: number;

--- a/frontend/src/components/document/DocumentSidebar.tsx
+++ b/frontend/src/components/document/DocumentSidebar.tsx
@@ -143,7 +143,7 @@ export default function DocumentSidebar({ documents = [], activeDoc, onSelectDoc
         </h3>
       </div>
 
-      <ScrollArea className="flex-1 px-3">
+      <ScrollArea className="flex-1 px-3 overflow-auto">
         {documents.length === 0 ? (
           <div className="text-center py-12">
             <FolderOpen className="w-8 h-8 mx-auto text-muted-foreground/40 mb-3" />
@@ -167,6 +167,9 @@ export default function DocumentSidebar({ documents = [], activeDoc, onSelectDoc
                   <div className="flex-1 min-w-0">
                     <p className="text-sm font-medium truncate leading-tight">
                       {doc.original_name}
+                    </p>
+                    <p className="text-xs text-muted-foreground mt-1">
+                      {doc.summary || "📄 No summary available"}
                     </p>
                     <div className="flex items-center gap-2 mt-1">
                       <span className="text-[10px] text-muted-foreground">


### PR DESCRIPTION
## 📋 PR Checklist

> Thank you for contributing to **PDF-Assistant-RAG**! 🎉  
> Please fill out this template before submitting. PRs without it filled in will be closed.

---

### 🔗 Related Issue
Closes #37 

---

### 📝 What does this PR do?
This PR adds automatic document summarization to the RAG pipeline. After a document is uploaded and indexed, the system generates a 2–3 sentence summary using the LLM (via HuggingFace API) and stores it in the database. The summary is then displayed in the document card within the sidebar, giving users a quick preview of each document.

Key Changes:
- Added summary column to the Document model.
- Created app/rag/summarizer.py with generate_document_summary() function that extracts text from the first N chunks and calls the LLM to produce a short summary.
- Integrated summarization into the background ingestion task (_ingest_document) so it runs automatically after chunking and embedding.
- Updated DocumentResponse schema to include the summary field.
- Modified the frontend sidebar component to display the summary for each document.
- Added scrollbar (overflow-auto) to automatically enable scrolling when many documents are present in the sidebar
---

### 🗂️ Type of Change
<!-- Check all that apply -->
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [x] 🔧 Refactor / code cleanup
- [x] 📝 Documentation update
- [x] 🎨 UI / styling change
- [ ] ⚙️ CI / tooling / config change
- [ ] 🧪 Tests

---

### 🧪 How was this tested?
<!-- Describe how you verified your changes work. -->
- [x] Ran the backend locally (`uvicorn app.main:app --reload`)
- [x] Ran the frontend locally (`npm run dev` inside `frontend/`)
- [x] Tested the affected API endpoints manually
- [ ] Added / updated tests

---

### 📸 Screenshots (if UI change)
<img width="2878" height="1442" alt="Screenshot 2026-05-28 155232" src="https://github.com/user-attachments/assets/7cd2aa3f-e29c-4b87-b812-6e2222a4e875" />

---

### ⚠️ Anything to flag for reviewers?
- The method I used to generate short summary is "stuff" which takes first N chunks from the document (where generally summary resides) and stuffs them into single text block and sends to LLM for summary generation, this generally is 'one' LLM call which saves lots of time and tokens as this operation calls LLM only once and gets the summary.
- There are other methods as well (ex. map reduce works by calling LLM once for summary generation of each chunk and then generating final summary among them which includes lots of LLM calls). 
- I have not used the other types because they take much time in generating summary and take lots of LLM calls. 

---

### ✅ Self-Review Checklist
- [x] My branch is based on **`dev`**, not `main`
- [x] I have not added any secrets / API keys
- [x] I have not modified `main` branch or any HuggingFace deployment config
- [x] My code follows the existing style (no unnecessary formatting changes)
- [x] I have updated relevant docs / comments if needed
