### PR TITLE
devops: add pre-commit hooks for black, flake8, and prettier (#58)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,55 @@
+repos:
+  # ── Python Formatting ─────────────────────────────────────
+  - repo: https://github.com/psf/black
+    rev: 24.10.0
+    hooks:
+      - id: black
+        language_version: python3
+        args: [--line-length=120]
+        files: ^backend/
+
+  # ── Python Linting ────────────────────────────────────────
+  - repo: https://github.com/PyCQA/flake8
+    rev: 7.1.1
+    hooks:
+      - id: flake8
+        args:
+          - --max-line-length=120
+          - --select=E9,F63,F7,F82,E501
+          - --count
+        files: ^backend/
+
+  # ── JavaScript / TypeScript / JSON / CSS / Markdown Formatting ──
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v4.0.0-alpha.8
+    hooks:
+      - id: prettier
+        types_or: [javascript, jsx, ts, tsx, json, css, markdown]
+        files: ^frontend/
+        exclude: ^frontend/(node_modules|.next|dist|build)/
+
+  # ── General Hygiene ───────────────────────────────────────
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
+      - id: end-of-file-fixer
+      - id: check-yaml
+        args: [--allow-multiple-documents]
+      - id: check-json
+        exclude: ^frontend/(node_modules|.next)/
+      - id: check-merge-conflict
+      - id: check-added-large-files
+        args: [--maxkb=1024]
+      - id: mixed-line-ending
+        args: [--fix=lf]
+        exclude: \.(bat|cmd|ps1)$
+
+  # ── Security ─────────────────────────────────────────────
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        args: [--baseline, .secrets.baseline]
+        exclude: \.env\.example$

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,36 @@ cp ../.env.example .env            # Fill in your own dev values
 uvicorn app.main:app --reload --port 8000
 ```
 
+### Pre-commit Hooks (Required)
+
+We use [`pre-commit`](https://pre-commit.com/) to enforce code style automatically before every commit. This prevents style-related CI failures.
+
+```bash
+# Install pre-commit (one-time setup)
+pip install pre-commit
+
+# Install the hooks into your local clone (one-time per checkout)
+pre-commit install
+
+# (Optional) Run against all files to verify setup
+pre-commit run --all-files
+```
+
+**What the hooks check:**
+
+| Hook | Tool | Scope |
+|------|------|-------|
+| Python formatting | `black` (line-length 120) | `backend/` |
+| Python linting | `flake8` (errors only) | `backend/` |
+| JS/TS/JSON/CSS/MD formatting | `prettier` | `frontend/` |
+| Trailing whitespace | `pre-commit-hooks` | All files |
+| YAML/JSON validity | `pre-commit-hooks` | All files |
+| Merge-conflict markers | `pre-commit-hooks` | All files |
+| Large file guard (>1 MB) | `pre-commit-hooks` | All files |
+| Secret detection | `detect-secrets` | All files |
+
+> ⚠️ If a hook modifies files, it will block your commit. Just `git add` the auto-fixed files and commit again.
+
 ### Frontend (Next.js)
 
 ```bash


### PR DESCRIPTION
## Description
Sets up pre-commit hooks to enforce consistent code formatting and catch common issues before they reach CI.

### Changes:
- **.pre-commit-config.yaml** — defines all hooks:
  - lack (v24.10.0) — Python auto-formatter for ackend/, line-length 120
  - lake8 (v7.1.1) — Python linter for ackend/, errors only (E9,F63,F7,F82,E501)
  - prettier (v4.0.0-alpha.8) — JS/TS/JSON/CSS/Markdown formatter for rontend/
  - 	railing-whitespace — removes trailing whitespace on all files
  - end-of-file-fixer — ensures files end with a newline
  - check-yaml — validates YAML syntax
  - check-json — validates JSON syntax
  - check-merge-conflict — catches accidental conflict markers
  - check-added-large-files — blocks files > 1 MB
  - mixed-line-ending — normalises to LF (except Windows scripts)
  - detect-secrets — detects secrets/credentials accidentally committed
- **CONTRIBUTING.md** — adds a **Pre-commit Hooks (Required)** section with a quick-start table explaining what each hook covers

## Related Issue
Closes #58

## Type of Change
- [x] ⚙️ CI / configuration
- [x] 📝 Documentation

## How to Test
`ash
pip install pre-commit
pre-commit install
pre-commit run --all-files
`
All hooks should run without errors (auto-fixes will show as modified files).

## Checklist
- [x] My code follows the project's existing style
- [x] I have tested my changes
- [x] I have linked the related issue above
- [x] My PR title follows Conventional Commits format