### PR TITLE
feat(ui): Use react-pdf library for PDF split-screen viewer

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -83,7 +83,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -677,7 +676,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2112,7 +2110,6 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -2220,7 +2217,6 @@
       "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright": "1.60.0"
       },
@@ -2689,7 +2685,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2699,7 +2694,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2786,7 +2780,6 @@
       "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.0",
         "@typescript-eslint/types": "8.59.0",
@@ -3331,7 +3324,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3786,7 +3778,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4838,7 +4829,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5024,7 +5014,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5324,7 +5313,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -5684,7 +5672,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6149,7 +6136,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -6234,7 +6220,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "typescript": "^5 || ^6"
       },
@@ -9591,7 +9576,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9601,7 +9585,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10926,7 +10909,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11195,7 +11177,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11878,7 +11859,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useCallback } from "react";
 import dynamic from "next/dynamic";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/lib/auth";
+import { Loader2 } from "lucide-react";
 import {
   api,
   CONNECTION_ERROR_BANNER_MESSAGE,
@@ -13,8 +14,16 @@ import {
 import Header from "@/components/layout/Header";
 import DocumentSidebar from "@/components/document/DocumentSidebar";
 import ChatPanel from "@/components/chat/ChatPanel";
-import PDFViewer from "@/components/document/PDFViewer";
 import { Skeleton } from "@/components/ui/skeleton";
+
+const PDFViewer = dynamic(() => import("@/components/document/PDFViewer"), {
+  ssr: false,
+  loading: () => (
+    <div className="h-full flex items-center justify-center bg-background/50">
+      <Loader2 className="w-6 h-6 animate-spin text-primary" />
+    </div>
+  ),
+});
 
 export interface DocInfo {
   summary: string;

--- a/frontend/src/components/document/PDFViewer.tsx
+++ b/frontend/src/components/document/PDFViewer.tsx
@@ -5,6 +5,14 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { ChevronLeft, ChevronRight, ZoomIn, ZoomOut, Loader2 } from "lucide-react";
 import { API_BASE } from "@/lib/api";
+import { Document, Page, pdfjs } from "react-pdf";
+
+// Import styles for react-pdf layers
+import "react-pdf/dist/Page/AnnotationLayer.css";
+import "react-pdf/dist/Page/TextLayer.css";
+
+// Configure PDF.js worker using standard unpkg URL
+pdfjs.GlobalWorkerOptions.workerSrc = `//unpkg.com/pdfjs-dist@${pdfjs.version}/build/pdf.worker.min.mjs`;
 
 interface Props {
   documentId: string;
@@ -16,14 +24,16 @@ interface Props {
 export default function PDFViewer({ documentId, currentPage, onPageChange, totalPages }: Props) {
   const [scale, setScale] = useState(1.0);
   const [loading, setLoading] = useState(true);
-  // Local editable value — initialized from currentPage prop.
-  // The iframe key={documentId-currentPage} already forces remount on
-  // external page changes, so no useEffect sync is needed.
   const [pageInput, setPageInput] = useState(String(currentPage));
-  const pdfUrl = `${API_BASE}/api/v1/documents/${documentId}/pdf`;
 
-  // Append page fragment for native viewer navigation
-  const iframeSrc = `${pdfUrl}#page=${currentPage}`;
+  const pdfUrl = `${API_BASE}/api/v1/documents/${documentId}/pdf`;
+  const token = typeof window !== "undefined" ? localStorage.getItem("token") : null;
+
+  // Configure file object with Authorization headers
+  const fileConfig = {
+    url: pdfUrl,
+    httpHeaders: token ? { Authorization: `Bearer ${token}` } : undefined,
+  };
 
   const handlePageSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -31,11 +41,9 @@ export default function PDFViewer({ documentId, currentPage, onPageChange, total
     if (!isNaN(num) && num >= 1 && num <= totalPages) {
       onPageChange(num);
     } else {
-      // Reset to the current valid page without needing a useEffect
       setPageInput(String(currentPage));
     }
   };
-
 
   return (
     <div className="h-full flex flex-col bg-background">
@@ -46,7 +54,11 @@ export default function PDFViewer({ documentId, currentPage, onPageChange, total
             variant="ghost"
             size="icon"
             className="h-7 w-7"
-            onClick={() => onPageChange(Math.max(1, currentPage - 1))}
+            onClick={() => {
+              const newPage = Math.max(1, currentPage - 1);
+              onPageChange(newPage);
+              setPageInput(String(newPage));
+            }}
             disabled={currentPage <= 1}
           >
             <ChevronLeft className="w-4 h-4" />
@@ -68,7 +80,11 @@ export default function PDFViewer({ documentId, currentPage, onPageChange, total
             variant="ghost"
             size="icon"
             className="h-7 w-7"
-            onClick={() => onPageChange(Math.min(totalPages, currentPage + 1))}
+            onClick={() => {
+              const newPage = Math.min(totalPages, currentPage + 1);
+              onPageChange(newPage);
+              setPageInput(String(newPage));
+            }}
             disabled={currentPage >= totalPages}
           >
             <ChevronRight className="w-4 h-4" />
@@ -99,20 +115,33 @@ export default function PDFViewer({ documentId, currentPage, onPageChange, total
       </div>
 
       {/* ── PDF Render ──────────────────────────────── */}
-      <div className="flex-1 overflow-auto relative">
-        {loading && (
-          <div className="absolute inset-0 flex items-center justify-center bg-background/80 z-10">
-            <Loader2 className="w-6 h-6 animate-spin text-primary" />
-          </div>
-        )}
-        <iframe
-          key={`${documentId}-${currentPage}`}
-          src={iframeSrc}
-          className="w-full h-full border-0"
-          style={{ transform: `scale(${scale})`, transformOrigin: "top left", width: `${100/scale}%`, height: `${100/scale}%` }}
-          onLoad={() => setLoading(false)}
-          title="PDF Viewer"
-        />
+      <div className="flex-1 overflow-auto bg-muted/30 flex justify-center items-start p-4 relative">
+        <Document
+          file={fileConfig}
+          onLoadSuccess={() => setLoading(false)}
+          onLoadError={(err) => {
+            console.error("PDF load error:", err);
+            setLoading(false);
+          }}
+          loading={
+            <div className="absolute inset-0 flex items-center justify-center bg-background/80 z-10">
+              <Loader2 className="w-6 h-6 animate-spin text-primary" />
+            </div>
+          }
+          className="shadow-md border border-border bg-card max-w-full"
+        >
+          <Page
+            pageNumber={currentPage}
+            scale={scale}
+            renderAnnotationLayer={false}
+            renderTextLayer={true}
+            loading={
+              <div className="flex items-center justify-center p-8">
+                <Loader2 className="w-6 h-6 animate-spin text-primary" />
+              </div>
+            }
+          />
+        </Document>
       </div>
     </div>
   );

--- a/frontend/src/components/document/PDFViewer.tsx
+++ b/frontend/src/components/document/PDFViewer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { ChevronLeft, ChevronRight, ZoomIn, ZoomOut, Loader2, AlertCircle } from "lucide-react";
@@ -23,16 +23,18 @@ interface Props {
 
 export default function PDFViewer({ documentId, currentPage, onPageChange, totalPages }: Props) {
   const [scale, setScale] = useState(1.0);
-  const [loading, setLoading] = useState(true);
+  const [, setLoading] = useState(true);
   const [pageInput, setPageInput] = useState(String(currentPage));
+  const [prevCurrentPage, setPrevCurrentPage] = useState(currentPage);
+
+  // Sync page input state with current page prop updates during render phase
+  if (currentPage !== prevCurrentPage) {
+    setPrevCurrentPage(currentPage);
+    setPageInput(String(currentPage));
+  }
 
   const pdfUrl = `${API_BASE}/api/v1/documents/${documentId}/pdf`;
   const token = typeof window !== "undefined" ? localStorage.getItem("token") : null;
-
-  // Sync page input state with current page prop updates (e.g. when jumping via citations)
-  useEffect(() => {
-    setPageInput(String(currentPage));
-  }, [currentPage]);
 
   // Configure file object with Authorization headers
   const fileConfig = {

--- a/frontend/src/components/document/PDFViewer.tsx
+++ b/frontend/src/components/document/PDFViewer.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { ChevronLeft, ChevronRight, ZoomIn, ZoomOut, Loader2 } from "lucide-react";
+import { ChevronLeft, ChevronRight, ZoomIn, ZoomOut, Loader2, AlertCircle } from "lucide-react";
 import { API_BASE } from "@/lib/api";
 import { Document, Page, pdfjs } from "react-pdf";
 
@@ -28,6 +28,11 @@ export default function PDFViewer({ documentId, currentPage, onPageChange, total
 
   const pdfUrl = `${API_BASE}/api/v1/documents/${documentId}/pdf`;
   const token = typeof window !== "undefined" ? localStorage.getItem("token") : null;
+
+  // Sync page input state with current page prop updates (e.g. when jumping via citations)
+  useEffect(() => {
+    setPageInput(String(currentPage));
+  }, [currentPage]);
 
   // Configure file object with Authorization headers
   const fileConfig = {
@@ -115,7 +120,7 @@ export default function PDFViewer({ documentId, currentPage, onPageChange, total
       </div>
 
       {/* ── PDF Render ──────────────────────────────── */}
-      <div className="flex-1 overflow-auto bg-muted/30 flex justify-center items-start p-4 relative">
+      <div className="flex-1 overflow-auto bg-muted/30 flex justify-center items-start p-4 relative w-full">
         <Document
           file={fileConfig}
           onLoadSuccess={() => setLoading(false)}
@@ -126,6 +131,23 @@ export default function PDFViewer({ documentId, currentPage, onPageChange, total
           loading={
             <div className="absolute inset-0 flex items-center justify-center bg-background/80 z-10">
               <Loader2 className="w-6 h-6 animate-spin text-primary" />
+            </div>
+          }
+          error={
+            <div className="flex flex-col items-center justify-center p-8 text-center bg-card border border-destructive/20 rounded-lg max-w-md mx-auto my-12 shadow-sm gap-3">
+              <AlertCircle className="w-8 h-8 text-destructive animate-pulse" />
+              <div>
+                <p className="font-semibold text-sm text-foreground mb-1">Failed to load PDF</p>
+                <p className="text-xs text-muted-foreground leading-relaxed">
+                  We encountered an error loading this PDF document. Please verify the document is ready or try refreshing the page.
+                </p>
+              </div>
+            </div>
+          }
+          noData={
+            <div className="flex flex-col items-center justify-center p-8 text-center bg-card border border-border rounded-lg max-w-md mx-auto my-12 shadow-sm gap-2">
+              <p className="font-semibold text-sm text-foreground">No PDF document selected</p>
+              <p className="text-xs text-muted-foreground">Select or upload a document to view it here.</p>
             </div>
           }
           className="shadow-md border border-border bg-card max-w-full"


### PR DESCRIPTION
Fixes #120

### Description
Replaces the native browser \iframe\ rendering in \PDFViewer\ with the \eact-pdf\ library, fulfilling the requirement of using a library to render PDFs in split screen and solving browser-specific iframe limitations.

### Changes
- Replaced \iframe\ in \PDFViewer\ component with \eact-pdf\'s \Document\ and \Page\ rendering.
- Dynamically passed \Authorization: Bearer <token>\ in \httpHeaders\ configuration of \eact-pdf\ requests. This secures document routes by eliminating the need to expose API tokens via URL query parameters.
- Configured client-side only lazy loading with \ssr: false\ in \dashboard/page.tsx\ for the \PDFViewer\ component. This prevents \ReferenceError: DOMMatrix is not defined\ build errors during Next.js server-side page prerendering.
- Added dynamic page input synchronization.
- Verified Next.js production builds compile cleanly.