### PR TITLE
fix(api): enforce chat rate limit requirement

### DIFF
--- a/backend/app/rate_limit.py
+++ b/backend/app/rate_limit.py
@@ -6,6 +6,9 @@ from slowapi import Limiter
 from slowapi.util import get_remote_address
 
 
+CHAT_QUERY_RATE_LIMIT = "15/minute"
+
+
 def rate_limit_key_func(request: Request) -> str:
     """Use authenticated user id when available, otherwise fall back to client IP."""
     authorization = request.headers.get("authorization", "")

--- a/backend/app/routes/chat.py
+++ b/backend/app/routes/chat.py
@@ -17,7 +17,7 @@ from app.auth import get_current_user
 from app.database import get_db
 from app.metrics import record_query_response_time
 from app.models import User, ChatMessage, Document, SharedMessage, ChatSession
-from app.rate_limit import limiter
+from app.rate_limit import CHAT_QUERY_RATE_LIMIT, limiter
 from app.schemas import (
     ChatRequest,
     ChatResponse,
@@ -221,7 +221,7 @@ def generate_answer_stream(question: str, user_id: str, document_id: Optional[st
 
 
 @router.post("/ask", response_model=ChatResponse)
-@limiter.limit("10/minute")
+@limiter.limit(CHAT_QUERY_RATE_LIMIT)
 def ask_question(
     request: Request,
     payload: ChatRequest,
@@ -283,7 +283,7 @@ def ask_question(
 
 
 @router.post("/ask/stream")
-@limiter.limit("10/minute")
+@limiter.limit(CHAT_QUERY_RATE_LIMIT)
 def ask_question_stream(
     request: Request,
     payload: ChatRequest,

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -65,8 +65,11 @@ class Limiter:
     def __init__(self, key_func=None, *args, **kwargs):
         self.key_func = key_func
 
-    def limit(self, _value):
+    def limit(self, value):
         def decorator(fn):
+            limits = list(getattr(fn, "__rate_limits__", []))
+            limits.append(value)
+            setattr(fn, "__rate_limits__", limits)
             return fn
         return decorator
 

--- a/backend/tests/test_rate_limit.py
+++ b/backend/tests/test_rate_limit.py
@@ -1,0 +1,33 @@
+from types import SimpleNamespace
+
+from app.auth import create_access_token
+from app.rate_limit import CHAT_QUERY_RATE_LIMIT, rate_limit_key_func
+from app.routes.chat import ask_question, ask_question_stream
+
+
+class DummyRequest:
+    def __init__(self, headers=None):
+        self.headers = headers or {}
+        self.client = SimpleNamespace(host="203.0.113.10")
+
+
+def test_rate_limit_key_prefers_authenticated_user_id():
+    token = create_access_token("user-123")
+
+    key = rate_limit_key_func(
+        DummyRequest(headers={"authorization": f"Bearer {token}"})
+    )
+
+    assert key == "user:user-123"
+
+
+def test_rate_limit_key_falls_back_to_client_ip():
+    key = rate_limit_key_func(DummyRequest())
+
+    assert key.startswith("ip:")
+
+
+def test_chat_endpoints_use_required_rate_limit():
+    assert CHAT_QUERY_RATE_LIMIT == "15/minute"
+    assert ask_question.__rate_limits__ == [CHAT_QUERY_RATE_LIMIT]
+    assert ask_question_stream.__rate_limits__ == [CHAT_QUERY_RATE_LIMIT]


### PR DESCRIPTION
## Summary
- centralize the chat query SlowAPI limit as `CHAT_QUERY_RATE_LIMIT = "15/minute"`
- apply the required 15/minute limit to both regular and streaming chat endpoints
- add regression tests for authenticated-user/IP rate-limit keys and endpoint limit wiring

Fixes #278

## Validation
- `python3 -m py_compile backend/app/rate_limit.py backend/app/routes/chat.py backend/tests/conftest.py backend/tests/test_rate_limit.py`
- `uv run --python 3.11 --with-requirements backend/requirements.txt python -m pytest backend/tests/test_rate_limit.py backend/tests/test_chat.py -q`
- `uv run --python 3.11 --with black black --check backend/tests/test_rate_limit.py`
- `uv run --python 3.11 --with flake8 flake8 backend/tests/test_rate_limit.py backend/app/rate_limit.py --max-line-length=100`
- `git diff --check`

Note: full-file black/flake8 on legacy `backend/app/routes/chat.py` and `backend/tests/conftest.py` currently reports pre-existing formatting/style noise outside this scoped change, so I kept this PR focused on the limiter behavior and targeted tests.