### PR TITLE
feat: add workflow to auto-sync labels from referenced issue to PR

### DIFF
--- a/.github/workflows/sync-issue-labels.yml
+++ b/.github/workflows/sync-issue-labels.yml
@@ -1,0 +1,115 @@
+name: Sync Labels — Issue to PR
+
+# ──────────────────────────────────────────────────────────
+# Auto-syncs labels from referenced issue(s) to the PR when
+# a PR is opened or updated targeting `dev`.
+#
+# Why pull_request_target:
+#   Label operations need write permissions on the target
+#   repo. pull_request_target runs in the context of the
+#   base repo with access to secrets and write token.
+#   Since we only read issue data and apply labels, there
+#   is no security concern.
+# ──────────────────────────────────────────────────────────
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, edited, ready_for_review]
+    branches: ["dev"]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: write
+
+jobs:
+  sync-labels:
+    name: Sync labels from referenced issue
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Extract issue numbers from PR body
+        id: extract
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          # Match patterns:
+          #   "Closes #123"
+          #   "Fixes #456, #789"  (comma-separated)
+          #   "Resolves #111, #222, #333"
+          #
+          # Approach: grab lines containing a keyword, then
+          # extract every #NNN from those lines.
+          ISSUES=$(
+            echo "${PR_BODY:-}" \
+              | grep -ioP '(Closes|Fixes|Resolves).*' 2>/dev/null || true \
+              | grep -oP '#\d+' 2>/dev/null || true \
+              | grep -oP '\d+' 2>/dev/null || true \
+              | sort -un 2>/dev/null || true \
+              | tr '\n' ' ' 2>/dev/null || true \
+              | xargs
+          )
+          echo "Found issues: [$ISSUES]"
+          echo "issues=$ISSUES" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch and apply labels
+        if: steps.extract.outputs.issues != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUES: ${{ steps.extract.outputs.issues }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          ALL_LABELS=""
+
+          for ISSUE in $ISSUES; do
+            echo "--- Fetching labels for #$ISSUE ---"
+
+            LABELS=$(gh issue view "$ISSUE" --repo "$REPO" --json labels --jq '.labels[].name' 2>/dev/null || true)
+
+            if [ -z "$LABELS" ]; then
+              echo "  → No labels on #$ISSUE, skipping"
+              continue
+            fi
+
+            echo "  → Labels: $(echo "$LABELS" | tr '\n' ' ')"
+
+            # Accumulate labels (newline-separated, deduplicated later)
+            ALL_LABELS="${ALL_LABELS}${LABELS}"$'\n'
+          done
+
+          if [ -z "$ALL_LABELS" ]; then
+            echo "No labels found across all referenced issues. Exiting."
+            exit 0
+          fi
+
+          # Deduplicate and remove empty lines
+          UNIQUE_LABELS=$(echo "$ALL_LABELS" | sort -u | grep -v '^$')
+
+          echo ""
+          echo "=== Applying labels to PR #$PR_NUMBER ==="
+          echo "$UNIQUE_LABELS"
+
+          # Get labels already on the PR
+          EXISTING=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json labels --jq '.labels[].name' 2>/dev/null || true)
+
+          MISSING=0
+          while IFS= read -r LABEL; do
+            [ -z "$LABEL" ] && continue
+            if echo "$EXISTING" | grep -qxF "$LABEL"; then
+              echo "  ✓ Already present: $LABEL"
+            else
+              echo "  + Adding: $LABEL"
+              gh label create "$LABEL" --repo "$REPO" 2>/dev/null || true  # create if not exists
+              gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "$LABEL"
+              MISSING=$((MISSING + 1))
+            fi
+          done <<< "$UNIQUE_LABELS"
+
+          if [ "$MISSING" -eq 0 ]; then
+            echo "All labels already synced — nothing to add."
+          else
+            echo "Done. Added $MISSING label(s) to PR #$PR_NUMBER."
+          fi


### PR DESCRIPTION
### 🔗 Related Issue
Closes #199

---

### 📝 What does this PR do?
Adds a GitHub Actions workflow that automatically syncs labels from referenced issue(s) to a PR, eliminating the need for maintainers to manually copy labels.

**New file:** `.github/workflows/sync-issue-labels.yml`

**How it works:**
1. Triggers on `pull_request_target` when a PR is opened, reopened, synchronized, edited, or marked ready-for-review targeting `dev`
2. Parses `Closes #NNN`, `Fixes #NNN`, or `Resolves #NNN` from the PR body (matching the existing PR template format)
3. Fetches labels from each referenced issue via the GitHub API (`gh issue view`)
4. Merges labels from multiple issue references (deduplicated)
5. Applies any missing labels to the PR

**Edge cases handled:**
- ✅ Multiple issue references in one PR (e.g., `Closes #185, #190`) — merges labels from all
- ✅ No issue reference — silently skips
- ✅ Issue has no labels — silently skips
- ✅ PR already has the labels — no duplicates
- ✅ Issue fetch fails — graceful skip with log
- ✅ Empty PR body — handled via `${PR_BODY:-}` default
- ✅ Label doesn't exist in repo yet — auto-created before applying

---

### 🗂️ Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🔧 Refactor / code cleanup
- [ ] 📝 Documentation update
- [ ] 🎨 UI / styling change
- [x] ⚙️ CI / tooling / config change
- [ ] 🧪 Tests

---

### 🧪 How was this tested?
- [ ] Ran the backend locally (`uvicorn app.main:app --reload`)
- [ ] Ran the frontend locally (`npm run dev` inside `frontend/`)
- [ ] Tested the affected API endpoints manually
- [ ] Added / updated tests

**Static analysis:** YAML syntax validated against the existing workflow patterns in the repo.
**Note:** This workflow can only be fully verified once merged to `dev`, as `pull_request_target` runs in the context of the base repo. The script has been structured with defensive error handling (`|| true`, `2>/dev/null`, `set -euo pipefail`) to fail gracefully.

---

### 📸 Screenshots (if UI change)
N/A — CI workflow only

---

### ⚠️ Anything to flag for reviewers?
- Uses `pull_request_target` (not `pull_request`) because label operations require write permissions on the target repo. Since the workflow only **reads** issue data and **writes** labels, there's no security concern with `pull_request_target`.
- Does NOT trigger on `labeled`/`unlabeled` events to prevent infinite loops
- Does NOT require a checkout step — all operations use the `gh` CLI (pre-installed on GitHub Actions runners)
- Single-file addition — no changes to existing CI workflows or the PR template

---

### ✅ Self-Review Checklist
- [x] My branch is based on **`dev`**, not `main`
- [x] I have not added any secrets / API keys
- [x] I have not modified `main` branch or any HuggingFace deployment config
- [x] My code follows the existing style (no unnecessary formatting changes)
- [x] I have updated relevant docs / comments if needed