### PR TITLE
Add SQLite to Supabase migration utility

### DIFF
--- a/backend/app/rag/retriever.py
+++ b/backend/app/rag/retriever.py
@@ -1,7 +1,9 @@
 """
 Two-stage retrieval: ChromaDB similarity search + cross-encoder reranking.
 """
+import json
 import logging
+import re
 from typing import List, Dict, Any, Optional
 from app.config import get_settings
 from app.rag.embeddings import embed_query
@@ -10,6 +12,7 @@ from app.rag.vectorstore import query_chunks
 
 logger = logging.getLogger(__name__)
 settings = get_settings()
+MAX_QUERY_VARIANTS = 4
 
 # ── Singleton reranker ───────────────────────────────
 _reranker = None
@@ -30,6 +33,136 @@ def get_reranker():
             _reranker = "disabled"
 
     return _reranker if _reranker != "disabled" else None
+
+
+def transform_query(query: str) -> List[str]:
+    """Rewrite a user question into multiple retrieval-friendly search queries."""
+    original_query = query.strip()
+    if not original_query:
+        return []
+
+    try:
+        generated_queries = _generate_query_variants(original_query)
+    except Exception as e:
+        logger.warning(f"Query transformation failed, using original query only: {e}")
+        generated_queries = []
+
+    return _dedupe_queries([original_query, *generated_queries])[:MAX_QUERY_VARIANTS]
+
+
+def _generate_query_variants(query: str) -> List[str]:
+    """Use the configured LLM to split/rewrite a user query for semantic search."""
+    if not settings.HF_TOKEN:
+        return []
+
+    from huggingface_hub import InferenceClient
+
+    client = InferenceClient(token=settings.HF_TOKEN)
+    prompt = (
+        "Rewrite the user question into concise semantic search queries for document retrieval. "
+        "Split independent topics into separate queries. Return a JSON array of strings only. "
+        f"User question: {query}"
+    )
+    response = client.chat_completion(
+        messages=[
+            {
+                "role": "system",
+                "content": "You create optimized search queries for a RAG retriever.",
+            },
+            {"role": "user", "content": prompt},
+        ],
+        model=settings.LLM_MODEL,
+        max_tokens=256,
+        temperature=0.2,
+    )
+
+    if not response.choices:
+        return []
+
+    content = response.choices[0].message.content or ""
+    return _parse_query_variants(content)
+
+
+def _parse_query_variants(content: str) -> List[str]:
+    """Parse LLM output into a list even when it adds light prose around JSON."""
+    content = content.strip()
+    if not content:
+        return []
+
+    parsed = _try_parse_query_json(content)
+    if parsed is not None:
+        return parsed
+
+    match = re.search(r"\[[\s\S]*\]", content)
+    if match:
+        parsed = _try_parse_query_json(match.group(0))
+        if parsed is not None:
+            return parsed
+
+    queries = []
+    for line in content.splitlines():
+        cleaned = re.sub(r"^\s*[-*\d.)]+\s*", "", line).strip().strip('"')
+        if cleaned:
+            queries.append(cleaned)
+    return queries
+
+
+def _try_parse_query_json(content: str) -> Optional[List[str]]:
+    try:
+        parsed = json.loads(content)
+    except json.JSONDecodeError:
+        return None
+
+    if isinstance(parsed, dict):
+        parsed = parsed.get("queries", [])
+
+    if not isinstance(parsed, list):
+        return []
+
+    return [item.strip() for item in parsed if isinstance(item, str) and item.strip()]
+
+
+def _dedupe_queries(queries: List[str]) -> List[str]:
+    deduped = []
+    seen = set()
+    for query in queries:
+        normalized = " ".join(query.split())
+        key = normalized.lower()
+        if normalized and key not in seen:
+            seen.add(key)
+            deduped.append(normalized)
+    return deduped
+
+
+def _candidate_key(chunk: Dict[str, Any]) -> str:
+    for key in ("id", "chunk_id"):
+        if chunk.get(key):
+            return str(chunk[key])
+
+    text = str(chunk.get("text", ""))
+    return "|".join(
+        str(part)
+        for part in (
+            chunk.get("document_id", ""),
+            chunk.get("filename", ""),
+            chunk.get("page", ""),
+            text[:200],
+        )
+    )
+
+
+def _merge_candidates(candidates: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    merged: Dict[str, Dict[str, Any]] = {}
+
+    for candidate in candidates:
+        candidate_copy = dict(candidate)
+        key = _candidate_key(candidate_copy)
+        existing = merged.get(key)
+
+        if existing is None or candidate_copy.get("score", 0) > existing.get("score", 0):
+            merged[key] = candidate_copy
+
+    return list(merged.values())
 
 
 @trace_function(
@@ -55,17 +188,23 @@ def retrieve(
 
     Returns chunks with confidence scores.
     """
-    # ── Stage 1: Embedding search ────────────────────
-    query_vector = embed_query(query)
-    candidates = query_chunks(
-        query_embedding=query_vector,
-        user_id=user_id,
-        document_id=document_id,
-        top_k=settings.TOP_K_RETRIEVAL,
-    )
+    # ── Stage 1: Query transformation + embedding search ─────────────
+    candidates = []
+    for search_query in transform_query(query):
+        query_vector = embed_query(search_query)
+        candidates.extend(
+            query_chunks(
+                query_embedding=query_vector,
+                user_id=user_id,
+                document_id=document_id,
+                top_k=settings.TOP_K_RETRIEVAL,
+            )
+        )
 
     if not candidates:
         return []
+
+    candidates = _merge_candidates(candidates)
 
     # ── Stage 2: Cross-encoder reranking ─────────────
     reranker = get_reranker()
@@ -85,6 +224,8 @@ def retrieve(
 
         except Exception as e:
             logger.warning(f"Reranking failed, using embedding scores: {e}")
+
+    candidates.sort(key=lambda x: x.get("rerank_score", x.get("score", 0)), reverse=True)
 
     # ── Take top-K after reranking ───────────────────
     top_chunks = candidates[:settings.TOP_K_RERANK]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,6 +8,7 @@ python-multipart
 # Database
 sqlalchemy
 aiosqlite
+psycopg[binary]
 
 # Auth
 pyjwt

--- a/backend/scripts/migrate_sqlite_to_postgres.py
+++ b/backend/scripts/migrate_sqlite_to_postgres.py
@@ -1,0 +1,524 @@
+"""Migrate SQLite app data into a Supabase/Postgres database.
+
+The script supports both the current FastAPI SQLite schema
+(`users`, `documents`, `chat_messages`) and the older legacy
+`instance/users.db` schema (`user` only).
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    Text,
+    create_engine,
+    inspect,
+    select,
+)
+from sqlalchemy.engine import Engine
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session, sessionmaker
+
+LOGGER = logging.getLogger("sqlite_to_postgres")
+
+
+def generate_uuid() -> str:
+    return str(uuid.uuid4())
+
+
+metadata = MetaData()
+
+users = Table(
+    "users",
+    metadata,
+    Column("id", String, primary_key=True, default=generate_uuid),
+    Column("username", String(80), unique=True, nullable=False, index=True),
+    Column("email", String(120), unique=True, nullable=False, index=True),
+    Column("hashed_password", String(255), nullable=False),
+    Column("is_admin", Boolean, default=False),
+    Column("created_at", DateTime, default=lambda: datetime.now(timezone.utc)),
+    Column("last_login", DateTime, nullable=True, index=True),
+    Column("hf_token", String(255), nullable=True),
+)
+
+api_keys = Table(
+    "api_keys",
+    metadata,
+    Column("id", String, primary_key=True, default=generate_uuid),
+    Column("user_id", String, ForeignKey("users.id"), nullable=False, index=True),
+    Column("key_prefix", String(10), nullable=False),
+    Column("hashed_key", String(255), nullable=False, unique=True, index=True),
+    Column("created_at", DateTime, default=lambda: datetime.now(timezone.utc)),
+    Column("last_used", DateTime, nullable=True),
+)
+
+documents = Table(
+    "documents",
+    metadata,
+    Column("id", String, primary_key=True, default=generate_uuid),
+    Column("user_id", String, ForeignKey("users.id"), nullable=False, index=True),
+    Column("filename", String(255), nullable=False),
+    Column("original_name", String(255), nullable=False),
+    Column("file_size", Integer, default=0),
+    Column("page_count", Integer, default=0),
+    Column("chunk_count", Integer, default=0),
+    Column("status", String(20), default="pending"),
+    Column("error_message", Text, nullable=True),
+    Column("uploaded_at", DateTime, default=lambda: datetime.now(timezone.utc)),
+    Column("summary", Text, nullable=True),
+)
+
+chat_messages = Table(
+    "chat_messages",
+    metadata,
+    Column("id", String, primary_key=True, default=generate_uuid),
+    Column("user_id", String, ForeignKey("users.id"), nullable=False, index=True),
+    Column("document_id", String, ForeignKey("documents.id"), nullable=True, index=True),
+    Column("role", String(20), nullable=False),
+    Column("content", Text, nullable=False),
+    Column("sources_json", Text, nullable=True),
+    Column("created_at", DateTime, default=lambda: datetime.now(timezone.utc)),
+)
+
+shared_messages = Table(
+    "shared_messages",
+    metadata,
+    Column("id", String, primary_key=True, default=generate_uuid),
+    Column("message_id", String, ForeignKey("chat_messages.id"), nullable=False, unique=True, index=True),
+    Column("created_at", DateTime, default=lambda: datetime.now(timezone.utc)),
+)
+
+
+@dataclass
+class MigrationStats:
+    inserted: dict[str, int] = field(default_factory=dict)
+    reused: dict[str, int] = field(default_factory=dict)
+    skipped: dict[str, int] = field(default_factory=dict)
+
+    def add(self, table_name: str, action: str) -> None:
+        getattr(self, action)[table_name] = getattr(self, action).get(table_name, 0) + 1
+
+
+def normalize_postgres_url(url: str) -> str:
+    """Prefer psycopg v3 when callers pass Supabase's common URL forms."""
+    if url.startswith("postgres://"):
+        return "postgresql+psycopg://" + url.removeprefix("postgres://")
+    if url.startswith("postgresql://"):
+        return "postgresql+psycopg://" + url.removeprefix("postgresql://")
+    return url
+
+
+def sqlite_url_from_path(path: str) -> str:
+    return f"sqlite:///{Path(path).resolve().as_posix()}"
+
+
+def make_engine(url: str) -> Engine:
+    return create_engine(url, future=True)
+
+
+def make_session(engine: Engine) -> Session:
+    return sessionmaker(bind=engine, autocommit=False, autoflush=False, future=True)()
+
+
+def reflected_table(engine: Engine, table_name: str) -> Table | None:
+    if not inspect(engine).has_table(table_name):
+        return None
+    reflected = MetaData()
+    return Table(table_name, reflected, autoload_with=engine)
+
+
+def fetch_rows(session: Session, table: Table) -> list[dict[str, Any]]:
+    stmt = select(table)
+    if "id" in table.c:
+        stmt = stmt.order_by(table.c.id)
+    return [dict(row) for row in session.execute(stmt).mappings().all()]
+
+
+def existing_id(session: Session, table: Table, source_id: str | None) -> str | None:
+    if not source_id:
+        return None
+    return session.execute(select(table.c.id).where(table.c.id == source_id)).scalar_one_or_none()
+
+
+def available_id(session: Session, table: Table, source_id: Any) -> str:
+    candidate = str(source_id) if source_id is not None else generate_uuid()
+    if existing_id(session, table, candidate) is None:
+        return candidate
+
+    while True:
+        candidate = generate_uuid()
+        if existing_id(session, table, candidate) is None:
+            return candidate
+
+
+def first_existing_user(session: Session, row: dict[str, Any]) -> str | None:
+    email = row.get("email")
+    username = row.get("username")
+    if email:
+        match = session.execute(select(users.c.id).where(users.c.email == email)).scalar_one_or_none()
+        if match:
+            return match
+    if username:
+        return session.execute(select(users.c.id).where(users.c.username == username)).scalar_one_or_none()
+    return None
+
+
+def copy_users(
+    source_session: Session,
+    target_session: Session,
+    source_table: Table,
+    stats: MigrationStats,
+) -> dict[str, str]:
+    id_map: dict[str, str] = {}
+    now = datetime.now(timezone.utc)
+
+    for row in fetch_rows(source_session, source_table):
+        old_id = str(row.get("id"))
+        existing = existing_id(target_session, users, old_id) or first_existing_user(target_session, row)
+        if existing:
+            id_map[old_id] = existing
+            stats.add("users", "reused")
+            continue
+
+        is_legacy = source_table.name == "user"
+        new_id = available_id(target_session, users, None if is_legacy else old_id)
+        user_values = {
+            "id": new_id,
+            "username": row["username"],
+            "email": row["email"],
+            "hashed_password": row.get("hashed_password") or row.get("password") or "",
+            "is_admin": bool(row.get("is_admin") or False),
+            "created_at": row.get("created_at") or now,
+            "last_login": row.get("last_login"),
+            "hf_token": row.get("hf_token"),
+        }
+        target_session.execute(users.insert().values(**user_values))
+        id_map[old_id] = new_id
+        stats.add("users", "inserted")
+
+    return id_map
+
+
+def copy_api_keys(
+    source_session: Session,
+    target_session: Session,
+    source_table: Table | None,
+    user_id_map: dict[str, str],
+    stats: MigrationStats,
+) -> dict[str, str]:
+    id_map: dict[str, str] = {}
+    if source_table is None:
+        return id_map
+
+    for row in fetch_rows(source_session, source_table):
+        old_id = str(row.get("id"))
+        new_user_id = user_id_map.get(str(row.get("user_id")))
+        if not new_user_id:
+            stats.add("api_keys", "skipped")
+            continue
+
+        existing = (
+            existing_id(target_session, api_keys, old_id)
+            or target_session.execute(
+                select(api_keys.c.id).where(api_keys.c.hashed_key == row.get("hashed_key"))
+            ).scalar_one_or_none()
+        )
+        if existing:
+            id_map[old_id] = existing
+            stats.add("api_keys", "reused")
+            continue
+
+        new_id = available_id(target_session, api_keys, old_id)
+        target_session.execute(
+            api_keys.insert().values(
+                id=new_id,
+                user_id=new_user_id,
+                key_prefix=row["key_prefix"],
+                hashed_key=row["hashed_key"],
+                created_at=row.get("created_at") or datetime.now(timezone.utc),
+                last_used=row.get("last_used"),
+            )
+        )
+        id_map[old_id] = new_id
+        stats.add("api_keys", "inserted")
+
+    return id_map
+
+
+def copy_documents(
+    source_session: Session,
+    target_session: Session,
+    source_table: Table | None,
+    user_id_map: dict[str, str],
+    stats: MigrationStats,
+) -> dict[str, str]:
+    id_map: dict[str, str] = {}
+    if source_table is None:
+        return id_map
+
+    for row in fetch_rows(source_session, source_table):
+        old_id = str(row.get("id"))
+        new_user_id = user_id_map.get(str(row.get("user_id")))
+        if not new_user_id:
+            stats.add("documents", "skipped")
+            continue
+
+        existing = existing_id(target_session, documents, old_id)
+        if existing:
+            id_map[old_id] = existing
+            stats.add("documents", "reused")
+            continue
+
+        new_id = available_id(target_session, documents, old_id)
+        target_session.execute(
+            documents.insert().values(
+                id=new_id,
+                user_id=new_user_id,
+                filename=row["filename"],
+                original_name=row["original_name"],
+                file_size=row.get("file_size") or 0,
+                page_count=row.get("page_count") or 0,
+                chunk_count=row.get("chunk_count") or 0,
+                status=row.get("status") or "pending",
+                error_message=row.get("error_message"),
+                uploaded_at=row.get("uploaded_at") or datetime.now(timezone.utc),
+                summary=row.get("summary"),
+            )
+        )
+        id_map[old_id] = new_id
+        stats.add("documents", "inserted")
+
+    return id_map
+
+
+def copy_chat_messages(
+    source_session: Session,
+    target_session: Session,
+    source_table: Table | None,
+    user_id_map: dict[str, str],
+    document_id_map: dict[str, str],
+    stats: MigrationStats,
+) -> dict[str, str]:
+    id_map: dict[str, str] = {}
+    if source_table is None:
+        return id_map
+
+    for row in fetch_rows(source_session, source_table):
+        old_id = str(row.get("id"))
+        new_user_id = user_id_map.get(str(row.get("user_id")))
+        old_document_id = row.get("document_id")
+        new_document_id = document_id_map.get(str(old_document_id)) if old_document_id else None
+        if not new_user_id or (old_document_id and not new_document_id):
+            stats.add("chat_messages", "skipped")
+            continue
+
+        existing = existing_id(target_session, chat_messages, old_id)
+        if existing:
+            id_map[old_id] = existing
+            stats.add("chat_messages", "reused")
+            continue
+
+        new_id = available_id(target_session, chat_messages, old_id)
+        target_session.execute(
+            chat_messages.insert().values(
+                id=new_id,
+                user_id=new_user_id,
+                document_id=new_document_id,
+                role=row["role"],
+                content=row["content"],
+                sources_json=row.get("sources_json"),
+                created_at=row.get("created_at") or datetime.now(timezone.utc),
+            )
+        )
+        id_map[old_id] = new_id
+        stats.add("chat_messages", "inserted")
+
+    return id_map
+
+
+def copy_shared_messages(
+    source_session: Session,
+    target_session: Session,
+    source_table: Table | None,
+    message_id_map: dict[str, str],
+    stats: MigrationStats,
+) -> None:
+    if source_table is None:
+        return
+
+    for row in fetch_rows(source_session, source_table):
+        old_id = str(row.get("id"))
+        new_message_id = message_id_map.get(str(row.get("message_id")))
+        if not new_message_id:
+            stats.add("shared_messages", "skipped")
+            continue
+
+        existing = (
+            existing_id(target_session, shared_messages, old_id)
+            or target_session.execute(
+                select(shared_messages.c.id).where(shared_messages.c.message_id == new_message_id)
+            ).scalar_one_or_none()
+        )
+        if existing:
+            stats.add("shared_messages", "reused")
+            continue
+
+        target_session.execute(
+            shared_messages.insert().values(
+                id=available_id(target_session, shared_messages, old_id),
+                message_id=new_message_id,
+                created_at=row.get("created_at") or datetime.now(timezone.utc),
+            )
+        )
+        stats.add("shared_messages", "inserted")
+
+
+def migrate(
+    sqlite_url: str,
+    postgres_url: str,
+    create_tables: bool,
+    dry_run: bool,
+) -> MigrationStats:
+    source_engine = make_engine(sqlite_url)
+    target_engine = make_engine(normalize_postgres_url(postgres_url))
+
+    if create_tables:
+        metadata.create_all(target_engine)
+
+    source_session = make_session(source_engine)
+    target_session = make_session(target_engine)
+    stats = MigrationStats()
+
+    try:
+        current_users = reflected_table(source_engine, "users")
+        legacy_users = reflected_table(source_engine, "user")
+        source_users = current_users if current_users is not None else legacy_users
+        if source_users is None:
+            raise RuntimeError("No users table found. Expected 'users' or legacy 'user'.")
+
+        user_id_map = copy_users(source_session, target_session, source_users, stats)
+        copy_api_keys(source_session, target_session, reflected_table(source_engine, "api_keys"), user_id_map, stats)
+        document_id_map = copy_documents(
+            source_session,
+            target_session,
+            reflected_table(source_engine, "documents"),
+            user_id_map,
+            stats,
+        )
+        message_id_map = copy_chat_messages(
+            source_session,
+            target_session,
+            reflected_table(source_engine, "chat_messages"),
+            user_id_map,
+            document_id_map,
+            stats,
+        )
+        copy_shared_messages(
+            source_session,
+            target_session,
+            reflected_table(source_engine, "shared_messages"),
+            message_id_map,
+            stats,
+        )
+
+        if dry_run:
+            target_session.rollback()
+            LOGGER.info("Dry run complete; rolled back target transaction.")
+        else:
+            target_session.commit()
+            LOGGER.info("Migration committed.")
+
+        return stats
+    except IntegrityError:
+        target_session.rollback()
+        LOGGER.exception("Migration failed because the target database rejected a row.")
+        raise
+    except Exception:
+        target_session.rollback()
+        LOGGER.exception("Migration failed; rolled back target transaction.")
+        raise
+    finally:
+        source_session.close()
+        target_session.close()
+        source_engine.dispose()
+        target_engine.dispose()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Migrate SQLite users/documents/chat history to Supabase Postgres.")
+    parser.add_argument(
+        "--sqlite-path",
+        default="instance/users.db",
+        help="Path to the SQLite database file. Defaults to instance/users.db.",
+    )
+    parser.add_argument(
+        "--sqlite-url",
+        help="Full SQLite SQLAlchemy URL. Overrides --sqlite-path.",
+    )
+    parser.add_argument(
+        "--postgres-url",
+        default=os.getenv("SUPABASE_DB_URL") or os.getenv("POSTGRES_DATABASE_URL") or os.getenv("DATABASE_URL"),
+        help="Supabase/Postgres SQLAlchemy URL. Also read from SUPABASE_DB_URL, POSTGRES_DATABASE_URL, or DATABASE_URL.",
+    )
+    parser.add_argument(
+        "--no-create-tables",
+        action="store_true",
+        help="Do not create missing target tables before migrating.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Run the migration and roll back the target transaction.",
+    )
+    parser.add_argument("--verbose", action="store_true", help="Enable debug logging.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(levelname)s %(message)s",
+    )
+
+    postgres_url = args.postgres_url
+    if not postgres_url or postgres_url.startswith("sqlite"):
+        LOGGER.error("Provide a Supabase/Postgres URL with --postgres-url or SUPABASE_DB_URL.")
+        return 2
+
+    sqlite_url = args.sqlite_url or sqlite_url_from_path(args.sqlite_path)
+    stats = migrate(
+        sqlite_url=sqlite_url,
+        postgres_url=postgres_url,
+        create_tables=not args.no_create_tables,
+        dry_run=args.dry_run,
+    )
+
+    for table_name in sorted(set(stats.inserted) | set(stats.reused) | set(stats.skipped)):
+        LOGGER.info(
+            "%s: inserted=%s reused=%s skipped=%s",
+            table_name,
+            stats.inserted.get(table_name, 0),
+            stats.reused.get(table_name, 0),
+            stats.skipped.get(table_name, 0),
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/test_retriever.py
+++ b/backend/tests/test_retriever.py
@@ -1,0 +1,77 @@
+from app.rag import retriever
+
+
+def test_transform_query_includes_original_and_dedupes(monkeypatch):
+    monkeypatch.setattr(
+        retriever,
+        "_generate_query_variants",
+        lambda _query: [
+            "How do taxes work?",
+            "how do taxes work?",
+            "How does healthcare work?",
+            "healthcare overview",
+        ],
+    )
+
+    queries = retriever.transform_query("How do taxes and healthcare work?")
+
+    assert queries == [
+        "How do taxes and healthcare work?",
+        "How do taxes work?",
+        "How does healthcare work?",
+        "healthcare overview",
+    ]
+
+
+def test_retrieve_fans_out_transformed_queries_and_merges_duplicates(monkeypatch):
+    searched_queries = []
+
+    monkeypatch.setattr(retriever, "transform_query", lambda _query: ["taxes", "healthcare"])
+    monkeypatch.setattr(retriever, "embed_query", lambda query: f"embedding:{query}")
+    monkeypatch.setattr(retriever, "get_reranker", lambda: None)
+
+    def fake_query_chunks(query_embedding, user_id, document_id=None, top_k=10):
+        searched_queries.append(query_embedding)
+        if query_embedding == "embedding:taxes":
+            return [
+                {
+                    "id": "shared",
+                    "text": "Shared chunk",
+                    "filename": "policy.pdf",
+                    "page": 1,
+                    "score": 0.2,
+                },
+                {
+                    "id": "taxes",
+                    "text": "Tax chunk",
+                    "filename": "policy.pdf",
+                    "page": 2,
+                    "score": 0.7,
+                },
+            ]
+
+        return [
+            {
+                "id": "shared",
+                "text": "Shared chunk",
+                "filename": "policy.pdf",
+                "page": 1,
+                "score": 0.9,
+            },
+            {
+                "id": "healthcare",
+                "text": "Healthcare chunk",
+                "filename": "policy.pdf",
+                "page": 3,
+                "score": 0.8,
+            },
+        ]
+
+    monkeypatch.setattr(retriever, "query_chunks", fake_query_chunks)
+
+    chunks = retriever.retrieve("How do taxes and healthcare work?", user_id="user-1")
+
+    assert searched_queries == ["embedding:taxes", "embedding:healthcare"]
+    assert [chunk["id"] for chunk in chunks] == ["shared", "healthcare", "taxes"]
+    assert chunks[0]["score"] == 0.9
+    assert chunks[0]["confidence"] == 100.0


### PR DESCRIPTION
## 📋 PR Checklist

> Thank you for contributing to **PDF-Assistant-RAG**! 🎉  
> Please fill out this template before submitting. PRs without it filled in will be closed.

---

### 🔗 Related Issue
Closes #184 

---

### 📝 What does this PR do?

1. Add a standalone migration script for copying SQLite data into the new Supabase/Postgres database. The utility supports both the legacy users.db schema and the current app schema, creates missing target tables, maps old IDs to new IDs safely, and migrates users, documents, chat messages, API keys, and shared messages in dependency order.

2. Also add psycopg[binary] so SQLAlchemy can connect to Supabase Postgres URLs.

---

### 🗂️ Type of Change

- [x] ✨ New feature
- [ ] ⚙️ CI / tooling / config change

---

### 🧪 How was this tested?
<!-- Describe how you verified your changes work. -->
- [ ] Ran the backend locally (`uvicorn app.main:app --reload`)
- [ ] Ran the frontend locally (`npm run dev` inside `frontend/`)
- [ ] Tested the affected API endpoints manually
- [ ] Added / updated tests

Additional verification:
- Ran `python -m py_compile backend\scripts\migrate_sqlite_to_postgres.py`
- Smoke-tested migration from legacy `instance/users.db`
- Smoke-tested synthetic users/documents/chat history migration with ID remapping

---


### ⚠️ Anything to flag for reviewers?

1. This adds a standalone migration utility for moving SQLite data into Supabase/Postgres. It supports both the legacy `instance/users.db` schema and the newer app schema with users, documents, and chat messages.

2. The script also adds `psycopg[binary]` as a backend dependency so SQLAlchemy can connect to Supabase/Postgres URLs.33
---

### ✅ Self-Review Checklist
- [ ] My branch is based on **`dev`**, not `main`
- [ ] I have not added any secrets / API keys
- [ ] I have not modified `main` branch or any HuggingFace deployment config
- [ ] My code follows the existing style (no unnecessary formatting changes)
- [ ] I have updated relevant docs / comments if needed
