### PR TITLE
feat: add hf_token field and setHfToken action to auth store

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -201,6 +201,29 @@ class ApiClient {
     return res.json();
   }
 
+  async put<T>(path: string, body?: unknown, options?: FetchOptions): Promise<T> {
+    const res = await this.fetchWithConnectionError(`${this.baseUrl}${path}`, {
+      method: "PUT",
+      headers: this.getHeaders(options?.token),
+      body: body ? JSON.stringify(body) : undefined,
+      ...options,
+    });
+
+    // Auto-refresh on 401
+    if (res.status === 401 && !options?._skipRefresh) {
+      const newToken = await this.tryRefreshToken();
+      if (newToken) {
+        return this.put<T>(path, body, { ...options, token: newToken, _skipRefresh: true });
+      }
+    }
+
+    if (!res.ok) {
+      throw new Error(await this.getErrorMessage(res, res.statusText || "Request failed"));
+    }
+
+    return res.json();
+  }
+
   async postForm<T>(path: string, formData: FormData, options?: FetchOptions): Promise<T> {
     const token = options?.token || this.getToken();
     const headers: HeadersInit = {};

--- a/frontend/src/store/auth-store.ts
+++ b/frontend/src/store/auth-store.ts
@@ -8,6 +8,7 @@ export interface AuthUser {
   username: string;
   email: string;
   is_admin: boolean;
+  hf_token?: string;
   created_at: string;
 }
 
@@ -23,6 +24,7 @@ interface AuthStore {
   initializeAuth: () => Promise<void>;
   syncTokensRefreshed: (detail?: { accessToken?: string; user?: AuthUser | null }) => void;
   syncLoggedOut: () => void;
+  setHfToken: (hfToken: string) => Promise<void>;
 }
 
 const getStoredToken = () =>
@@ -137,5 +139,10 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
       loading: false,
       initialized: true,
     });
+  },
+
+  async setHfToken(hfToken: string) {
+    const response = await api.put<AuthUser>("/api/v1/auth/hf-token", { hf_token: hfToken });
+    set({ user: response });
   },
 }));


### PR DESCRIPTION
### 🔗 Related Issue
Closes #181

---

### 📝 What does this PR do?
Adds frontend support for saving a Hugging Face token to the user profile.

**frontend/src/lib/api.ts**
- Adds `put<T>()` method to `ApiClient` — follows the same pattern as `post<T>()`, including auto-refresh on 401

**frontend/src/store/auth-store.ts**
- Adds `hf_token?: string` field to the `AuthUser` interface
- Adds `setHfToken(hfToken: string)` action to `AuthStore` that sends `PUT /api/v1/auth/hf-token` and updates the store with the response

---

### 🗂️ Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🔧 Refactor / code cleanup
- [ ] 📝 Documentation update
- [ ] 🎨 UI / styling change
- [ ] ⚙️ CI / tooling / config change
- [ ] 🧪 Tests

---

### 🧪 How was this tested?
- [ ] Ran the backend locally (`uvicorn app.main:app --reload`)
- [x] Ran the frontend locally (`npm run dev` inside `frontend/`)
- [ ] Tested the affected API endpoints manually
- [ ] Added / updated tests

**TypeScript check:** `tsc --noEmit` — zero errors  
**Build:** `npm run build` — compiled successfully, zero errors, zero warnings

---

### 📸 Screenshots (if UI change)
N/A — no UI change; store + API client only

---

### ⚠️ Anything to flag for reviewers?
The `package-lock.json` was reverted after `npm install` to keep the diff clean — only intentional changes are included.

---

### ✅ Self-Review Checklist
- [x] My branch is based on **`dev`**, not `main`
- [x] I have not added any secrets / API keys
- [x] I have not modified `main` branch or any HuggingFace deployment config
- [x] My code follows the existing style (no unnecessary formatting changes)
- [x] I have updated relevant docs / comments if needed