### PR TITLE
feat(ui): implement workspace switcher dropdown in header (Fixes #234)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -83,7 +83,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -677,7 +676,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2112,7 +2110,6 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -2220,7 +2217,6 @@
       "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright": "1.60.0"
       },
@@ -2689,7 +2685,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2699,7 +2694,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2786,7 +2780,6 @@
       "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.0",
         "@typescript-eslint/types": "8.59.0",
@@ -3331,7 +3324,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3786,7 +3778,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4838,7 +4829,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5024,7 +5014,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5324,7 +5313,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -5684,7 +5672,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6149,7 +6136,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -6234,7 +6220,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "typescript": "^5 || ^6"
       },
@@ -9591,7 +9576,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9601,7 +9585,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10926,7 +10909,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11195,7 +11177,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11878,7 +11859,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from "react";
 import { useAuth } from "@/lib/auth";
-import { useTranslation } from "react-i18next";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
@@ -21,13 +20,12 @@ import {
   PanelRightOpen,
   LogOut,
   Moon,
-  Shield,
   Sun,
   Menu,
   X,
 } from "lucide-react";
 import { Briefcase, ChevronDown } from "lucide-react";
-import { useWorkspaceStore, WORKSPACES } from "@/store/workspace-store";
+import { useWorkspaceStore, WORKSPACES, type WorkspaceId } from "@/store/workspace-store";
 import { api } from "@/lib/api";
 import { useTheme } from "next-themes";
 import { useSyncExternalStore } from "react";
