### PR TITLE
feat(rag): Refactor LLM agent to use dynamic per-user tokens

### DIFF
--- a/backend/app/rag/agent.py
+++ b/backend/app/rag/agent.py
@@ -15,21 +15,11 @@ from app.rag.tracing import trace_function
 logger = logging.getLogger(__name__)
 settings = get_settings()
 
-# ── Singleton LLM client ─────────────────────────────
-_llm_client = None
-
-
-def get_llm_client() -> InferenceClient:
-    """Get or create HuggingFace InferenceClient (singleton)."""
-    global _llm_client
-
-    if _llm_client is None:
-        _llm_client = InferenceClient(
-            token=settings.HF_TOKEN,
-        )
-        logger.info(f"LLM client initialized for model: {settings.LLM_MODEL}")
-
-    return _llm_client
+def get_llm_client(hf_token: Optional[str] = None) -> InferenceClient:
+    """Create a HuggingFace InferenceClient per-request."""
+    return InferenceClient(
+        token=hf_token or settings.HF_TOKEN,
+    )
 
 
 def is_greeting(question: str) -> bool:
@@ -68,7 +58,7 @@ def _chat_messages(system: str, user_content: str) -> list:
 
 @trace_function(
     "generate_answer",
-    metadata_factory=lambda question, user_id, document_id=None: {
+    metadata_factory=lambda question, user_id, document_id=None, **kwargs: {
         "user_id": user_id,
         "document_id": document_id,
         "llm_model": settings.LLM_MODEL,
@@ -78,13 +68,14 @@ def generate_answer(
     question: str,
     user_id: str,
     document_id: Optional[str] = None,
+    hf_token: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Full RAG pipeline: retrieve → build context → generate answer.
     Returns dict with 'answer' and 'sources'.
     """
-    # Get HuggingFace InferenceClient singleton (created once, reused)
-    client = get_llm_client()
+    # Get HuggingFace InferenceClient per-request
+    client = get_llm_client(hf_token)
 
     # ── Handle greetings ─────────────────────────────
     # Short-circuit: if user just says "hello", skip RAG entirely
@@ -156,7 +147,7 @@ def generate_answer(
 
 @trace_function(
     "generate_answer_stream",
-    metadata_factory=lambda question, user_id, document_id=None: {
+    metadata_factory=lambda question, user_id, document_id=None, **kwargs: {
         "user_id": user_id,
         "document_id": document_id,
         "llm_model": settings.LLM_MODEL,
@@ -166,13 +157,14 @@ def generate_answer_stream(
     question: str,
     user_id: str,
     document_id: Optional[str] = None,
+    hf_token: Optional[str] = None,
 ) -> Generator[str, None, None]:
     """
     Streaming RAG pipeline — yields SSE-formatted chunks.
     First yields sources, then streams answer tokens.
     """
-    # Get HuggingFace InferenceClient singleton (created once, reused)
-    client = get_llm_client()
+    # Get HuggingFace InferenceClient per-request
+    client = get_llm_client(hf_token)
 
     # ── Handle greetings ─────────────────────────────
     # Short-circuit: if user just says "hello", skip RAG entirely

--- a/backend/app/routes/chat.py
+++ b/backend/app/routes/chat.py
@@ -82,16 +82,16 @@ def create_share_link(
     )
 
 
-def generate_answer(question: str, user_id: str, document_id: Optional[str] = None):
+def generate_answer(question: str, user_id: str, document_id: Optional[str] = None, hf_token: Optional[str] = None):
     from app.rag.agent import generate_answer as _generate_answer
 
-    return _generate_answer(question=question, user_id=user_id, document_id=document_id)
+    return _generate_answer(question=question, user_id=user_id, document_id=document_id, hf_token=hf_token)
 
 
-def generate_answer_stream(question: str, user_id: str, document_id: Optional[str] = None):
+def generate_answer_stream(question: str, user_id: str, document_id: Optional[str] = None, hf_token: Optional[str] = None):
     from app.rag.agent import generate_answer_stream as _generate_answer_stream
 
-    return _generate_answer_stream(question=question, user_id=user_id, document_id=document_id)
+    return _generate_answer_stream(question=question, user_id=user_id, document_id=document_id, hf_token=hf_token)
 
 
 @router.post("/ask", response_model=ChatResponse)
@@ -151,6 +151,7 @@ def ask_question(
             question=payload.question,
             user_id=user.id,
             document_id=payload.document_id,
+            hf_token=user.hf_token,
         )
 
         # Save to chat history
@@ -240,6 +241,7 @@ def ask_question_stream(
                 question=payload.question,
                 user_id=user.id,
                 document_id=payload.document_id,
+                hf_token=user.hf_token,
             ):
                 yield chunk
 

--- a/backend/tests/test_chat.py
+++ b/backend/tests/test_chat.py
@@ -1,7 +1,7 @@
 def test_chat_ask_success(client, auth_headers, ready_document, monkeypatch):
     monkeypatch.setattr(
         "app.routes.chat.generate_answer",
-        lambda question, user_id, document_id=None: {
+        lambda question, user_id, document_id=None, **kwargs: {
             "answer": "Mocked answer",
             "sources": [
                 {
@@ -48,3 +48,34 @@ def test_chat_ask_document_not_ready(client, auth_headers, pending_document):
 
     assert response.status_code == 400
     assert "Document is still pending" in response.json()["detail"]
+
+
+def test_agent_dynamic_token(monkeypatch):
+    from app.rag.agent import generate_answer
+    import app.rag.agent
+
+    called_with_token = None
+
+    class MockInferenceClient:
+        def __init__(self, token=None, **kwargs):
+            nonlocal called_with_token
+            called_with_token = token
+
+        def chat_completion(self, *args, **kwargs):
+            class MockResponse:
+                choices = []
+            return MockResponse()
+
+    # Mock the InferenceClient in app.rag.agent
+    monkeypatch.setattr(app.rag.agent, "InferenceClient", MockInferenceClient)
+    # Mock retrieval to return empty chunks
+    monkeypatch.setattr("app.rag.agent.retrieve", lambda **kwargs: [])
+
+    # Test with custom token
+    generate_answer(question="hello?", user_id="some-user", hf_token="my-custom-hf-token")
+    assert called_with_token == "my-custom-hf-token"
+
+    # Test with None (should fallback to global token in config)
+    generate_answer(question="hello?", user_id="some-user", hf_token=None)
+    from app.config import get_settings
+    assert called_with_token == get_settings().HF_TOKEN


### PR DESCRIPTION
Fixes #179

### Description
Refactors the LLM agent to stop using a global singleton LLM client and instead instantiate the client dynamically per-request using the user's specific Hugging Face token.

### Changes
- Removed the global singleton \InferenceClient\ inside \ackend/app/rag/agent.py\.
- Updated \get_llm_client()\ to accept an optional \hf_token\ and return an instance of \InferenceClient\ configured with it, falling back to the default \settings.HF_TOKEN\ if not provided.
- Added \hf_token\ parameter to \generate_answer\ and \generate_answer_stream\ signatures and calls.
- Updated tracing decorators to accept variable keyword arguments (\**kwargs\) in their metadata factories, avoiding type crashes when new parameters like \hf_token\ are passed.
- Added a comprehensive unit test \	est_agent_dynamic_token\ to assert correct per-request initialization and fallback behaviors.