### PR TITLE
feat: API keys generation and authentication

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -67,12 +67,39 @@ def decode_token(token: str, token_type: str = "access") -> Optional[str]:
 
 # ── FastAPI Dependencies ─────────────────────────────
 
+import hashlib
+
 def get_current_user(
     credentials: HTTPAuthorizationCredentials = Depends(security),
     db: Session = Depends(get_db),
 ) -> User:
-    """Dependency: extract and validate user from JWT bearer token."""
+    """Dependency: extract and validate user from JWT bearer token or API key."""
     token = credentials.credentials
+
+    # Check if token is an API key
+    if token.startswith("rag_"):
+        hashed = hashlib.sha256(token.encode("utf-8")).hexdigest()
+        from app.models import ApiKey
+        api_key = db.query(ApiKey).filter(ApiKey.hashed_key == hashed).first()
+        if not api_key:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid API key",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+        
+        api_key.last_used = datetime.now(timezone.utc)
+        db.commit()
+
+        user = api_key.user
+        if not user:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="User not found for this API key",
+            )
+        return user
+
+    # Otherwise, process as JWT
     user_id = decode_token(token)
 
     if not user_id:

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -26,6 +26,21 @@ class User(Base):
     # Relationships
     documents = relationship("Document", back_populates="owner", cascade="all, delete-orphan")
     messages = relationship("ChatMessage", back_populates="user", cascade="all, delete-orphan")
+    api_keys = relationship("ApiKey", back_populates="user", cascade="all, delete-orphan")
+
+
+class ApiKey(Base):
+    __tablename__ = "api_keys"
+
+    id = Column(String, primary_key=True, default=generate_uuid)
+    user_id = Column(String, ForeignKey("users.id"), nullable=False, index=True)
+    key_prefix = Column(String(10), nullable=False)
+    hashed_key = Column(String(255), nullable=False, unique=True, index=True)
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
+    last_used = Column(DateTime, nullable=True)
+
+    # Relationships
+    user = relationship("User", back_populates="api_keys")
 
 
 class Document(Base):

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy import select
 from app.config import get_settings
 from app.database import get_db
