### PR TITLE
test: add comprehensive E2E tests with Playwright

### DIFF
--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -1,0 +1,39 @@
+# E2E Testing with Playwright 🎭
+
+This directory contains End-to-End (E2E) tests for the PDF Assistant RAG frontend.
+
+## 🧪 Test Coverage
+
+1.  **Authentication**: Login and Registration flows.
+2.  **Document Management**: PDF upload, processing state, and deletion.
+3.  **Chat**: Sending messages, receiving streaming responses with markdown support (tables, code blocks), and viewing sources.
+4.  **Visual Regression**: Snapshot testing for key pages (Login, Register, Dashboard).
+
+## 🚀 Running Tests
+
+### Prerequisites
+Ensure you have installed the dependencies:
+```bash
+cd frontend
+npm install
+npx playwright install chromium
+```
+
+### Run all tests
+```bash
+npm run test:e2e
+```
+
+### Run tests in UI mode
+```bash
+npm run test:e2e:ui
+```
+
+## 🛠️ Testing Strategy
+
+We use Playwright's `page.route` to mock the backend API. This allows us to test the frontend in isolation, ensuring fast and reliable tests that don't depend on a running database or heavy LLM models.
+
+### Key Patterns
+- **Global Auth**: Mapped via `localStorage` injection in `beforeEach` or `addInitScript`.
+- **Streaming**: Mocked using `text/event-stream` to verify the chat's real-time feel.
+- **Snapshots**: Used to catch unintended UI changes in critical views.

--- a/frontend/e2e/auth-and-chat.spec.ts
+++ b/frontend/e2e/auth-and-chat.spec.ts
@@ -79,17 +79,18 @@ test("creates an account from the signup form", async ({ page }) => {
   await expect(page.getByText("No documents yet")).toBeVisible();
 });
 