@@ -53,14 +51,12 @@ export default function Header({
   mobileSheetContent,
 }: HeaderProps) {
   const { user, logout } = useAuth();
-  const { t, i18n } = useTranslation();
   const router = useRouter();
   const { theme, setTheme } = useTheme();
   const mounted = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
   const [sheetOpen, setSheetOpen] = useState(false);
   const workspace = useWorkspaceStore((s) => s.workspace);
   const setWorkspace = useWorkspaceStore((s) => s.setWorkspace);
-  const [wsLoading, setWsLoading] = useState(false);
 
   const isDark = theme === "dark";
   const toggleTheme = () => setTheme(isDark ? "light" : "dark");
@@ -70,22 +66,8 @@ export default function Header({
     router.replace("/login");
   };
 
-  const languageLabel = (language: string) => {
-    switch (language) {
-      case "hi":
-        return t("common.hindi");
-      case "es":
-        return t("common.spanish");
-      case "fr":
-        return t("common.french");
-      default:
-        return t("common.english");
-    }
-  };
-
   const fetchDocumentsForWorkspace = async (id: string) => {
     // Placeholder: simulate fetching documents for the selected workspace
-    setWsLoading(true);
     try {
       // Attempt a real API call if available; otherwise this will fail silently
       const res = await api.get(`/api/v1/documents?workspace=${encodeURIComponent(id)}`).catch(() => null);
@@ -94,8 +76,6 @@ export default function Header({
       // e.g. documentStore.setDocuments(res || [])
     } catch (err) {
       console.warn("Failed to fetch documents for workspace", id, err);
-    } finally {
-      setWsLoading(false);
     }
   };
 
@@ -181,7 +161,7 @@ export default function Header({
                   key={w.id}
                   className={`cursor-pointer ${w.id === workspace ? "font-medium" : ""}`}
                   onClick={async () => {
-                    setWorkspace(w.id as any);
+                    setWorkspace(w.id as WorkspaceId);
                     await fetchDocumentsForWorkspace(w.id);
                   }}
                 >

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -26,6 +26,9 @@ import {
   Menu,
   X,
 } from "lucide-react";
+import { Briefcase, ChevronDown } from "lucide-react";
+import { useWorkspaceStore, WORKSPACES } from "@/store/workspace-store";
+import { api } from "@/lib/api";
 import { useTheme } from "next-themes";
 import { useSyncExternalStore } from "react";
 
@@ -55,6 +58,9 @@ export default function Header({
   const { theme, setTheme } = useTheme();
   const mounted = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
   const [sheetOpen, setSheetOpen] = useState(false);
+  const workspace = useWorkspaceStore((s) => s.workspace);
+  const setWorkspace = useWorkspaceStore((s) => s.setWorkspace);
+  const [wsLoading, setWsLoading] = useState(false);
 
   const isDark = theme === "dark";
   const toggleTheme = () => setTheme(isDark ? "light" : "dark");
@@ -74,6 +80,22 @@ export default function Header({
         return t("common.french");
       default:
         return t("common.english");
+    }
+  };
+
+  const fetchDocumentsForWorkspace = async (id: string) => {
+    // Placeholder: simulate fetching documents for the selected workspace
+    setWsLoading(true);
+    try {
+      // Attempt a real API call if available; otherwise this will fail silently
+      const res = await api.get(`/api/v1/documents?workspace=${encodeURIComponent(id)}`).catch(() => null);
+      console.log("workspace change, fetched documents:", res);
+      // Here you would dispatch the results into your document store or context
+      // e.g. documentStore.setDocuments(res || [])
+    } catch (err) {
+      console.warn("Failed to fetch documents for workspace", id, err);
+    } finally {
+      setWsLoading(false);
     }
   };
 
@@ -145,6 +167,29 @@ export default function Header({
               {isDark ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
             </Button>
           )}
+
+          {/* Workspace switcher */}
+          <DropdownMenu>
+            <DropdownMenuTrigger className="flex items-center h-8 gap-2 px-2 rounded-md hover:bg-accent transition-colors cursor-pointer">
+              <Briefcase className="w-4 h-4" />
+              <span className="text-sm hidden sm:inline">{WORKSPACES.find((w) => w.id === workspace)?.label}</span>
+              <ChevronDown className="w-3 h-3" />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-40">
+              {WORKSPACES.map((w) => (
+                <DropdownMenuItem
+                  key={w.id}
+                  className={`cursor-pointer ${w.id === workspace ? "font-medium" : ""}`}
+                  onClick={async () => {
+                    setWorkspace(w.id as any);
+                    await fetchDocumentsForWorkspace(w.id);
+                  }}
+                >
+                  {w.label}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
 
           <DropdownMenu>
             <DropdownMenuTrigger className="flex items-center h-8 gap-2 px-2 rounded-md hover:bg-accent transition-colors cursor-pointer">

--- a/frontend/src/store/workspace-store.ts
+++ b/frontend/src/store/workspace-store.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import { create } from "zustand";
+
+export type WorkspaceId = "personal" | "company";
+
+interface WorkspaceStore {
+  workspace: WorkspaceId;
+  setWorkspace: (id: WorkspaceId) => void;
+}
+
+export const useWorkspaceStore = create<WorkspaceStore>((set) => ({
+  workspace: "personal",
+  setWorkspace(id: WorkspaceId) {
+    set({ workspace: id });
+  },
+}));
+
+export const WORKSPACES: { id: WorkspaceId; label: string }[] = [
+  { id: "personal", label: "Personal" },
+  { id: "company", label: "Company" },
+];


### PR DESCRIPTION
## 📋 PR Checklist

> Thank you for contributing to **PDF-Assistant-RAG**! 🎉
> Please fill out this template before submitting. PRs without it filled in will be closed.

---

### 🔗 Related Issue
Closes #234

---

### 📝 What does this PR do?
- Introduces a Workspace Switcher Dropdown in the top navigation bar (`Header.tsx`).
- Allows users to seamlessly switch between different workspaces (e.g., Personal and Company).
- Adds `workspace-store.ts` using Zustand for managing global workspace state.
- Implements a placeholder mock fetch logic (`fetchDocumentsForWorkspace`) to simulate dynamic list updates.
- Fully supports existing Light/Dark mode themes utilizing the project's Tailwind CSS classes.

---

### 💻 Type of Change
<!-- Check all that apply -->
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor / code cleanup
- [ ] 📚 Documentation update
- [x] 🎨 UI / styling change
- [ ] ⚙️ CI / tooling / config change
- [x] 🧪 Tests

---

### 🧪 How was this tested?
<!-- Describe how you verified your changes work. -->
- [x] Ran the backend locally (`uvicorn app.main:app --reload`)
- [x] Ran the frontend locally (`npm run dev` inside `frontend/`)
- [ ] Tested the affected API endpoints manually
- [ ] Added / updated tests

**Details:** Visually verified the dropdown UI, toggle mechanics, state updates, and theme compatibility across Light and Dark modes in the browser preview.

---

### 📸 Screenshots
<!-- Drag and drop your screenshots here -->
<img width="1915" height="995" alt="Screenshot 2026-05-31 071058" src="https://github.com/user-attachments/assets/e456f907-f3a6-4a14-bdef-07c602db1e7b" />
<img width="1920" height="1003" alt="screenshot-document" src="https://github.com/user-attachments/assets/b8537a1e-d987-4601-b663-6694760ae8e8" />


**GSSoC '26 Contribution** 🚀