-from app.models import User
+from app.models import User, ApiKey
 from app.schemas import (
     GoogleLoginRequest,
     RefreshRequest,
@@ -23,6 +23,8 @@ from app.schemas import (
     UserResponse,
     UserUpdate,
     UserUpdateResponse,
+    ApiKeyResponse,
+    ApiKeyCreateResponse,
 )
 from app.auth import hash_password, verify_password, create_access_token, create_refresh_token, get_current_user, decode_token
 
@@ -382,3 +384,40 @@ def update_password(payload:UpdatePassword,
     except SQLAlchemyError:
         db.rollback()
         raise HTTPException(status_code=400, detail="Database error")
+
+
+from typing import List
+import hashlib
+
+@router.post("/api-keys", response_model=ApiKeyCreateResponse, status_code=status.HTTP_201_CREATED)
+def create_api_key(user: User = Depends(get_current_user), db: Session = Depends(get_db)):
+    """Create a new API key for the authenticated user."""
+    raw_key = "rag_" + secrets.token_urlsafe(32)
+    hashed_key = hashlib.sha256(raw_key.encode("utf-8")).hexdigest()
+    
+    api_key = ApiKey(
+        user_id=user.id,
+        key_prefix=raw_key[:10],
+        hashed_key=hashed_key,
+    )
+    db.add(api_key)
+    db.commit()
+    db.refresh(api_key)
+    
+    return {"key": raw_key, "api_key": api_key}
+
+@router.get("/api-keys", response_model=List[ApiKeyResponse])
+def list_api_keys(user: User = Depends(get_current_user), db: Session = Depends(get_db)):
+    """List all API keys for the authenticated user."""
+    return db.query(ApiKey).filter(ApiKey.user_id == user.id).all()
+
+@router.delete("/api-keys/{key_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_api_key(key_id: str, user: User = Depends(get_current_user), db: Session = Depends(get_db)):
+    """Revoke an API key."""
+    api_key = db.query(ApiKey).filter(ApiKey.id == key_id, ApiKey.user_id == user.id).first()
+    if not api_key:
+        raise HTTPException(status_code=404, detail="API key not found")
+    
+    db.delete(api_key)
+    db.commit()
+    return None

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -136,5 +136,22 @@ class ChatHistoryResponse(BaseModel):
     document_id: Optional[str] = None
 
 
+# ── ApiKeys ─────────────────────────────────────────────
+
+class ApiKeyResponse(BaseModel):
+    id: str
+    key_prefix: str
+    created_at: datetime
+    last_used: Optional[datetime] = None
+
+    class Config:
+        from_attributes = True
+
+
+class ApiKeyCreateResponse(BaseModel):
+    key: str
+    api_key: ApiKeyResponse
+
+
 # Rebuild models for forward references
 TokenResponse.model_rebuild()

--- a/frontend/src/components/auth/ApiKeyManager.tsx
+++ b/frontend/src/components/auth/ApiKeyManager.tsx
@@ -32,7 +32,10 @@ export default function ApiKeyManager() {
   };
 
   useEffect(() => {
-    fetchKeys();
+    const timer = setTimeout(() => {
+      fetchKeys();
+    }, 0);
+    return () => clearTimeout(timer);
   }, []);
 
   const generateKey = async () => {
@@ -69,11 +72,16 @@ export default function ApiKeyManager() {
 
   return (
     <Dialog onOpenChange={(open) => { if (!open) setNewKey(null); }}>
-      <DialogTrigger className="flex w-full cursor-pointer items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors hover:bg-accent hover:text-accent-foreground">
-        <Key className="mr-2 h-4 w-4" />
-        <span>API Keys</span>
-      </DialogTrigger>
+      <DialogTrigger
+        render={
+          <button className="flex w-full cursor-pointer items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors hover:bg-accent hover:text-accent-foreground">
+            <Key className="mr-2 h-4 w-4" />
+            <span>API Keys</span>
+          </button>
+        }
+      />
       <DialogContent className="max-w-2xl sm:rounded-2xl border-border/40 p-6 md:p-8 bg-background/95 backdrop-blur-xl shadow-2xl">
+
         <DialogHeader>
           <DialogTitle className="text-2xl font-bold tracking-tight">API Keys</DialogTitle>
           <p className="text-sm text-muted-foreground mt-1.5">

--- a/frontend/src/components/auth/ApiKeyManager.tsx
+++ b/frontend/src/components/auth/ApiKeyManager.tsx
@@ -19,10 +19,6 @@ export default function ApiKeyManager() {
   const [loading, setLoading] = useState(false);
   const [copied, setCopied] = useState(false);
 
-  useEffect(() => {
-    fetchKeys();
-  }, []);
-
   const fetchKeys = async () => {
     try {
       setLoading(true);
@@ -34,6 +30,10 @@ export default function ApiKeyManager() {
       setLoading(false);
     }
   };
+
+  useEffect(() => {
+    fetchKeys();
+  }, []);
 
   const generateKey = async () => {
     try {
@@ -114,7 +114,7 @@ export default function ApiKeyManager() {
             {keys.length === 0 ? (
               <div className="p-8 text-center text-sm text-muted-foreground bg-muted/20">
                 <Key className="w-8 h-8 mx-auto mb-3 opacity-20" />
-                You don't have any API keys yet.
+                You don&apos;t have any API keys yet.
               </div>
             ) : (
               <div className="divide-y divide-border/50">

--- a/frontend/src/components/auth/ApiKeyManager.tsx
+++ b/frontend/src/components/auth/ApiKeyManager.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { api } from "@/lib/api";
+import { Key, Plus, Trash2, Copy, Check } from "lucide-react";
+
+interface ApiKey {
+  id: string;
+  key_prefix: string;
+  created_at: string;
+  last_used: string | null;
+}
+
+export default function ApiKeyManager() {
+  const [keys, setKeys] = useState<ApiKey[]>([]);
+  const [newKey, setNewKey] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    fetchKeys();
+  }, []);
+
+  const fetchKeys = async () => {
+    try {
+      setLoading(true);
+      const data = await api.get<ApiKey[]>("/api/v1/auth/api-keys");
+      setKeys(data || []);
+    } catch (err) {
+      console.error("Failed to load API keys", err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const generateKey = async () => {
+    try {
+      setLoading(true);
+      const data = await api.post<{ key: string; api_key: ApiKey }>("/api/v1/auth/api-keys");
+      setNewKey(data.key);
+      setKeys((prev) => [...prev, data.api_key]);
+    } catch (err) {
+      console.error("Failed to generate API key", err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const revokeKey = async (id: string) => {
+    if (!confirm("Are you sure you want to revoke this key? Any integrations using it will immediately break.")) return;
+    
+    try {
+      await api.delete(`/api/v1/auth/api-keys/${id}`);
+      setKeys((prev) => prev.filter((k) => k.id !== id));
+    } catch (err) {
+      console.error("Failed to revoke API key", err);
+    }
+  };
+
+  const copyToClipboard = () => {
+    if (newKey) {
+      navigator.clipboard.writeText(newKey);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
+  return (
+    <Dialog onOpenChange={(open) => { if (!open) setNewKey(null); }}>
+      <DialogTrigger asChild>
+        <button className="flex w-full cursor-pointer items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors hover:bg-accent hover:text-accent-foreground">
+          <Key className="mr-2 h-4 w-4" />
+          <span>API Keys</span>
+        </button>
+      </DialogTrigger>
+      <DialogContent className="max-w-2xl sm:rounded-2xl border-border/40 p-6 md:p-8 bg-background/95 backdrop-blur-xl shadow-2xl">
+        <DialogHeader>
+          <DialogTitle className="text-2xl font-bold tracking-tight">API Keys</DialogTitle>
+          <p className="text-sm text-muted-foreground mt-1.5">
+            Manage API keys to access the RAG engine programmatically from your own applications or scripts.
+          </p>
+        </DialogHeader>
+
+        {newKey && (
+          <div className="my-6 p-5 border border-primary/20 bg-primary/5 rounded-xl space-y-3 animate-in fade-in zoom-in-95 duration-300">
+            <h4 className="font-semibold text-primary flex items-center gap-2">
+              <Key className="w-4 h-4" /> Save your new API key
+            </h4>
+            <p className="text-sm text-muted-foreground">
+              Please copy this key and store it somewhere safe. For security reasons, you will <strong>never</strong> be able to view it again.
+            </p>
+            <div className="flex items-center gap-2 mt-2">
+              <code className="flex-1 bg-background/80 border border-border/50 px-4 py-2.5 rounded-lg text-sm font-mono break-all text-foreground shadow-inner">
+                {newKey}
+              </code>
+              <Button onClick={copyToClipboard} variant={copied ? "default" : "secondary"} className="shrink-0 shadow-sm">
+                {copied ? <Check className="w-4 h-4 mr-2" /> : <Copy className="w-4 h-4 mr-2" />}
+                {copied ? "Copied!" : "Copy"}
+              </Button>
+            </div>
+          </div>
+        )}
+
+        <div className="space-y-4 mt-6">
+          <div className="flex items-center justify-between">
+            <h3 className="text-sm font-medium text-foreground/80 uppercase tracking-wider">Active Keys</h3>
+            <Button onClick={generateKey} disabled={loading} size="sm" className="rounded-full shadow-sm hover:shadow-md transition-shadow">
+              <Plus className="w-4 h-4 mr-1.5" />
+              Generate New Key
+            </Button>
+          </div>
+
+          <div className="rounded-xl border border-border/50 bg-card overflow-hidden shadow-sm">
+            {keys.length === 0 ? (
+              <div className="p-8 text-center text-sm text-muted-foreground bg-muted/20">
+                <Key className="w-8 h-8 mx-auto mb-3 opacity-20" />
+                You don't have any API keys yet.
+              </div>
+            ) : (
+              <div className="divide-y divide-border/50">
+                {keys.map((key) => (
+                  <div key={key.id} className="flex items-center justify-between p-4 hover:bg-muted/30 transition-colors group">
+                    <div className="space-y-1">
+                      <div className="font-mono text-sm font-medium tracking-tight">
+                        {key.key_prefix}••••••••••••••••••••••
+                      </div>
+                      <div className="text-xs text-muted-foreground flex gap-4">
+                        <span>Created: {new Date(key.created_at).toLocaleDateString()}</span>
+                        <span>Last used: {key.last_used ? new Date(key.last_used).toLocaleDateString() : "Never"}</span>
+                      </div>
+                    </div>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => revokeKey(key.id)}
+                      className="text-destructive/70 hover:text-destructive hover:bg-destructive/10 opacity-0 group-hover:opacity-100 transition-all"
+                      title="Revoke key"
+                    >
+                      <Trash2 className="w-4 h-4" />
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/auth/ApiKeyManager.tsx
+++ b/frontend/src/components/auth/ApiKeyManager.tsx
@@ -69,11 +69,9 @@ export default function ApiKeyManager() {
 
   return (
     <Dialog onOpenChange={(open) => { if (!open) setNewKey(null); }}>
-      <DialogTrigger asChild>
-        <button className="flex w-full cursor-pointer items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors hover:bg-accent hover:text-accent-foreground">
-          <Key className="mr-2 h-4 w-4" />
-          <span>API Keys</span>
-        </button>
+      <DialogTrigger className="flex w-full cursor-pointer items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors hover:bg-accent hover:text-accent-foreground">
+        <Key className="mr-2 h-4 w-4" />
+        <span>API Keys</span>
       </DialogTrigger>
       <DialogContent className="max-w-2xl sm:rounded-2xl border-border/40 p-6 md:p-8 bg-background/95 backdrop-blur-xl shadow-2xl">
         <DialogHeader>

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -21,7 +21,7 @@ import {
   Moon,
   Sun,
 } from "lucide-react";
-import { useState, useSyncExternalStore } from "react";
+import { useSyncExternalStore } from "react";
 import { useTheme } from "next-themes";
 import ApiKeyManager from "@/components/auth/ApiKeyManager";
 
@@ -80,14 +80,19 @@ export default function Header({ sidebarOpen, onToggleSidebar, viewerOpen, onTog
         )}
 
         <DropdownMenu>
-          <DropdownMenuTrigger className="flex items-center h-8 gap-2 px-2 rounded-md hover:bg-accent transition-colors cursor-pointer">
-            <Avatar className="w-6 h-6">
-              <AvatarFallback className="text-[10px] bg-primary/20 text-primary">
-                {user?.username?.slice(0, 2).toUpperCase() || "U"}
-              </AvatarFallback>
-            </Avatar>
-            <span className="text-sm hidden sm:inline">{user?.username}</span>
-          </DropdownMenuTrigger>
+          <DropdownMenuTrigger
+            render={
+              <button className="flex items-center h-8 gap-2 px-2 rounded-md hover:bg-accent transition-colors cursor-pointer">
+                <Avatar className="w-6 h-6">
+                  <AvatarFallback className="text-[10px] bg-primary/20 text-primary">
+                    {user?.username?.slice(0, 2).toUpperCase() || "U"}
+                  </AvatarFallback>
+                </Avatar>
+                <span className="text-sm hidden sm:inline">{user?.username}</span>
+              </button>
+            }
+          />
+
           <DropdownMenuContent align="end" className="w-56">
             <div className="px-3 py-2">
               <p className="text-sm font-medium">{user?.username}</p>

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -22,6 +22,7 @@ import {
   Sun,
 } from "lucide-react";
 import { useState } from "react";
+import ApiKeyManager from "@/components/auth/ApiKeyManager";
 
 interface HeaderProps {
   sidebarOpen: boolean;
@@ -87,11 +88,13 @@ export default function Header({ sidebarOpen, onToggleSidebar, viewerOpen, onTog
             </Avatar>
             <span className="text-sm hidden sm:inline">{user?.username}</span>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-48">
+          <DropdownMenuContent align="end" className="w-56">
             <div className="px-3 py-2">
               <p className="text-sm font-medium">{user?.username}</p>
               <p className="text-xs text-muted-foreground truncate">{user?.email}</p>
             </div>
+            <DropdownMenuSeparator />
+            <ApiKeyManager />
             <DropdownMenuSeparator />
             <DropdownMenuItem className="text-destructive cursor-pointer" onClick={handleLogout}>
               <LogOut className="w-4 h-4 mr-2" />


### PR DESCRIPTION
Fixes #161.

**Changes:**
- Added \ApiKey\ model in backend and updated \User\ relationships.
- Updated \get_current_user\ dependency to seamlessly validate Bearer tokens that start with \ag_\ against the hashed keys in the database.
- Added \/api/v1/auth/api-keys\ endpoints for creating, listing, and revoking API keys.
- Implemented \ApiKeyManager.tsx\ in the frontend, integrated cleanly into the user profile dropdown.