### PR TITLE
feat(ui): build google drive folder selector tree-view (Fixes #230)

### DIFF
--- a/frontend/src/app/drive/page.tsx
+++ b/frontend/src/app/drive/page.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import DriveFolderSelector from "@/components/DriveFolderSelector";
+
+export default function DrivePage() {
+  return (
+    <main className="min-h-screen bg-background px-4 py-10 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-5xl space-y-6">
+        <section className="rounded-3xl border border-border/70 bg-card/80 p-6 shadow-sm backdrop-blur-xl">
+          <div className="mb-2 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <p className="text-sm uppercase tracking-[0.2em] text-muted-foreground">Drive connector demo</p>
+              <h1 className="text-3xl font-semibold">Google Drive Folder Selector</h1>
+            </div>
+            <p className="max-w-xl text-sm leading-6 text-muted-foreground">
+              Browse a mocked Google Drive folder tree, expand nested folders, and select one target folder to integrate with uploads or document imports.
+            </p>
+          </div>
+        </section>
+
+        <DriveFolderSelector />
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/components/DriveFolderSelector.tsx
+++ b/frontend/src/components/DriveFolderSelector.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { ChevronDown, ChevronRight, CheckCircle, Folder } from "lucide-react";
+import { getDriveFolders, type DriveFolder } from "@/services/drive-api";
+import { Button } from "@/components/ui/button";
+
+interface DriveFolderSelectorProps {
+  onSelect?: (folder: DriveFolder) => void;
+}
+
+function FolderItem({
+  folder,
+  depth,
+  expandedIds,
+  onToggle,
+  selectedId,
+  onSelect,
+}: {
+  folder: DriveFolder;
+  depth: number;
+  expandedIds: Record<string, boolean>;
+  onToggle: (id: string) => void;
+  selectedId: string | null;
+  onSelect: (folder: DriveFolder) => void;
+}) {
+  const hasChildren = Array.isArray(folder.children) && folder.children.length > 0;
+  const isExpanded = expandedIds[folder.id] === true;
+  const isSelected = folder.id === selectedId;
+
+  return (
+    <div>
+      <div
+        className={`flex items-center gap-2 rounded-xl px-3 py-2 transition-colors ${
+          isSelected ? "bg-primary/10 text-primary" : "hover:bg-muted"
+        }`}
+        style={{ paddingLeft: `${depth * 1.5}rem` }}
+      >
+        {hasChildren ? (
+          <button
+            type="button"
+            className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/70"
+            onClick={() => onToggle(folder.id)}
+            aria-label={isExpanded ? "Collapse folder" : "Expand folder"}
+          >
+            {isExpanded ? (
+              <ChevronDown className="h-4 w-4" />
+            ) : (
+              <ChevronRight className="h-4 w-4" />
+            )}
+          </button>
+        ) : (
+          <div className="h-8 w-8 flex items-center justify-center text-muted-foreground">
+            <span className="h-4 w-4" />
+          </div>
+        )}
+
+        <button
+          type="button"
+          className="flex min-w-0 flex-1 items-center gap-2 text-left text-sm font-medium leading-tight text-foreground"
+          onClick={() => onSelect(folder)}
+        >
+          <Folder className="h-4 w-4 text-primary" />
+          <span className="truncate">{folder.name}</span>
+        </button>
+
+        {isSelected && <CheckCircle className="h-4 w-4 text-emerald-500" />}
+      </div>
+
+      {hasChildren && isExpanded && (
+        <div className="border-l border-border/50">
+          {folder.children?.map((child) => (
+            <FolderItem
+              key={child.id}
+              folder={child}
+              depth={depth + 1}
+              expandedIds={expandedIds}
+              onToggle={onToggle}
+              selectedId={selectedId}
+              onSelect={onSelect}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function DriveFolderSelector({ onSelect }: DriveFolderSelectorProps) {
+  const [folders, setFolders] = useState<DriveFolder[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [expandedIds, setExpandedIds] = useState<Record<string, boolean>>({});
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+
+    void getDriveFolders().then((data) => {
+      if (!active) return;
+      setFolders(data);
+      setLoading(false);
+    });
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const selectedFolder = useMemo(
+    () => folders.flatMap((folder) => collectFolders(folder)).find((folder) => folder.id === selectedId) ?? null,
+    [folders, selectedId]
+  );
+
+  const handleToggle = (id: string) => {
+    setExpandedIds((current) => ({
+      ...current,
+      [id]: !current[id],
+    }));
+  };
+
+  const handleSelect = (folder: DriveFolder) => {
+    setSelectedId(folder.id);
+    onSelect?.(folder);
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-3xl border border-border/70 bg-card/80 p-4 shadow-sm backdrop-blur-xl">
+        <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="text-sm uppercase tracking-[0.2em] text-muted-foreground">Google Drive</p>
+            <h2 className="text-xl font-semibold">Select a folder</h2>
+          </div>
+          <div className="text-sm text-muted-foreground">
+            Pick exactly one folder from the tree.
+          </div>
+        </div>
+
+        {loading ? (
+          <div className="space-y-2">
+            {[1, 2, 3].map((item) => (
+              <div key={item} className="h-11 rounded-lg bg-muted/50 animate-pulse" />
+            ))}
+          </div>
+        ) : (
+          <div className="space-y-1">
+            {folders.map((folder) => (
+              <FolderItem
+                key={folder.id}
+                folder={folder}
+                depth={0}
+                expandedIds={expandedIds}
+                onToggle={handleToggle}
+                selectedId={selectedId}
+                onSelect={handleSelect}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="rounded-3xl border border-border/70 bg-card/80 p-4 text-sm text-muted-foreground">
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <span className="font-semibold text-foreground">Selected folder</span>
+          <span className="rounded-full bg-muted px-3 py-1 text-xs uppercase tracking-[0.18em] text-muted-foreground">
+            {selectedFolder ? "Ready" : "None"}
+          </span>
+        </div>
+
+        {selectedFolder ? (
+          <div className="space-y-1 rounded-2xl border border-border/50 bg-background/80 p-4">
+            <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+              <Folder className="h-4 w-4 text-primary" />
+              <span>{selectedFolder.name}</span>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Folder ID: {selectedFolder.id}
+            </p>
+          </div>
+        ) : (
+          <p>Please select a folder to continue.</p>
+        )}
+      </div>
+
+      <div className="flex justify-end">
+        <Button
+          type="button"
+          variant="secondary"
+          onClick={() => void (selectedFolder && window.alert(`Selected folder: ${selectedFolder.name}`))}
+          disabled={!selectedFolder}
+        >
+          Confirm selection
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function collectFolders(folder: DriveFolder): DriveFolder[] {
+  return [folder, ...(folder.children ?? []).flatMap(collectFolders)];
+}

--- a/frontend/src/services/drive-api.ts
+++ b/frontend/src/services/drive-api.ts
@@ -1,0 +1,52 @@
+export interface DriveFolder {
+  id: string
+  name: string
+  children?: DriveFolder[]
+}
+
+const dummyFolders: DriveFolder[] = [
+  {
+    id: "root",
+    name: "My Drive",
+    children: [
+      {
+        id: "finance",
+        name: "Finance",
+        children: [
+          { id: "q1-reports", name: "Q1 Reports" },
+          { id: "q2-reports", name: "Q2 Reports" },
+          {
+            id: "budgets",
+            name: "Budgets",
+            children: [
+              { id: "team-budgets", name: "Team Budgets" },
+              { id: "project-budgets", name: "Project Budgets" },
+            ],
+          },
+        ],
+      },
+      {
+        id: "marketing",
+        name: "Marketing",
+        children: [
+          { id: "campaign-assets", name: "Campaign Assets" },
+          { id: "brand-guidelines", name: "Brand Guidelines" },
+        ],
+      },
+      {
+        id: "personal",
+        name: "Personal",
+        children: [
+          { id: "receipts", name: "Receipts" },
+          { id: "travel", name: "Travel" },
+        ],
+      },
+    ],
+  },
+]
+
+export async function getDriveFolders(): Promise<DriveFolder[]> {
+  return new Promise((resolve) => {
+    window.setTimeout(() => resolve(dummyFolders), 300)
+  })
+}


### PR DESCRIPTION

## 📋 PR Checklist

> Thank you for contributing to **PDF-Assistant-RAG**! 🎉

---

### 🔗 Related Issue
Closes #230

---

### 📝 What does this PR do?
- **Mock Drive API:** Created a mock service (`frontend/src/services/drive-api.ts`) to return dummy nested folder structures, simulating the Google Drive API.
- **Tree-View Component:** Built a recursive `DriveFolderSelector` component that allows users to expand/collapse nested folder trees and select a specific directory.
- **Demo Route:** Mounted the component on `/drive` for easy testing and visualization.
- **Strict Typing:** Ensured zero `any` types and fully strict TypeScript interfaces. 

---

### 💻 Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature (UI)
- [ ] ♻️ Refactor / code cleanup
- [x] 🧪 Tests / Mock Services

---

### 📸 Screenshots
<img width="1349" height="998" alt="Screenshot 2026-05-31 154424" src="https://github.com/user-attachments/assets/65db7343-9dc8-4868-a1df-88a4de7dc0e7" />



**GSSoC '26 Contribution** 🚀