### PR TITLE
feat(rag): add query transformation before retrieval

### DIFF
--- a/backend/app/rag/retriever.py
+++ b/backend/app/rag/retriever.py
@@ -1,7 +1,9 @@
 """
 Two-stage retrieval: ChromaDB similarity search + cross-encoder reranking.
 """
+import json
 import logging
+import re
 from typing import List, Dict, Any, Optional
 from app.config import get_settings
 from app.rag.embeddings import embed_query
@@ -10,6 +12,7 @@ from app.rag.vectorstore import query_chunks
 
 logger = logging.getLogger(__name__)
 settings = get_settings()
+MAX_QUERY_VARIANTS = 4
 
 # ── Singleton reranker ───────────────────────────────
 _reranker = None
@@ -30,6 +33,136 @@ def get_reranker():
             _reranker = "disabled"
 
     return _reranker if _reranker != "disabled" else None
+
+
+def transform_query(query: str) -> List[str]:
+    """Rewrite a user question into multiple retrieval-friendly search queries."""
+    original_query = query.strip()
+    if not original_query:
+        return []
+
+    try:
+        generated_queries = _generate_query_variants(original_query)
+    except Exception as e:
+        logger.warning(f"Query transformation failed, using original query only: {e}")
+        generated_queries = []
+
+    return _dedupe_queries([original_query, *generated_queries])[:MAX_QUERY_VARIANTS]
+
+
+def _generate_query_variants(query: str) -> List[str]:
+    """Use the configured LLM to split/rewrite a user query for semantic search."""
+    if not settings.HF_TOKEN:
+        return []
+
+    from huggingface_hub import InferenceClient
+
+    client = InferenceClient(token=settings.HF_TOKEN)
+    prompt = (
+        "Rewrite the user question into concise semantic search queries for document retrieval. "
+        "Split independent topics into separate queries. Return a JSON array of strings only. "
+        f"User question: {query}"
+    )
+    response = client.chat_completion(
+        messages=[
+            {
+                "role": "system",
+                "content": "You create optimized search queries for a RAG retriever.",
+            },
+            {"role": "user", "content": prompt},
+        ],
+        model=settings.LLM_MODEL,
+        max_tokens=256,
+        temperature=0.2,
+    )
+
+    if not response.choices:
+        return []
+
+    content = response.choices[0].message.content or ""
+    return _parse_query_variants(content)
+
+
+def _parse_query_variants(content: str) -> List[str]:
+    """Parse LLM output into a list even when it adds light prose around JSON."""
+    content = content.strip()
+    if not content:
+        return []
+
+    parsed = _try_parse_query_json(content)
+    if parsed is not None:
+        return parsed
+
+    match = re.search(r"\[[\s\S]*\]", content)
+    if match:
+        parsed = _try_parse_query_json(match.group(0))
+        if parsed is not None:
+            return parsed
+
+    queries = []
+    for line in content.splitlines():
+        cleaned = re.sub(r"^\s*[-*\d.)]+\s*", "", line).strip().strip('"')
+        if cleaned:
+            queries.append(cleaned)
+    return queries
+
+
+def _try_parse_query_json(content: str) -> Optional[List[str]]:
+    try:
+        parsed = json.loads(content)
+    except json.JSONDecodeError:
+        return None
+
+    if isinstance(parsed, dict):
+        parsed = parsed.get("queries", [])
+
+    if not isinstance(parsed, list):
+        return []
+
+    return [item.strip() for item in parsed if isinstance(item, str) and item.strip()]
+
+
+def _dedupe_queries(queries: List[str]) -> List[str]:
+    deduped = []
+    seen = set()
+    for query in queries:
+        normalized = " ".join(query.split())
+        key = normalized.lower()
+        if normalized and key not in seen:
+            seen.add(key)
+            deduped.append(normalized)
+    return deduped
+
+
+def _candidate_key(chunk: Dict[str, Any]) -> str:
+    for key in ("id", "chunk_id"):
+        if chunk.get(key):
+            return str(chunk[key])
+
+    text = str(chunk.get("text", ""))
+    return "|".join(
+        str(part)
+        for part in (
+            chunk.get("document_id", ""),
+            chunk.get("filename", ""),
+            chunk.get("page", ""),
+            text[:200],
+        )
+    )
+
+
+def _merge_candidates(candidates: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    merged: Dict[str, Dict[str, Any]] = {}
+
+    for candidate in candidates:
+        candidate_copy = dict(candidate)
+        key = _candidate_key(candidate_copy)
+        existing = merged.get(key)
+
+        if existing is None or candidate_copy.get("score", 0) > existing.get("score", 0):
+            merged[key] = candidate_copy
+
+    return list(merged.values())
 
 
 @trace_function(
@@ -55,17 +188,23 @@ def retrieve(
 
     Returns chunks with confidence scores.
     """
-    # ── Stage 1: Embedding search ────────────────────
-    query_vector = embed_query(query)
-    candidates = query_chunks(
-        query_embedding=query_vector,
-        user_id=user_id,
-        document_id=document_id,
-        top_k=settings.TOP_K_RETRIEVAL,
-    )
+    # ── Stage 1: Query transformation + embedding search ─────────────
+    candidates = []
+    for search_query in transform_query(query):
+        query_vector = embed_query(search_query)
+        candidates.extend(
+            query_chunks(
+                query_embedding=query_vector,
+                user_id=user_id,
+                document_id=document_id,
+                top_k=settings.TOP_K_RETRIEVAL,
+            )
+        )
 
     if not candidates:
         return []
+
+    candidates = _merge_candidates(candidates)
 
     # ── Stage 2: Cross-encoder reranking ─────────────
     reranker = get_reranker()
@@ -85,6 +224,8 @@ def retrieve(
 
         except Exception as e:
             logger.warning(f"Reranking failed, using embedding scores: {e}")
+
+    candidates.sort(key=lambda x: x.get("rerank_score", x.get("score", 0)), reverse=True)
 
     # ── Take top-K after reranking ───────────────────
     top_chunks = candidates[:settings.TOP_K_RERANK]

--- a/backend/tests/test_retriever.py
+++ b/backend/tests/test_retriever.py
@@ -1,0 +1,77 @@
+from app.rag import retriever
+
+
+def test_transform_query_includes_original_and_dedupes(monkeypatch):
+    monkeypatch.setattr(
+        retriever,
+        "_generate_query_variants",
+        lambda _query: [
+            "How do taxes work?",
+            "how do taxes work?",
+            "How does healthcare work?",
+            "healthcare overview",
+        ],
+    )
+
+    queries = retriever.transform_query("How do taxes and healthcare work?")
+
+    assert queries == [
+        "How do taxes and healthcare work?",
+        "How do taxes work?",
+        "How does healthcare work?",
+        "healthcare overview",
+    ]
+
+
+def test_retrieve_fans_out_transformed_queries_and_merges_duplicates(monkeypatch):
+    searched_queries = []
+
+    monkeypatch.setattr(retriever, "transform_query", lambda _query: ["taxes", "healthcare"])
+    monkeypatch.setattr(retriever, "embed_query", lambda query: f"embedding:{query}")
+    monkeypatch.setattr(retriever, "get_reranker", lambda: None)
+
+    def fake_query_chunks(query_embedding, user_id, document_id=None, top_k=10):
+        searched_queries.append(query_embedding)
+        if query_embedding == "embedding:taxes":
+            return [
+                {
+                    "id": "shared",
+                    "text": "Shared chunk",
+                    "filename": "policy.pdf",
+                    "page": 1,
+                    "score": 0.2,
+                },
+                {
+                    "id": "taxes",
+                    "text": "Tax chunk",
+                    "filename": "policy.pdf",
+                    "page": 2,
+                    "score": 0.7,
+                },
+            ]
+
+        return [
+            {
+                "id": "shared",
+                "text": "Shared chunk",
+                "filename": "policy.pdf",
+                "page": 1,
+                "score": 0.9,
+            },
+            {
+                "id": "healthcare",
+                "text": "Healthcare chunk",
+                "filename": "policy.pdf",
+                "page": 3,
+                "score": 0.8,
+            },
+        ]
+
+    monkeypatch.setattr(retriever, "query_chunks", fake_query_chunks)
+
+    chunks = retriever.retrieve("How do taxes and healthcare work?", user_id="user-1")
+
+    assert searched_queries == ["embedding:taxes", "embedding:healthcare"]
+    assert [chunk["id"] for chunk in chunks] == ["shared", "healthcare", "taxes"]
+    assert chunks[0]["score"] == 0.9
+    assert chunks[0]["confidence"] == 100.0


### PR DESCRIPTION
## 📋 PR Checklist

> Thank you for contributing to **PDF-Assistant-RAG**! 🎉  
> Please fill out this template before submitting. PRs without it filled in will be closed.

---

### 🔗 Related Issue
Closes #157 

---

### 📝 What does this PR do?
- Add LLM-powered query transformation for multi-topic user prompts
- Fan out retrieval across rewritten search queries before querying ChromaDB
- Deduplicate retrieved chunks and keep the highest scoring result
- Preserve existing retriever response shape for the RAG pipeline
- Add retriever tests for query deduplication and multi-query fan-out

---

### 🗂️ Type of Change

- [ ] ✨ New feature
- [ ] 🧪 Tests

---

### 🧪 How was this tested?

- [ ] Added / updated tests

Additional verification:
- `python -m flake8 backend/app 
- `python -m pytest backend/tests -v --basetemp backend\.tmp\pytest`

---

### ⚠️ Anything to flag for reviewers?
The query transformation uses the configured HuggingFace LLM lazily and falls back to the original query if transformation fails, so retrieval should continue working even without a valid token or usable LLM response.


---

### ✅ Self-Review Checklist
- [ ] My branch is based on **`dev`**, not `main`
- [ ] I have not added any secrets / API keys
- [ ] I have not modified `main` branch or any HuggingFace deployment config
- [ ] My code follows the existing style (no unnecessary formatting changes)
- [ ] I have updated relevant docs / comments if needed