-test("uploads a document and chats with it", async ({ page }) => {
+test("uploads a PDF document and chats with it", async ({ page }) => {
   const documents: typeof uploadedDocument[] = [];
+  const pdfDoc = { ...uploadedDocument, original_name: "test.pdf" };
   const markdownAnswer = [
-    "A short summary.",
+    "A short summary of the PDF.",
     "",
     "| Field | Value |",
     "| --- | --- |",
-    "| Pages | 1 |",
+    "| Format | PDF |",
     "",
     "```ts",
-    "const answer = 42;",
+    "const isPdf = true;",
     "```",
   ].join("\n");
 
@@ -101,8 +102,8 @@ test("uploads a document and chats with it", async ({ page }) => {
   await mockDashboardApis(page, documents);
 
   await page.route("**/api/v1/documents/upload", async (route) => {
-    documents.push(uploadedDocument);
-    await route.fulfill({ status: 202, json: uploadedDocument });
+    documents.push(pdfDoc);
+    await route.fulfill({ status: 202, json: pdfDoc });
   });
 
   await page.route("**/api/v1/chat/history/doc-1", async (route) => {
@@ -122,23 +123,77 @@ test("uploads a document and chats with it", async ({ page }) => {
   });
 
   await page.goto("/dashboard");
+  
+  // Upload as a PDF
   await page.locator('input[type="file"]').setInputFiles({
-    name: "notes.txt",
-    mimeType: "text/plain",
-    buffer: Buffer.from("hello world"),
+    name: "test.pdf",
+    mimeType: "application/pdf",
+    buffer: Buffer.from("%PDF-1.4\n%..."),
   });
 
-  const documentButton = page.getByRole("button", { name: /notes\.txt/ });
-  await expect(documentButton).toBeVisible();
-  await documentButton.click();
+  await expect(page.getByText("test.pdf")).toBeVisible();
+  await page.getByText("test.pdf").click();
   await expect(page.getByText("Ask about your document")).toBeVisible();
 
-  await page.locator("#chat-input").fill("Summarize this document");
+  await page.locator("#chat-input").fill("Summarize this PDF");
   await page.locator("#send-btn").click();
 
-  await expect(page.getByText("Summarize this document")).toBeVisible();
-  await expect(page.getByText("A short summary.")).toBeVisible();
+  await expect(page.getByText("Summarize this PDF")).toBeVisible();
+  await expect(page.getByText("A short summary of the PDF.")).toBeVisible();
   await expect(page.getByRole("columnheader", { name: "Field" })).toBeVisible();
-  await expect(page.getByRole("cell", { name: "Pages" })).toBeVisible();
-  await expect(page.getByText("const answer = 42;")).toBeVisible();
+  await expect(page.getByRole("cell", { name: "Format" })).toBeVisible();
+  await expect(page.getByText("const isPdf = true;")).toBeVisible();
+});
+
+test("deletes a document successfully", async ({ page }) => {
+  const pdfDoc = { ...uploadedDocument, original_name: "test.pdf" };
+  
+  await page.addInitScript(() => {
+    localStorage.setItem("token", "access-token");
+    localStorage.setItem("refresh_token", "refresh-token");
+  });
+
+  await mockDashboardApis(page, [pdfDoc]);
+
+  await page.route("**/api/v1/documents/doc-1", async (route) => {
+    expect(route.request().method()).toBe("DELETE");
+    await route.fulfill({ status: 204 });
+  });
+
+  // Mock empty list after deletion
+  await page.route("**/api/v1/documents/", async (route) => {
+    if (route.request().method() === "GET") {
+        await route.fulfill({ json: { items: [], total: 0, page: 1, pages: 0 } });
+    }
+  }, { times: 1 });
+
+  await page.goto("/dashboard");
+  await expect(page.getByText("test.pdf")).toBeVisible();
+  
+  // Delete the document
+  await page.getByText("test.pdf").hover();
+  // Find the button with Trash2 icon
+  await page.locator('button:has(svg.lucide-trash2)').click();
+  
+  // Handle confirm dialog
+  page.on('dialog', dialog => dialog.accept());
+
+  await expect(page.getByText("No documents yet")).toBeVisible();
+});
+
+test("logs out successfully", async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem("token", "access-token");
+    localStorage.setItem("refresh_token", "refresh-token");
+  });
+
+  await mockDashboardApis(page);
+
+  await page.goto("/dashboard");
+  await page.getByRole("button", { name: "tester" }).click();
+  await page.getByRole("menuitem", { name: "Log out" }).click();
+
+  await expect(page).toHaveURL(/\/login$/);
+  const token = await page.evaluate(() => localStorage.getItem("token"));
+  expect(token).toBeNull();
 });

--- a/frontend/e2e/auth-and-chat.spec.ts
+++ b/frontend/e2e/auth-and-chat.spec.ts
@@ -170,13 +170,13 @@ test("deletes a document successfully", async ({ page }) => {
   await page.goto("/dashboard");
   await expect(page.getByText("test.pdf")).toBeVisible();
   
+  // Handle confirm dialog (must be registered BEFORE click)
+  page.on('dialog', dialog => dialog.accept());
+
   // Delete the document
   await page.getByText("test.pdf").hover();
   // Find the button with Trash2 icon
   await page.locator('button:has(svg.lucide-trash2)').click();
-  
-  // Handle confirm dialog
-  page.on('dialog', dialog => dialog.accept());
 
   await expect(page.getByText("No documents yet")).toBeVisible();
 });
@@ -191,7 +191,7 @@ test("logs out successfully", async ({ page }) => {
 
   await page.goto("/dashboard");
   await page.getByRole("button", { name: "tester" }).click();
-  await page.getByRole("menuitem", { name: "Log out" }).click();
+  await page.getByRole("menuitem", { name: "Sign out" }).click();
 
   await expect(page).toHaveURL(/\/login$/);
   const token = await page.evaluate(() => localStorage.getItem("token"));

--- a/frontend/e2e/auth-and-chat.spec.ts
+++ b/frontend/e2e/auth-and-chat.spec.ts
@@ -131,8 +131,9 @@ test("uploads a PDF document and chats with it", async ({ page }) => {
     buffer: Buffer.from("%PDF-1.4\n%..."),
   });
 
-  await expect(page.getByText("test.pdf")).toBeVisible();
-  await page.getByText("test.pdf").click();
+  const documentButton = page.getByRole("button", { name: /test\.pdf/ });
+  await expect(documentButton).toBeVisible();
+  await documentButton.click();
   await expect(page.getByText("Ask about your document")).toBeVisible();
 
   await page.locator("#chat-input").fill("Summarize this PDF");
@@ -146,37 +147,32 @@ test("uploads a PDF document and chats with it", async ({ page }) => {
 });
 
 test("deletes a document successfully", async ({ page }) => {
-  const pdfDoc = { ...uploadedDocument, original_name: "test.pdf" };
+  const documents = [{ ...uploadedDocument, original_name: "test.pdf" }];
   
   await page.addInitScript(() => {
     localStorage.setItem("token", "access-token");
     localStorage.setItem("refresh_token", "refresh-token");
   });
 
-  await mockDashboardApis(page, [pdfDoc]);
+  await mockDashboardApis(page, documents);
 
   await page.route("**/api/v1/documents/doc-1", async (route) => {
     expect(route.request().method()).toBe("DELETE");
-    await route.fulfill({ status: 204 });
+    documents.pop();
+    await route.fulfill({ status: 200, json: { message: "deleted" } });
   });
 
-  // Mock empty list after deletion
-  await page.route("**/api/v1/documents/", async (route) => {
-    if (route.request().method() === "GET") {
-        await route.fulfill({ json: { items: [], total: 0, page: 1, pages: 0 } });
-    }
-  }, { times: 1 });
-
   await page.goto("/dashboard");
-  await expect(page.getByText("test.pdf")).toBeVisible();
+  const documentButton = page.getByRole("button", { name: /test\.pdf/ });
+  await expect(documentButton).toBeVisible();
   
   // Handle confirm dialog (must be registered BEFORE click)
   page.on('dialog', dialog => dialog.accept());
 
   // Delete the document
-  await page.getByText("test.pdf").hover();
+  await documentButton.hover();
   // Find the button with Trash2 icon
-  await page.locator('button:has(svg.lucide-trash2)').click();
+  await page.locator('button.shrink-0:has(svg.lucide-trash2)').click();
 
   await expect(page.getByText("No documents yet")).toBeVisible();
 });


### PR DESCRIPTION
## 📋 PR Checklist

> Thank you for contributing to **PDF-Assistant-RAG**! 🎉  
> Please fill out this template before submitting. PRs without it filled in will be closed.

---

### 🔗 Related Issue
Closes #53

---

### 📝 What does this PR do?
Adds comprehensive E2E tests using Playwright to verify essential frontend flows:
- User registration and login.
- PDF document upload and processing state.
- Real-time streaming chat with markdown support (tables, code blocks).
- Document deletion and chat history clearing (using dynamic route mocks to avoid delete race conditions).
- User logout and session management.
- Visual regression snapshots for critical pages (bypassed on CI).

---

### 🗂️ Type of Change
- [x] 🧪 Tests

---

### 🧪 How was this tested?
- [x] Ran the frontend locally (`npm run dev` inside `frontend/`)
- [x] Added / updated tests

---

### 📸 Screenshots (if UI change)
<!-- Drag and drop screenshots here -->

---

### ⚠️ Anything to flag for reviewers?
Fixed the Playwright E2E race condition where `{ times: 1 }` route mocks were consumed on initial page load instead of post-deletion. Replaced with dynamic route checking/mutation.

---

### ✅ Self-Review Checklist
- [x] My branch is based on **`dev`**, not `main`
- [x] I have not added any secrets / API keys
- [x] I have not modified `main` branch or any HuggingFace deployment config
- [x] My code follows the existing style (no unnecessary formatting changes)
- [x] I have updated relevant docs / comments if needed
