### PR TITLE
feat: soft-delete documents

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -75,6 +75,8 @@ def _migrate_schema():
     existing_docs_columns = {c["name"] for c in inspector.get_columns("documents")}
     docs_migrations = [
         ("documents", "last_accessed_at", "ALTER TABLE documents ADD COLUMN last_accessed_at TIMESTAMP"),
+        ("documents", "is_deleted", "ALTER TABLE documents ADD COLUMN is_deleted BOOLEAN DEFAULT FALSE NOT NULL"),
+        ("documents", "deleted_at", "ALTER TABLE documents ADD COLUMN deleted_at TIMESTAMP"),
     ]
     for table, column, ddl in docs_migrations:
         if column not in existing_docs_columns:

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -182,6 +182,8 @@ class Document(Base):
     drive_file_id = Column(String(255), unique=True, nullable=True, index=True)
     drive_folder_id = Column(String(255), nullable=True, index=True)
     drive_synced_at = Column(DateTime, nullable=True)
+    is_deleted = Column(Boolean, default=False, nullable=False, index=True)
+    deleted_at = Column(DateTime, nullable=True)
 
     # Relationships
     owner = relationship("User", back_populates="documents")
@@ -238,4 +240,3 @@ class SharedMessage(Base):
 
     # Relationships
     message = relationship("ChatMessage", back_populates="shared_message")
-

