### PR TITLE
security: Encrypt Hugging Face tokens at rest in database

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -16,7 +16,7 @@ class EncryptedString(TypeDecorator):
     """SQLAlchemy TypeDecorator that encrypts strings before storing in database,
     and decrypts them when reading.
     """
-    impl = String
+    impl = Text
     cache_ok = False
 
     def process_bind_param(self, value, dialect):
@@ -55,7 +55,7 @@ class User(Base):
     is_admin = Column(Boolean, default=False)
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
     last_login = Column(DateTime, nullable=True, index=True)
-    hf_token = Column(EncryptedString(255), nullable=True)
+    hf_token = Column(EncryptedString, nullable=True)
 
     # Relationships
     documents = relationship("Document", back_populates="owner", cascade="all, delete-orphan")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -2,10 +2,43 @@
 SQLAlchemy ORM models for users, documents, and chat messages.
 """
 import uuid
+import base64
+import hashlib
 from datetime import datetime, timezone
+from cryptography.fernet import Fernet
 from sqlalchemy import Column, String, Integer, DateTime, ForeignKey, Text, Boolean
+from sqlalchemy.types import TypeDecorator
 from sqlalchemy.orm import relationship
 from app.database import Base
+
+
+class EncryptedString(TypeDecorator):
+    """SQLAlchemy TypeDecorator that encrypts strings before storing in database,
+    and decrypts them when reading.
+    """
+    impl = String
+    cache_ok = False
+
+    def process_bind_param(self, value, dialect):
+        if value is None:
+            return value
+        from app.config import get_settings
+        settings = get_settings()
+        key = base64.urlsafe_b64encode(hashlib.sha256(settings.SECRET_KEY.encode()).digest())
+        cipher = Fernet(key)
+        return cipher.encrypt(value.encode()).decode()
+
+    def process_result_value(self, value, dialect):
+        if value is None:
+            return value
+        from app.config import get_settings
+        settings = get_settings()
+        key = base64.urlsafe_b64encode(hashlib.sha256(settings.SECRET_KEY.encode()).digest())
+        cipher = Fernet(key)
+        try:
+            return cipher.decrypt(value.encode()).decode()
+        except Exception:
+            return value
 
 
 def generate_uuid():
@@ -22,7 +55,7 @@ class User(Base):
     is_admin = Column(Boolean, default=False)
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
     last_login = Column(DateTime, nullable=True, index=True)
-    hf_token = Column(String(255), nullable=True)
+    hf_token = Column(EncryptedString(255), nullable=True)
 
     # Relationships
     documents = relationship("Document", back_populates="owner", cascade="all, delete-orphan")

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -115,3 +115,10 @@ def test_hf_token_appears_in_user_response(client, auth_headers, user, db_sessio
     me_resp = client.get("/api/v1/auth/me", headers=auth_headers)
     assert me_resp.status_code == 200
     assert me_resp.json()["hf_token"] == "hf_persist_token"
+
+    # Verify encryption at rest in the database directly
+    from sqlalchemy import text
+    row = db_session.execute(text("SELECT hf_token FROM users WHERE id = :id"), {"id": user.id}).fetchone()
+    stored_token = row[0]
+    assert stored_token is not None
+    assert stored_token != "hf_persist_token"


### PR DESCRIPTION
Fixes #175

### Description
Implement secure encryption at rest for user Hugging Face tokens. Users' tokens are encrypted automatically when saving to the database and decrypted transparently when retrieved, ensuring API keys are never stored in plain text.

### Changes
- Introduced an \EncryptedString\ TypeDecorator in \ackend/app/models.py\ which transparently encrypts and decrypts strings using cryptography's \Fernet\ symmetric encryption.
- Dynamically derived the encryption key by hashing the application's \SECRET_KEY\, ensuring compatibility with any configuration environment.
- Configured \User.hf_token\ to use \EncryptedString\.
- Added an integration test assertion in \ackend/tests/test_auth.py\ that queries the database directly with raw SQL to verify that stored values are indeed encrypted and differ from plain text.
- Ensured graceful fallback: if decryption fails (e.g., if there are existing unencrypted tokens), it returns the plain text token without crashing.