### PR TITLE
feat: Implement web search tool for agent

### DIFF
--- a/backend/app/rag/tools.py
+++ b/backend/app/rag/tools.py
@@ -1,8 +1,13 @@
 """Agent tools for the PDF Assistant RAG backend."""
 
 import ast
+import logging
 import operator as op
 from typing import Any
+
+from ddgs import DDGS
+
+logger = logging.getLogger(__name__)
 
 from huggingface_hub.inference._generated.types.chat_completion import (
     ChatCompletionInputFunctionDefinition,
@@ -71,16 +76,48 @@ def calculate_expression(expression: str) -> str:
     return str(result)
 
 
+def web_search(query: str, max_results: int = 5) -> str:
+    """Search the web using DuckDuckGo (no API key required).
+
+    Returns a formatted string of search results including title, URL, and snippet.
+    """
+    try:
+        with DDGS() as ddgs:
+            results = list(ddgs.text(query, max_results=max_results))
+
+        if not results:
+            return "No web search results found."
+
+        formatted = []
+        for i, r in enumerate(results, 1):
+            formatted.append(
+                f"{i}. **{r.get('title', 'No title')}**\n"
+                f"   URL: {r.get('href', '')}\n"
+                f"   {r.get('body', '')}"
+            )
+        return "\n\n".join(formatted)
+
+    except Exception as exc:
+        logger.error("DuckDuckGo search error: %s", exc)
+        return f"Web search failed: {exc}"
+
+
 def execute_tool(name: str, arguments: dict[str, Any]) -> str:
     """Execute a registered tool by name."""
-    if name != "calculator":
-        raise ValueError(f"Unknown tool: {name}")
+    if name == "calculator":
+        expression = arguments.get("expression")
+        if not isinstance(expression, str) or not expression.strip():
+            raise ValueError("The calculator tool requires a non-empty 'expression' string.")
+        return calculate_expression(expression)
 
-    expression = arguments.get("expression")
-    if not isinstance(expression, str) or not expression.strip():
-        raise ValueError("The calculator tool requires a non-empty 'expression' string.")
+    if name == "web_search":
+        query = arguments.get("query")
+        if not isinstance(query, str) or not query.strip():
+            raise ValueError("The web_search tool requires a non-empty 'query' string.")
+        max_results = int(arguments.get("max_results", 5))
+        return web_search(query, max_results)
 
-    return calculate_expression(expression)
+    raise ValueError(f"Unknown tool: {name}")
 
 
 CALCULATOR_TOOL = ChatCompletionInputTool(
@@ -107,10 +144,38 @@ CALCULATOR_TOOL = ChatCompletionInputTool(
     type="tool",
 )
 
+WEB_SEARCH_TOOL = ChatCompletionInputTool(
+    function=ChatCompletionInputFunctionDefinition(
+        name="web_search",
+        description=(
+            "Search the web using DuckDuckGo for current information not found in the uploaded documents. "
+            "Use this when the user asks about real-world facts, recent events, or topics outside the PDF content."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "The search query to look up on the web.",
+                },
+                "max_results": {
+                    "type": "integer",
+                    "description": "Number of search results to return (default: 5, max: 10).",
+                    "default": 5,
+                },
+            },
+            "required": ["query"],
+        },
+    ),
+    type="tool",
+)
+
 TOOL_PROMPT = (
     "Use the calculator tool for all numeric arithmetic operations in the user query. "
     "The tool accepts a single 'expression' field and returns the evaluated numeric result. "
-    "Do not attempt to compute arithmetic without the tool."
+    "Do not attempt to compute arithmetic without the tool. "
+    "Use the web_search tool when the user asks about real-world facts, current events, "
+    "or topics that are not covered by the uploaded PDF documents."
 )
 
-TOOLS = [CALCULATOR_TOOL]
+TOOLS = [CALCULATOR_TOOL, WEB_SEARCH_TOOL]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -63,3 +63,4 @@ python-docx
 pypdf
 reportlab
 crawl4ai
+ddgs


### PR DESCRIPTION

Closes #220 

---

### 📝 What does this PR do?

Integrates **DuckDuckGo Search** as a free, no-auth-required LLM tool into the RAG agent pipeline.

When the user asks a question that falls outside the uploaded PDF content (e.g. real-world facts, current events, general knowledge), the LLM can now autonomously call the `web_search` tool to fetch live results from DuckDuckGo and incorporate them into its answer.

**Changes summary:**
- Added `web_search(query, max_results)` tool function in `backend/app/rag/tools.py`
- Registered `WEB_SEARCH_TOOL`  alongside the existing `CALCULATOR_TOOL`
- Updated `execute_tool()` dispatcher to handle `web_search` calls
- Updated `TOOL_PROMPT` to instruct the LLM when to use web search vs calculator
- Added `ddgs` to `backend/requirements.txt`

---

### 🗂️ Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🔧 Refactor / code cleanup
- [ ] 📝 Documentation update
- [ ] 🎨 UI / styling change
- [ ] ⚙️ CI / tooling / config change
- [ ] 🧪 Tests

---

### 🧪 How was this tested?
- [x] Ran the backend locally (`uvicorn app.main:app --reload`)
- [ ] Ran the frontend locally (`npm run dev` inside `frontend/`)
- [x] Tested the affected API endpoints manually
- [ ] Added / updated tests



---



### ⚠️ Anything to flag for reviewers?

- The package `duckduckgo-search` has been **renamed to `ddgs`** (v9+). The old package name is now a deprecated stub. This PR uses `ddgs` directly to avoid the deprecation warning and ensure correct behaviour.


---

### ✅ Self-Review Checklist
- [x] My branch is based on **`dev`**, not `main`
- [x] I have not added any secrets / API keys
- [x] I have not modified `main` branch or any HuggingFace deployment config
- [x] My code follows the existing style (no unnecessary formatting changes)
- [x] I have updated relevant docs / comments if needed
