### PR TITLE
feat(ui): add source snippet preview on hover and expandable excerpt toggle in SourceCard

### DIFF
--- a/frontend/src/components/chat/SourceCard.tsx
+++ b/frontend/src/components/chat/SourceCard.tsx
@@ -4,7 +4,14 @@ import { useState } from "react";
 import type { SourceChunk } from "@/store/chat-store";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { ChevronDown, ChevronUp, FileText, Eye } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { ChevronDown, ChevronUp, FileText, Eye, TextQuote } from "lucide-react";
+
+const EXCERPT_THRESHOLD = 200;
 
 interface Props {
   sources: SourceChunk[];
@@ -13,89 +20,125 @@ interface Props {
 
 export default function SourceCard({ sources = [], onPageClick }: Props) {
   const [expanded, setExpanded] = useState(false);
+  const [excerptOpen, setExcerptOpen] = useState<Set<number>>(new Set());
 
   if (sources.length === 0) return null;
 
+  const toggleExcerpt = (i: number) => {
+    const next = new Set(excerptOpen);
+    if (next.has(i)) {
+      next.delete(i);
+    } else {
+      next.add(i);
+    }
+    setExcerptOpen(next);
+  };
+
   return (
     <div className="rounded-lg border border-border/50 bg-card/50 overflow-hidden">
-      {/* ── Header ──────────────────────────────────── */}
-      <button
-        onClick={() => setExpanded(!expanded)}
-        className="w-full flex items-center justify-between px-3 py-2 text-xs hover:bg-accent/30 transition-colors"
-      >
-        <span className="flex items-center gap-1.5 text-muted-foreground">
-          <FileText className="w-3.5 h-3.5" />
-          {sources.length} source{sources.length > 1 ? "s" : ""} cited
-        </span>
-        {expanded ? (
-          <ChevronUp className="w-3.5 h-3.5 text-muted-foreground" />
-        ) : (
-          <ChevronDown className="w-3.5 h-3.5 text-muted-foreground" />
-        )}
-      </button>
+        {/* ── Header ──────────────────────────────────── */}
+        <button
+          onClick={() => setExpanded(!expanded)}
+          className="w-full flex items-center justify-between px-3 py-2 text-xs hover:bg-accent/30 transition-colors"
+        >
+          <span className="flex items-center gap-1.5 text-muted-foreground">
+            <FileText className="w-3.5 h-3.5" />
+            {sources.length} source{sources.length > 1 ? "s" : ""} cited
+          </span>
+          {expanded ? (
+            <ChevronUp className="w-3.5 h-3.5 text-muted-foreground" />
+          ) : (
+            <ChevronDown className="w-3.5 h-3.5 text-muted-foreground" />
+          )}
+        </button>
 
-      {/* ── Collapsed: Mini badges ──────────────────── */}
-      {!expanded && (
-        <div className="px-3 pb-2 flex flex-wrap gap-1">
-          {sources.map((src, i) => (
-            <Badge
-              key={i}
-              variant="secondary"
-              className="text-[10px] h-5 cursor-pointer hover:bg-primary/20 transition-colors"
-              onClick={() => onPageClick(src.page + 1)}
-            >
-              p.{src.page + 1} • {src.confidence}%
-            </Badge>
-          ))}
-        </div>
-      )}
-
-      {/* ── Expanded: Full source cards ─────────────── */}
-      {expanded && (
-        <div className="border-t border-border/30">
-          {sources.map((src, i) => (
-            <div
-              key={i}
-              className="px-3 py-2.5 border-b border-border/20 last:border-b-0 hover:bg-accent/20 transition-colors"
-            >
-              <div className="flex items-center justify-between mb-1.5">
-                <div className="flex items-center gap-2">
-                  <span className="text-[10px] font-medium text-muted-foreground">
-                    {src.filename}
-                  </span>
-                  <Badge variant="outline" className="text-[9px] h-4 px-1.5">
-                    Page {src.page + 1}
-                  </Badge>
+        {/* ── Collapsed: Mini badges with hover preview ── */}
+        {!expanded && (
+          <div className="px-3 pb-2 flex flex-wrap gap-1">
+            {sources.map((src, i) => (
+              <Tooltip key={i}>
+                <TooltipTrigger className="inline-flex">
                   <Badge
                     variant="secondary"
-                    className={`text-[9px] h-4 px-1.5 ${
-                      src.confidence >= 80
-                        ? "text-emerald-400 bg-emerald-400/10"
-                        : src.confidence >= 50
-                        ? "text-yellow-400 bg-yellow-400/10"
-                        : "text-muted-foreground"
-                    }`}
+                    className="text-[10px] h-5 cursor-pointer hover:bg-primary/20 transition-colors"
+                    onClick={() => onPageClick(src.page + 1)}
                   >
-                    {src.confidence}% match
+                    p.{src.page + 1} • {src.confidence}%
                   </Badge>
-                </div>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-6 px-2 text-[10px]"
-                  onClick={() => onPageClick(src.page + 1)}
+                </TooltipTrigger>
+                <TooltipContent
+                  side="top"
+                  align="center"
+                  className="max-w-xs p-2"
                 >
-                  <Eye className="w-3 h-3 mr-1" />
-                  View
-                </Button>
+                  <p className="text-[11px] leading-relaxed line-clamp-6">
+                    {src.text}
+                  </p>
+                </TooltipContent>
+              </Tooltip>
+            ))}
+          </div>
+        )}
+
+        {/* ── Expanded: Full source cards ─────────────── */}
+        {expanded && (
+          <div className="border-t border-border/30">
+            {sources.map((src, i) => (
+              <div
+                key={i}
+                className="px-3 py-2.5 border-b border-border/20 last:border-b-0 hover:bg-accent/20 transition-colors"
+              >
+                <div className="flex items-center justify-between mb-1.5">
+                  <div className="flex items-center gap-2">
+                    <span className="text-[10px] font-medium text-muted-foreground">
+                      {src.filename}
+                    </span>
+                    <Badge variant="outline" className="text-[9px] h-4 px-1.5">
+                      Page {src.page + 1}
+                    </Badge>
+                    <Badge
+                      variant="secondary"
+                      className={`text-[9px] h-4 px-1.5 ${
+                        src.confidence >= 80
+                          ? "text-emerald-400 bg-emerald-400/10"
+                          : src.confidence >= 50
+                          ? "text-yellow-400 bg-yellow-400/10"
+                          : "text-muted-foreground"
+                      }`}
+                    >
+                      {src.confidence}% match
+                    </Badge>
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 px-2 text-[10px]"
+                    onClick={() => onPageClick(src.page + 1)}
+                  >
+                    <Eye className="w-3 h-3 mr-1" />
+                    View
+                  </Button>
+                </div>
+                <p
+                  className={`text-[11px] text-muted-foreground leading-relaxed ${
+                    excerptOpen.has(i) ? "" : "line-clamp-3"
+                  }`}
+                >
+                  {src.text}
+                </p>
+                {src.text.length > EXCERPT_THRESHOLD && (
+                  <button
+                    onClick={() => toggleExcerpt(i)}
+                    className="mt-1.5 flex items-center gap-1 text-[10px] text-primary/70 hover:text-primary transition-colors"
+                  >
+                    <TextQuote className="w-3 h-3" />
+                    {excerptOpen.has(i) ? "Hide excerpt" : "Show excerpt"}
+                  </button>
+                )}
               </div>
-              <p className="text-[11px] text-muted-foreground leading-relaxed line-clamp-3">
-                {src.text}
-              </p>
-            </div>
-          ))}
-        </div>
-      )}
+            ))}
+          </div>
+        )}
     </div>
   );
 }


### PR DESCRIPTION
## Description

Adds two complementary UX patterns to the `SourceCard` component for viewing source text chunks:

### 1. Hover preview on collapsed badges
- Each collapsed mini badge (`p.X • YY%`) now shows a tooltip with a text preview on hover
- Uses existing Base UI `Tooltip` component
- Preview clamped to 6 lines to keep tooltips compact

### 2. Expandable `Show excerpt` toggle
- Each expanded source card has a `Show excerpt` / `Hide excerpt` toggle
- Conditionally removes `line-clamp-3` to reveal full text inline
- Toggle only appears when text exceeds 200 chars (avoids clutter for short snippets)
- Uses `Set<number>` state for independent per-source expansion

### Changes
- `frontend/src/components/chat/SourceCard.tsx` — added tooltip wrapper on badges, `Show excerpt` toggle with `TextQuote` icon, `EXCERPT_THRESHOLD` constant

### Verification
- [x] Build passes with zero errors (`next build`)
- [x] No redundant `TooltipProvider` (already provided at app layout level)

Closes #48