### PR TITLE
feat(backend): Extract Bounding Boxes during PDF parsing

### DIFF
--- a/backend/app/rag/chunker.py
+++ b/backend/app/rag/chunker.py
@@ -122,11 +122,19 @@ def extract_pdf_with_tables(filepath: str) -> List[Dict[str, Any]]:
             for table_index, table in enumerate(tables):
                 table_text = _table_to_markdown(table.extract() or [])
                 if table_text.strip():
+                    # Normalize table bbox: [x0/W, y0/H, x1/W, y1/H]
+                    W, H = float(page.width), float(page.height)
+                    normalized_bbox = [
+                        round(float(table.bbox[0]) / W, 4),
+                        round(float(table.bbox[1]) / H, 4),
+                        round(float(table.bbox[2]) / W, 4),
+                        round(float(table.bbox[3]) / H, 4),
+                    ]
                     pages.append({
                         "text": table_text,
                         "page": page_num,
                         "chunk_type": "table",
-                        "bbox": json.dumps([round(float(value), 2) for value in table.bbox]),
+                        "bbox": json.dumps(normalized_bbox),
                         "table_index": table_index,
                     })
 
@@ -210,46 +218,85 @@ def chunk_document(filepath: str) -> List[Dict[str, Any]]:
 
     all_chunks = []
     chunk_index = 0
+    pdf_doc = None
 
-    for page_data in pages:
-        text = page_data["text"]
-        page_num = page_data["page"]
-        chunk_type = page_data.get("chunk_type", "text")
+    if ext == "pdf":
+        try:
+            pdf_doc = fitz.open(filepath)
+        except Exception as e:
+            import logging
+            logger = logging.getLogger(__name__)
+            logger.warning(f"Could not open PDF with fitz for bbox extraction: {e}")
 
-        if chunk_type == "table":
-            all_chunks.append({
-                "text": text.strip(),
-                "page": page_num,
-                "chunk_index": chunk_index,
-                "chunk_type": "table",
-                "bbox": page_data.get("bbox", ""),
-                "table_index": page_data.get("table_index", 0),
-            })
-            chunk_index += 1
-            continue
+    try:
+        for page_data in pages:
+            text = page_data["text"]
+            page_num = page_data["page"]
+            chunk_type = page_data.get("chunk_type", "text")
 
-        # Split this page's text
-        splits = splitter.split_text(text)
-
-        for split_text in splits:
-            if split_text.strip():
+            if chunk_type == "table":
                 all_chunks.append({
-                    "text": split_text.strip(),
+                    "text": text.strip(),
                     "page": page_num,
                     "chunk_index": chunk_index,
-                    "chunk_type": chunk_type,
+                    "chunk_type": "table",
+                    "bbox": page_data.get("bbox", ""),
+                    "table_index": page_data.get("table_index", 0),
                 })
                 chunk_index += 1
+                continue
 
-        # Attach any images that belong to this page after text chunks for the page
-        for img in [i for i in images if i["page"] == page_num]:
-            all_chunks.append({
-                "text": "",
-                "page": page_num,
-                "chunk_index": chunk_index,
-                "image_bytes": img["image_bytes"],
-            })
-            chunk_index += 1
+            # Split this page's text
+            splits = splitter.split_text(text)
+
+            for split_text in splits:
+                if split_text.strip():
+                    chunk = {
+                        "text": split_text.strip(),
+                        "page": page_num,
+                        "chunk_index": chunk_index,
+                        "chunk_type": chunk_type,
+                    }
+
+                    # Extract bbox for PDF text chunks
+                    if pdf_doc and page_num <= len(pdf_doc):
+                        try:
+                            page_obj = pdf_doc[page_num - 1]
+                            # Use search_for to find the text on the page
+                            rects = page_obj.search_for(split_text.strip())
+                            if rects:
+                                W, H = float(page_obj.rect.width), float(page_obj.rect.height)
+                                # Rects can span multiple lines, we store them as a list of normalized bboxes
+                                norm_rects = [
+                                    [
+                                        round(r.x0 / W, 4),
+                                        round(r.y0 / H, 4),
+                                        round(r.x1 / W, 4),
+                                        round(r.y1 / H, 4)
+                                    ]
+                                    for r in rects
+                                ]
+                                chunk["bbox"] = json.dumps(norm_rects)
+                        except Exception as e:
+                            import logging
+                            logger = logging.getLogger(__name__)
+                            logger.warning(f"Bbox extraction error on page {page_num}: {e}")
+
+                    all_chunks.append(chunk)
+                    chunk_index += 1
+
+            # Attach any images that belong to this page after text chunks for the page
+            for img in [i for i in images if i["page"] == page_num]:
+                all_chunks.append({
+                    "text": "",
+                    "page": page_num,
+                    "chunk_index": chunk_index,
+                    "image_bytes": img["image_bytes"],
+                })
+                chunk_index += 1
+    finally:
+        if pdf_doc:
+            pdf_doc.close()
 
     return all_chunks
 

