### PR TITLE
feat: add PUT /auth/hf-token endpoint

### DIFF
--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -14,6 +14,7 @@ from app.database import get_db
 from app.models import User, ApiKey
 from app.schemas import (
     GoogleLoginRequest,
+    HFTokenUpdate,
     RefreshRequest,
     TokenResponse,
     UpdatePassword,
@@ -278,6 +279,34 @@ def get_me(user: User = Depends(get_current_user)):
         itself does not need to raise any HTTP exceptions.
     """
     return UserResponse.model_validate(user)
+
+@router.put("/hf-token", response_model=UserResponse)
+def update_hf_token(
+    payload: HFTokenUpdate,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Update the HuggingFace token for the authenticated user.
+
+    Stores the provided HF token in the user's profile so it can be used
+    for HuggingFace API calls (e.g. InferenceClient) in place of the
+    globally configured ``HF_TOKEN`` environment variable.
+
+    Args:
+        payload: HFTokenUpdate object containing the new ``hf_token`` value.
+        user: The currently authenticated user, obtained from the
+            ``get_current_user`` dependency.
+        db: SQLAlchemy database session, obtained from the dependency.
+
+    Returns:
+        UserResponse: The updated user profile including the new ``hf_token``
+        field.
+    """
+    user.hf_token = payload.hf_token
+    db.commit()
+    db.refresh(user)
+    return UserResponse.model_validate(user)
+
 
 @router.put("/update")
 def update_user_info(payload:UserUpdate,

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -79,3 +79,39 @@ def test_refresh_token_success(client, refresh_token):
     assert payload["access_token"]
     assert payload["refresh_token"]
     assert payload["token_type"] == "bearer"
+
+
+def test_update_hf_token_success(client, auth_headers):
+    response = client.put(
+        "/api/v1/auth/hf-token",
+        json={"hf_token": "hf_new_token_value"},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["hf_token"] == "hf_new_token_value"
+
+
+def test_update_hf_token_requires_auth(client):
+    response = client.put(
+        "/api/v1/auth/hf-token",
+        json={"hf_token": "hf_unauth"},
+    )
+
+    assert response.status_code in (401, 403)
+
+
+def test_hf_token_appears_in_user_response(client, auth_headers, user, db_session):
+    # First update the token
+    put_resp = client.put(
+        "/api/v1/auth/hf-token",
+        json={"hf_token": "hf_persist_token"},
+        headers=auth_headers,
+    )
+    assert put_resp.status_code == 200
+
+    # Then verify it shows up in GET /me
+    me_resp = client.get("/api/v1/auth/me", headers=auth_headers)
+    assert me_resp.status_code == 200
+    assert me_resp.json()["hf_token"] == "hf_persist_token"


### PR DESCRIPTION
### 🔗 Related Issue
Closes #178

---

### 📝 What does this PR do?
Adds an authenticated `PUT /auth/hf-token` endpoint that allows users to store their HuggingFace token, which can be used in place of the globally configured `HF_TOKEN` env var for HuggingFace API calls.

**Changes:**
- `backend/app/routes/auth.py` — New `PUT /auth/hf-token` endpoint that takes `{ "hf_token": "..." }`, persists it to the user's DB record, and returns the updated `UserResponse`
- `backend/tests/test_auth.py` — 3 new tests covering success, auth-required, and persistence via `GET /me`

---

### 🗂️ Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🔧 Refactor / code cleanup
- [ ] 📝 Documentation update
- [ ] 🎨 UI / styling change
- [ ] ⚙️ CI / tooling / config change
- [x] 🧪 Tests

---

### 🧪 How was this tested?
- [x] Ran the backend locally (`uvicorn app.main:app --reload`)
- [ ] Ran the frontend locally (`npm run dev` inside `frontend/`)
- [x] Tested the affected API endpoints manually
- [x] Added / updated tests

All 20 tests pass (17 existing + 3 new).

---

### 📸 Screenshots (if UI change)
N/A — backend-only

---

### ⚠️ Anything to flag for reviewers?
This PR depends on the `hf_token` column added in #177 (already merged into `dev`). The `HFTokenUpdate` schema and updated `UserResponse` were also introduced there. Only the endpoint and tests are new here.

Rebased cleanly on latest `upstream/dev`.

---

### ✅ Self-Review Checklist
- [x] My branch is based on **`dev`**, not `main`
- [x] I have not added any secrets / API keys
- [x] I have not modified `main` branch or any HuggingFace deployment config
- [x] My code follows the existing style (no unnecessary formatting changes)
- [x] I have updated relevant docs / comments if needed