--- a/backend/app/routes/chat.py
+++ b/backend/app/routes/chat.py
@@ -236,6 +236,7 @@ def ask_question(
             doc = db.query(Document).filter(
                 Document.id == payload.document_id,
                 Document.user_id == user.id,
+                Document.is_deleted.is_(False),
             ).first()
 
             if not doc:
@@ -296,6 +297,7 @@ def ask_question_stream(
         doc = db.query(Document).filter(
             Document.id == payload.document_id,
             Document.user_id == user.id,
+            Document.is_deleted.is_(False),
         ).first()
 
         if not doc:
@@ -437,6 +439,7 @@ def export_chat_history(
     doc = db.query(Document).filter(
         Document.id == document_id,
         Document.user_id == resolved_user.id,
+        Document.is_deleted.is_(False),
     ).first()
 
     if not doc:

--- a/backend/app/routes/documents.py
+++ b/backend/app/routes/documents.py
@@ -8,6 +8,7 @@ import uuid
 import logging
 import asyncio
 import concurrent.futures
+from datetime import datetime, timezone
 from typing import Optional
 from pathlib import Path
 import shutil
@@ -23,7 +24,7 @@ from app.schemas import DocumentResponse, DocumentListResponse, DocumentStatusRe
 from app.auth import get_current_user
 from app.config import get_settings
 from app.rag.chunker import chunk_document, get_page_count
-from app.rag.vectorstore import store_chunks, delete_document_chunks
+from app.rag.vectorstore import store_chunks
 
 try:
     from crawl4ai import AsyncWebCrawler
@@ -158,7 +159,11 @@ def _ingest_document(document_id: str, filepath: str, original_name: str, user_i
 
     db = SessionLocal()
     try:
-        doc = db.query(Document).filter(Document.id == document_id).first()
+        doc = (
+            db.query(Document)
+            .filter(Document.id == document_id, Document.is_deleted.is_(False))
+            .first()
+        )
         if not doc:
             logger.error(f"Document {document_id} not found for ingestion")
             return
@@ -236,7 +241,11 @@ def _ingest_document(document_id: str, filepath: str, original_name: str, user_i
     except Exception as e:
         logger.error(f"Ingestion error for {document_id}: {e}")
         try:
-            doc = db.query(Document).filter(Document.id == document_id).first()
+            doc = (
+                db.query(Document)
+                .filter(Document.id == document_id, Document.is_deleted.is_(False))
+                .first()
+            )
             if doc:
                 doc.status = "failed"
                 doc.error_message = str(e)[:500]
@@ -476,6 +485,7 @@ def get_document_status(
     doc = db.query(Document).filter(
         Document.id == document_id,
         Document.user_id == user.id,
+        Document.is_deleted.is_(False),
     ).first()
 
     if not doc:
@@ -517,7 +527,7 @@ def list_documents(
     """Total Pages"""
     totalDocuments = (
         db.query(Document)
-        .filter(Document.user_id == user.id)
+        .filter(Document.user_id == user.id, Document.is_deleted.is_(False))
         .count()
     )
     """Total Pages"""
@@ -526,7 +536,7 @@ def list_documents(
     """List all documents for the authenticated user in Paginated form"""
     docs = ((
             db.execute(select(Document)
-            .where(Document.user_id == user.id)
+            .where(Document.user_id == user.id, Document.is_deleted.is_(False))
             .order_by(Document.uploaded_at.desc())
             .limit(per_page).offset(skip))
             )
@@ -567,6 +577,7 @@ def get_document(
     doc = db.query(Document).filter(
         Document.id == document_id,
         Document.user_id == user.id,
+        Document.is_deleted.is_(False),
     ).first()
 
     if not doc:
@@ -603,6 +614,7 @@ def serve_pdf(
     doc = db.query(Document).filter(
         Document.id == document_id,
         Document.user_id == user.id,
+        Document.is_deleted.is_(False),
     ).first()
 
     if not doc:
@@ -627,12 +639,11 @@ def delete_document(
     db: Session = Depends(get_db),
 ):
     """
-    Delete a document and its associated vector embeddings.
+    Soft-delete a document so it disappears from normal document APIs.
 
-    Removes the document from the database, deletes the physical file from
-    disk, and attempts to delete all corresponding vector chunks from ChromaDB.
-    If ChromaDB deletion fails, the error is logged but does not block the
-    overall operation.
+    The underlying file, vectors, graph, and chat history are retained for a
+    future recycle-bin/restore flow. Normal read/list endpoints filter deleted
+    documents so accidental deletion is reversible at the database level.
 
     Args:
         document_id: The unique identifier of the document to delete.
@@ -653,32 +664,14 @@ def delete_document(
     doc = db.query(Document).filter(
         Document.id == document_id,
         Document.user_id == user.id,
+        Document.is_deleted.is_(False),
     ).first()
 
     if not doc:
         raise HTTPException(status_code=404, detail="Document not found")
 
-    # Delete file from disk
-    filepath = os.path.join(settings.UPLOAD_DIR, user.id, doc.filename)
-    if os.path.exists(filepath):
-        os.remove(filepath)
-
-    # Delete vectors from ChromaDB
-    try:
-        delete_document_chunks(document_id=document_id, user_id=user.id)
-    except Exception as e:
-        logger.warning(f"Error deleting vectors: {e}")
-
-    # Delete persisted knowledge graph
-    try:
-        from app.rag.graph_builder import delete_graph
-
-        delete_graph(user_id=user.id, document_id=document_id)
-    except Exception as e:
-        logger.warning(f"Error deleting knowledge graph: {e}")
-
-    # Delete from database (cascades to chat messages)
-    db.delete(doc)
+    doc.is_deleted = True
+    doc.deleted_at = datetime.now(timezone.utc)
     db.commit()
 
     return {"message": f"Document '{doc.original_name}' deleted successfully"}
@@ -714,6 +707,7 @@ def update_chunk_settings(
     doc = db.query(Document).filter(
         Document.id == document_id,
         Document.user_id == user.id,
+        Document.is_deleted.is_(False),
     ).first()
 
     if not doc:

--- a/backend/tests/test_documents.py
+++ b/backend/tests/test_documents.py
@@ -93,14 +93,13 @@ def test_ingest_document_builds_and_saves_graph(db_session, monkeypatch, tmp_pat
     assert refreshed.chunk_count == 1
 
 
-def test_delete_document_removes_knowledge_graph(client, auth_headers, ready_document, monkeypatch):
-    deleted = {}
+def test_delete_document_soft_deletes_and_hides_document(client, auth_headers, ready_document, db_session, monkeypatch):
+    deletion_calls = []
     doc_id = ready_document.id
 
-    monkeypatch.setattr("app.routes.documents.delete_document_chunks", lambda **kwargs: None)
     monkeypatch.setattr(
         "app.rag.graph_builder.delete_graph",
-        lambda user_id, document_id: deleted.update(
+        lambda user_id, document_id: deletion_calls.append(
             {"user_id": user_id, "document_id": document_id}
         ),
     )
@@ -111,4 +110,15 @@ def test_delete_document_removes_knowledge_graph(client, auth_headers, ready_doc
     )
 
     assert response.status_code == 200
-    assert deleted["document_id"] == doc_id
+    assert deletion_calls == []
+
+    db_session.refresh(ready_document)
+    assert ready_document.is_deleted is True
+    assert ready_document.deleted_at is not None
+
+    list_response = client.get("/api/v1/documents/", headers=auth_headers)
+    assert list_response.status_code == 200
+    assert list_response.json()["total"] == 0
+
+    get_response = client.get(f"/api/v1/documents/{doc_id}", headers=auth_headers)
+    assert get_response.status_code == 404


### PR DESCRIPTION
## Summary
- add document soft-delete metadata and lightweight startup migration columns
- make delete mark documents as deleted while keeping files, vectors, graphs, and chat history available for future restore flows
- hide soft-deleted documents from list/read/status/chat/export/chunk-settings paths
- add a focused backend test that verifies soft-delete persistence and normal API filtering

## Notes
- The current backend has a `Document` model but no workspace model, so this scopes the implementation to the existing document APIs and leaves the same pattern ready for a workspace model later.
- I avoided deployment/config files per the contribution guide.

## Validation
- `python3 -m py_compile backend/app/models.py backend/app/database.py backend/app/routes/documents.py backend/app/routes/chat.py backend/tests/test_documents.py`
- `git diff --check`
- `uv run --python 3.11 --with-requirements backend/requirements.txt --with flake8 python -m flake8 backend/app --max-line-length=120 --select=E9,F63,F7,F82 --count --show-source --statistics`
- `uv run --python 3.11 --with-requirements backend/requirements.txt python -m pytest backend/tests/test_documents.py -q`

Closes #285