--- a/backend/tests/test_chunker.py
+++ b/backend/tests/test_chunker.py
@@ -49,17 +49,20 @@ def test_pdf_table_detection_separates_table_from_paragraph(monkeypatch):
             return [["Name", "Amount"], ["Alpha", "$10"]]
 
     class FakePage:
+        width = 400
+        height = 200
+
         def find_tables(self):
             return [FakeTable()]
 
         def extract_words(self):
             return [
-                {"text": "Intro", "x0": 40, "x1": 70, "top": 20, "bottom": 30},
-                {"text": "paragraph", "x0": 75, "x1": 140, "top": 20, "bottom": 30},
-                {"text": "Name", "x0": 45, "x1": 80, "top": 100, "bottom": 110},
+                {"text": "Intro", "x0": 40,  "x1": 70, "top": 20, "bottom": 30},
+                {"text": "paragraph", "x0":  75, "x1": 140, "top": 20, "bottom": 30},
+                {"text": "Name", "x0": 45,  "x1": 80, "top": 100, "bottom": 110},
                 {"text": "Amount", "x0": 160, "x1": 220, "top": 100, "bottom": 110},
-                {"text": "Alpha", "x0": 45, "x1": 85, "top": 125, "bottom": 135},
-                {"text": "$10", "x0": 160, "x1": 185, "top": 125, "bottom": 135},
+                {"text": "Alpha", "x0": 45,  "x1": 85, "top": 125, "bottom": 135},
+                {"text": "$10", "x0": 160,  "x1": 185, "top": 125, "bottom": 135},
             ]
 
     class FakePdf:
@@ -82,6 +85,6 @@ def test_pdf_table_detection_separates_table_from_paragraph(monkeypatch):
     assert chunks[0]["text"] == "Intro paragraph"
     assert "Name" not in chunks[0]["text"]
     assert chunks[1]["chunk_type"] == "table"
-    assert chunks[1]["bbox"] == "[40.0, 90.0, 300.0, 160.0]"
+    assert chunks[1]["bbox"] == "[0.1, 0.45, 0.75, 0.8]"
     assert "| Name | Amount |" in chunks[1]["text"]
     assert "| Alpha | $10 |" in chunks[1]["text"]


### PR DESCRIPTION
Fixes #221.

### Description
This PR implements automatic bounding box extraction during the PDF parsing and ingestion pipeline. This data is crucial for the frontend to physically highlight text when a user clicks on a source citation.

### Changes
- Updated the ingestion pipeline in \chunker.py\ to extract exact (X, Y) coordinates for every text and table chunk.
- Utilized \itz.search_for\ (PyMuPDF) for text chunks and \pdfplumber\ for structured tables.
- Implemented coordinate normalization (0.0 to 1.0 range) based on page dimensions to ensure consistency across different screen resolutions and zoom levels.
- Serialized coordinates as a JSON string in the ChromaDB metadata field \box\.

Verified locally with sample PDFs to ensure coordinates are accurate and properly normalized.