### PR TITLE
test: add backend pytest suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,15 @@ jobs:
         run: |
           python -c "import sys; sys.path.insert(0, 'backend'); from app.config import settings; print('✅ Config imports OK')" || true
 
+      - name: Run backend pytest suite
+        env:
+          SECRET_KEY: ci-dummy-secret
+          DATABASE_URL: sqlite:///./ci_test.db
+          HF_TOKEN: ci-dummy-token
+          UPLOAD_DIR: /tmp/uploads
+          CHROMA_PERSIST_DIR: /tmp/chroma
+        run: pytest backend/tests -v
+
   # ── 2. Frontend Build Check ─────────────────────────────
   frontend-check:
     name: ⚛️ Frontend — TypeScript & Build

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -18,6 +18,9 @@ google-auth
 # Config
 pydantic-settings
 pydantic[email]
+pytest
+pytest-cov
+httpx
 
 # Document Processing
 PyMuPDF

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,183 @@
+import os
+import sys
+import types
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+
+ROOT = Path(__file__).resolve().parents[2]
+BACKEND_DIR = ROOT / "backend"
+
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+os.environ.setdefault("SECRET_KEY", "test-secret-key")
+os.environ.setdefault("DATABASE_URL", "sqlite:///./test_bootstrap.db")
+os.environ.setdefault("HF_TOKEN", "test-hf-token")
+os.environ.setdefault("UPLOAD_DIR", str(ROOT / "backend" / "test_uploads"))
+os.environ.setdefault("CHROMA_PERSIST_DIR", str(ROOT / "backend" / "test_chroma"))
+
+
+fake_embeddings = types.ModuleType("app.rag.embeddings")
+fake_embeddings.get_embedding_model = lambda: object()
+fake_embeddings.embed_query = lambda query: [0.0]
+fake_embeddings.embed_texts = lambda texts: [[0.0] for _ in texts]
+sys.modules.setdefault("app.rag.embeddings", fake_embeddings)
+
+
+class _FakeChromaClient:
+    def heartbeat(self):
+        return "ok"
+
+
+fake_vectorstore = types.ModuleType("app.rag.vectorstore")
+fake_vectorstore.get_chroma_client = lambda: _FakeChromaClient()
+fake_vectorstore.store_chunks = lambda chunks, document_id, filename, user_id: len(chunks)
+fake_vectorstore.delete_document_chunks = lambda document_id, user_id: None
+fake_vectorstore.query_chunks = lambda query_embedding, user_id, document_id=None, top_k=10: []
+sys.modules.setdefault("app.rag.vectorstore", fake_vectorstore)
+
+slowapi_module = types.ModuleType("slowapi")
+slowapi_errors = types.ModuleType("slowapi.errors")
+slowapi_middleware = types.ModuleType("slowapi.middleware")
+slowapi_util = types.ModuleType("slowapi.util")
+
+
+class RateLimitExceeded(Exception):
+    pass
+
+
+class SlowAPIMiddleware:
+    def __init__(self, app, *args, **kwargs):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        await self.app(scope, receive, send)
+
+
+class Limiter:
+    def __init__(self, key_func=None, *args, **kwargs):
+        self.key_func = key_func
+
+    def limit(self, _value):
+        def decorator(fn):
+            return fn
+        return decorator
+
+
+slowapi_errors.RateLimitExceeded = RateLimitExceeded
+slowapi_middleware.SlowAPIMiddleware = SlowAPIMiddleware
+slowapi_util.get_remote_address = lambda request: "127.0.0.1"
+slowapi_module.Limiter = Limiter
+
+sys.modules.setdefault("slowapi", slowapi_module)
+sys.modules.setdefault("slowapi.errors", slowapi_errors)
+sys.modules.setdefault("slowapi.middleware", slowapi_middleware)
+sys.modules.setdefault("slowapi.util", slowapi_util)
+
+from app.auth import create_access_token, create_refresh_token, hash_password
+from app.database import Base, get_db
+from app.main import app
+from app.models import Document, User
+
+
+@pytest.fixture()
+def db_session(tmp_path):
+    db_file = tmp_path / "test.db"
+    engine = create_engine(
+        f"sqlite:///{db_file}",
+        connect_args={"check_same_thread": False},
+    )
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine)
+        engine.dispose()
+
+
+@pytest.fixture()
+def client(db_session, monkeypatch):
+    def override_get_db():
+        try:
+            yield db_session
+        finally:
+            pass
+
+    @asynccontextmanager
+    async def no_lifespan(_app):
+        yield
+
+    monkeypatch.setattr("app.database.SessionLocal", lambda: db_session)
+    app.dependency_overrides[get_db] = override_get_db
+    app.router.lifespan_context = no_lifespan
+
+    with TestClient(app) as test_client:
+        yield test_client
+
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture()
+def user(db_session):
+    instance = User(
+        username="tester",
+        email="tester@example.com",
+        hashed_password=hash_password("password123"),
+    )
+    db_session.add(instance)
+    db_session.commit()
+    db_session.refresh(instance)
+    return instance
+
+
+@pytest.fixture()
+def auth_headers(user):
+    token = create_access_token(user.id)
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture()
+def refresh_token(user):
+    return create_refresh_token(user.id)
+
+
+@pytest.fixture()
+def ready_document(db_session, user):
+    instance = Document(
+        user_id=user.id,
+        filename="ready.txt",
+        original_name="ready.txt",
+        file_size=128,
+        page_count=1,
+        chunk_count=2,
+        status="ready",
+    )
+    db_session.add(instance)
+    db_session.commit()
+    db_session.refresh(instance)
+    return instance
+
+
+@pytest.fixture()
+def pending_document(db_session, user):
+    instance = Document(
+        user_id=user.id,
+        filename="pending.txt",
+        original_name="pending.txt",
+        file_size=64,
+        status="pending",
+    )
+    db_session.add(instance)
+    db_session.commit()
+    db_session.refresh(instance)
+    return instance

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,81 @@
+def test_register_success(client):
+    response = client.post(
+        "/api/v1/auth/register",
+        json={
+            "username": "newuser",
+            "email": "newuser@example.com",
+            "password": "password123",
+        },
+    )
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["access_token"]
+    assert payload["refresh_token"]
+    assert payload["user"]["email"] == "newuser@example.com"
+
+
+def test_register_duplicate_email_or_username_conflict(client):
+    payload = {
+        "username": "dupuser",
+        "email": "dup@example.com",
+        "password": "password123",
+    }
+    first = client.post("/api/v1/auth/register", json=payload)
+    assert first.status_code == 201
+
+    duplicate_email = client.post(
+        "/api/v1/auth/register",
+        json={**payload, "username": "anotheruser"},
+    )
+    assert duplicate_email.status_code == 409
+    assert duplicate_email.json()["detail"] == "Email already registered"
+
+    duplicate_username = client.post(
+        "/api/v1/auth/register",
+        json={**payload, "email": "another@example.com"},
+    )
+    assert duplicate_username.status_code == 409
+    assert duplicate_username.json()["detail"] == "Username already taken"
+
+
+def test_login_success(client, user):
+    response = client.post(
+        "/api/v1/auth/login",
+        json={"email": user.email, "password": "password123"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["access_token"]
+    assert payload["refresh_token"]
+    assert payload["user"]["username"] == user.username
+
+
+def test_login_invalid_password(client, user):
+    response = client.post(
+        "/api/v1/auth/login",
+        json={"email": user.email, "password": "wrong-password"},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid email or password"
+
+
+def test_auth_me_requires_auth(client):
+    response = client.get("/api/v1/auth/me")
+
+    assert response.status_code == 403
+
+
+def test_refresh_token_success(client, refresh_token):
+    response = client.post(
+        "/api/v1/auth/refresh",
+        json={"refresh_token": refresh_token},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["access_token"]
+    assert payload["refresh_token"]
+    assert payload["token_type"] == "bearer"

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -65,7 +65,7 @@ def test_login_invalid_password(client, user):
 def test_auth_me_requires_auth(client):
     response = client.get("/api/v1/auth/me")
 
-    assert response.status_code == 403
+    assert response.status_code in (401, 403)
 
 
 def test_refresh_token_success(client, refresh_token):

--- a/backend/tests/test_chat.py
+++ b/backend/tests/test_chat.py
@@ -1,0 +1,50 @@
+def test_chat_ask_success(client, auth_headers, ready_document, monkeypatch):
+    monkeypatch.setattr(
+        "app.routes.chat.generate_answer",
+        lambda question, user_id, document_id=None: {
+            "answer": "Mocked answer",
+            "sources": [
+                {
+                    "text": "Mock source",
+                    "filename": "ready.txt",
+                    "page": 1,
+                    "score": 0.99,
+                    "confidence": 99.0,
+                }
+            ],
+        },
+    )
+
+    response = client.post(
+        "/api/v1/chat/ask",
+        headers=auth_headers,
+        json={"question": "What is in the doc?", "document_id": ready_document.id},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["answer"] == "Mocked answer"
+    assert payload["document_id"] == ready_document.id
+    assert payload["sources"][0]["filename"] == "ready.txt"
+
+
+def test_chat_ask_document_not_found(client, auth_headers):
+    response = client.post(
+        "/api/v1/chat/ask",
+        headers=auth_headers,
+        json={"question": "Missing doc?", "document_id": "missing-doc-id"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Document not found"
+
+
+def test_chat_ask_document_not_ready(client, auth_headers, pending_document):
+    response = client.post(
+        "/api/v1/chat/ask",
+        headers=auth_headers,
+        json={"question": "Pending doc?", "document_id": pending_document.id},
+    )
+
+    assert response.status_code == 400
+    assert "Document is still pending" in response.json()["detail"]

--- a/backend/tests/test_chunker.py
+++ b/backend/tests/test_chunker.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+import pytest
+
+from app.rag.chunker import chunk_document, get_page_count
+
+
+def test_txt_extraction_and_chunking(tmp_path):
+    file_path = tmp_path / "notes.txt"
+    file_path.write_text("This is a sample text file for chunking.", encoding="utf-8")
+
+    chunks = chunk_document(str(file_path))
+
+    assert len(chunks) >= 1
+    assert chunks[0]["page"] == 1
+    assert "sample text file" in chunks[0]["text"]
+
+
+def test_empty_txt_returns_no_chunks(tmp_path):
+    file_path = tmp_path / "empty.txt"
+    file_path.write_text("   \n", encoding="utf-8")
+
+    assert chunk_document(str(file_path)) == []
+
+
+def test_unsupported_extension_raises_value_error(tmp_path):
+    file_path = tmp_path / "data.csv"
+    file_path.write_text("a,b,c", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Unsupported file type"):
+        chunk_document(str(file_path))
+
+
+def test_get_page_count_for_txt_returns_one(tmp_path):
+    file_path = tmp_path / "single.txt"
+    file_path.write_text("hello", encoding="utf-8")
+
+    assert get_page_count(str(file_path)) == 1

--- a/backend/tests/test_documents.py
+++ b/backend/tests/test_documents.py
@@ -10,7 +10,7 @@ def test_api_health(client):
 def test_protected_documents_list_requires_auth(client):
     response = client.get("/api/v1/documents/")
 
-    assert response.status_code == 403
+    assert response.status_code in (401, 403)
 
 
 def test_documents_list_authenticated(client, auth_headers, ready_document):

--- a/backend/tests/test_documents.py
+++ b/backend/tests/test_documents.py
@@ -1,0 +1,34 @@
+def test_api_health(client):
+    response = client.get("/api/health")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "healthy"
+    assert payload["version"] == "2.0.0"
+
+
+def test_protected_documents_list_requires_auth(client):
+    response = client.get("/api/v1/documents/")
+
+    assert response.status_code == 403
+
+
+def test_documents_list_authenticated(client, auth_headers, ready_document):
+    response = client.get("/api/v1/documents/", headers=auth_headers)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["total"] == 1
+    assert payload["items"][0]["id"] == ready_document.id
+    assert payload["items"][0]["original_name"] == "ready.txt"
+
+
+def test_upload_rejects_unsupported_extension_before_deep_validation(client, auth_headers):
+    response = client.post(
+        "/api/v1/documents/upload",
+        headers=auth_headers,
+        files={"file": ("payload.exe", b"binary-data", "application/octet-stream")},
+    )
+
+    assert response.status_code == 400
+    assert "not supported" in response.json()["detail"]


### PR DESCRIPTION
### 🔗 Related Issue
Closes #121

---

### 📝 What does this PR do?
Adds a backend pytest suite to cover core backend behavior and prevent regressions.

This PR:
- Adds pytest dependencies for backend testing
- Adds isolated test database setup with FastAPI TestClient fixtures
- Adds unit tests for document chunking
- Adds authentication endpoint tests
- Adds chat endpoint tests with mocked RAG generation
- Adds document endpoint tests
- Updates CI to run backend pytest automatically

---

### 🗂️ Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔧 Refactor / code cleanup
- [ ] 📝 Documentation update
- [ ] 🎨 UI / styling change
- [x] ⚙️ CI / tooling / config change
- [x] 🧪 Tests

---

### 🧪 How was this tested?
- [ ] Ran the backend locally (`uvicorn app.main:app --reload`)
- [ ] Ran the frontend locally (`npm run dev` inside `frontend/`)
- [ ] Tested the affected API endpoints manually
- [x] Added / updated tests

Additional check run:
- `PYTHONPATH=backend pytest backend/tests -v`

Result:
- `17 passed`

---

### 📸 Screenshots (if UI change)
N/A

---

### ⚠️ Anything to flag for reviewers?
Tests mock heavy RAG/vector/embedding dependencies so the suite stays fast and does not require external API keys.

---

### ✅ Self-Review Checklist
- [x] My branch is based on **`dev`**, not `main`
- [x] I have not added any secrets / API keys
- [x] I have not modified `main` branch or any HuggingFace deployment config
- [x] My code follows the existing style (no unnecessary formatting changes)
- [x] I have updated relevant docs / comments if needed