### PR TITLE
test: cover document upload validation

### DIFF
--- a/backend/app/routes/documents.py
+++ b/backend/app/routes/documents.py
@@ -82,6 +82,7 @@ async def validate_upload(file: UploadFile):
         size = Path(temp_path).stat().st_size
 
         if size > settings.MAX_UPLOAD_SIZE_MB * 1024 * 1024:
+            Path(temp_path).unlink(missing_ok=True)
             raise HTTPException(status_code=400, detail="File too large")
 
         # libmagic may not be installed in all environments — import lazily

--- a/backend/tests/test_document_upload_validation.py
+++ b/backend/tests/test_document_upload_validation.py
@@ -1,0 +1,169 @@
+import asyncio
+import io
+import sys
+import types
+import uuid
+from pathlib import Path
+
+import pytest
+from fastapi import BackgroundTasks, HTTPException, UploadFile
+from pypdf import PdfWriter
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.database import Base
+from app.models import Document, User
+from app.routes import documents
+
+
+def _pdf_bytes() -> bytes:
+    buffer = io.BytesIO()
+    writer = PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+    writer.write(buffer)
+    return buffer.getvalue()
+
+
+def _upload_file(name: str, content: bytes) -> UploadFile:
+    return UploadFile(filename=name, file=io.BytesIO(content))
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+@pytest.fixture(autouse=True)
+def fake_magic(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(
+        sys.modules,
+        "magic",
+        types.SimpleNamespace(from_file=lambda *_args, **_kwargs: "application/pdf"),
+    )
+
+
+def test_validate_upload_accepts_valid_pdf() -> None:
+    temp_path = None
+
+    try:
+        temp_path = _run(documents.validate_upload(_upload_file("report.pdf", _pdf_bytes())))
+        assert Path(temp_path).exists()
+        assert Path(temp_path).suffix == ".pdf"
+    finally:
+        if temp_path:
+            Path(temp_path).unlink(missing_ok=True)
+
+
+def test_validate_upload_rejects_invalid_file_type() -> None:
+    with pytest.raises(HTTPException) as exc:
+        _run(documents.validate_upload(_upload_file("notes.exe", b"not a document")))
+
+    assert exc.value.status_code == 400
+    assert "Only PDF" in exc.value.detail
+
+
+def test_validate_upload_rejects_oversized_file_and_removes_temp_file(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    created_paths: list[Path] = []
+    original_named_temporary_file = documents.tempfile.NamedTemporaryFile
+
+    def tracking_tempfile(*args, **kwargs):
+        kwargs.setdefault("dir", tmp_path)
+        handle = original_named_temporary_file(*args, **kwargs)
+        created_paths.append(Path(handle.name))
+        return handle
+
+    monkeypatch.setattr(documents.settings, "MAX_UPLOAD_SIZE_MB", 0)
+    monkeypatch.setattr(documents.tempfile, "NamedTemporaryFile", tracking_tempfile)
+
+    with pytest.raises(HTTPException) as exc:
+        _run(documents.validate_upload(_upload_file("too-large.pdf", _pdf_bytes())))
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "File too large"
+    assert created_paths
+    assert all(not path.exists() for path in created_paths)
+
+
+def test_validate_upload_rejects_corrupted_pdf() -> None:
+    with pytest.raises(HTTPException) as exc:
+        _run(documents.validate_upload(_upload_file("broken.pdf", b"%PDF-1.4\nnot really a pdf")))
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Corrupted or invalid file"
+
+
+@pytest.mark.parametrize(
+    "first_hex,second_hex",
+    [
+        (
+            "11111111111111111111111111111111",
+            "22222222222222222222222222222222",
+        )
+    ],
+)
+def test_upload_document_handles_duplicate_original_names(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    first_hex: str,
+    second_hex: str,
+) -> None:
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+
+    user = User(
+        id=str(uuid.uuid4()),
+        username="upload-tester",
+        email="upload@example.com",
+        hashed_password="hashed",
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+
+    temp_files: list[Path] = []
+
+    async def fake_validate_upload(_file: UploadFile) -> str:
+        handle = documents.tempfile.NamedTemporaryFile(delete=False, suffix=".pdf")
+        with handle:
+            handle.write(_pdf_bytes())
+        temp_files.append(Path(handle.name))
+        return handle.name
+
+    class FakeUUID:
+        def __init__(self, value: str) -> None:
+            self.hex = value
+
+    uuid_values = iter([FakeUUID(first_hex), FakeUUID(second_hex)])
+
+    monkeypatch.setattr(documents, "validate_upload", fake_validate_upload)
+    monkeypatch.setattr(documents.settings, "UPLOAD_DIR", str(tmp_path / "uploads"))
+    monkeypatch.setattr(documents.uuid, "uuid4", lambda: next(uuid_values))
+
+    first = _run(
+        documents.upload_document(
+            BackgroundTasks(),
+            file=_upload_file("same-name.pdf", b"first"),
+            user=user,
+            db=session,
+        )
+    )
+    second = _run(
+        documents.upload_document(
+            BackgroundTasks(),
+            file=_upload_file("same-name.pdf", b"second"),
+            user=user,
+            db=session,
+        )
+    )
+
+    stored_docs = session.query(Document).order_by(Document.filename).all()
+
+    assert [doc.original_name for doc in stored_docs] == ["same-name.pdf", "same-name.pdf"]
+    assert len({doc.filename for doc in stored_docs}) == 2
+    assert first.original_name == second.original_name == "same-name.pdf"
+    assert (tmp_path / "uploads" / user.id / f"{first_hex}.pdf").exists()
+    assert (tmp_path / "uploads" / user.id / f"{second_hex}.pdf").exists()
+    assert all(not path.exists() for path in temp_files)


### PR DESCRIPTION
## 📋 PR Checklist

### 🔗 Related Issue
Closes #50

### 📝 What does this PR do?
Adds focused backend pytest coverage for the document upload validation path:
- valid PDF uploads are accepted and produce a temporary PDF path
- invalid file extensions are rejected before processing
- oversized uploads are rejected and their temporary files are cleaned up
- corrupted PDF payloads are rejected clearly
- duplicate original filenames are handled by storing unique generated filenames while preserving the original display name

This also fixes the oversized-upload cleanup path in `validate_upload()` by unlinking the temporary file before raising the size-limit error.

### 🗂️ Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔧 Refactor / code cleanup
- [ ] 📝 Documentation update
- [ ] 🎨 UI / styling change
- [ ] ⚙️ CI / tooling / config change
- [x] 🧪 Tests

### 🧪 How was this tested?
- [ ] Ran the backend locally (`uvicorn app.main:app --reload`)
- [ ] Ran the frontend locally (`npm run dev` inside `frontend/`)
- [ ] Tested the affected API endpoints manually
- [x] Added / updated tests

Validation run:
```bash
uv run --with-requirements requirements.txt --with-requirements backend/requirements.txt python -m pytest backend/tests/test_document_upload_validation.py -q
PYTHONPATH=backend python3 -m py_compile backend/app/routes/documents.py backend/tests/test_document_upload_validation.py
git diff --check
uv run --with-requirements requirements.txt --with-requirements backend/requirements.txt --with flake8 --with flake8-bugbear flake8 backend/app --max-line-length=120 --select=E9,F63,F7,F82 --count --show-source --statistics
```

Results:
- focused pytest: 5 passed
- py_compile: passed
- git diff --check: passed
- backend flake8 error-only check: 0

### 📸 Screenshots (if UI change)
Not applicable, backend test coverage only.

### ⚠️ Anything to flag for reviewers?
No workflow or deployment files were changed. The new duplicate-name test documents the current behavior: duplicate original names are accepted safely because stored filenames are UUID-based and unique.

If accepted under GSSoC, please add the scoring labels from the issue, such as `gssoc`, `medium`, `testing`, and `backend` or the repo's equivalent difficulty/type labels.

### ✅ Self-Review Checklist
- [x] My branch is based on **`dev`**, not `main`
- [x] I have not added any secrets / API keys
- [x] I have not modified `main` branch or any HuggingFace deployment config
- [x] My code follows the existing style (no unnecessary formatting changes)
- [x] I have updated relevant docs / comments if needed
