### PR TITLE
feat(rag): add chat history memory to conversational chain

### DIFF
--- a/backend/app/rag/agent.py
+++ b/backend/app/rag/agent.py
@@ -30,10 +30,21 @@ def get_llm_client(hf_token: Optional[str] = None) -> InferenceClient:
     )
 
 
+def _format_chat_history(messages: List[Dict[str, str]]) -> str:
+    if not messages:
+        return ""
+    lines = ["Previous conversation:"]
+    for msg in messages:
+        role = "User" if msg["role"] == "user" else "Assistant"
+        lines.append(f"{role}: {msg['content']}")
+    return "\n".join(lines)
+
+
 def get_agent_executor(
     user_id: str,
     document_id: Optional[str] = None,
     hf_token: Optional[str] = None,
+    chat_history: Optional[List[Dict[str, str]]] = None,
 ):
     """Initialize the LangChain ReAct agent executor."""
     # Initialize tools
@@ -61,7 +72,9 @@ def get_agent_executor(
         max_iterations=5,
     )
 
-    return executor, pdf_tool
+    formatted_history = _format_chat_history(chat_history) if chat_history else ""
+
+    return executor, pdf_tool, formatted_history
 
 
 def is_greeting(question: str) -> bool:
@@ -87,6 +100,7 @@ def generate_answer(
     user_id: str,
     document_id: Optional[str] = None,
     hf_token: Optional[str] = None,
+    chat_history: Optional[List[Dict[str, str]]] = None,
 ) -> Dict[str, Any]:
     """
     Agentic generation: retrieve via tools → reason → generate answer.
@@ -111,8 +125,8 @@ def generate_answer(
 
     # ── Run Agent ────────────────────────────────────
     try:
-        executor, pdf_tool = get_agent_executor(user_id, document_id, hf_token)
-        result = executor.invoke({"input": question})
+        executor, pdf_tool, formatted_history = get_agent_executor(user_id, document_id, hf_token, chat_history)
+        result = executor.invoke({"input": question, "chat_history": formatted_history})
         
         raw_answer = result.get("output", "")
         try:
@@ -156,6 +170,7 @@ def generate_answer_stream(
     user_id: str,
     document_id: Optional[str] = None,
     hf_token: Optional[str] = None,
+    chat_history: Optional[List[Dict[str, str]]] = None,
 ) -> Generator[str, None, None]:
     """
     Streaming Agentic pipeline.
@@ -181,11 +196,11 @@ def generate_answer_stream(
 
     # ── Run Agent ────────────────────────────────────
     try:
-        executor, pdf_tool = get_agent_executor(user_id, document_id, hf_token)
+        executor, pdf_tool, formatted_history = get_agent_executor(user_id, document_id, hf_token, chat_history)
         
         sources_sent = False
 
-        for step in executor.stream({"input": question}):
+        for step in executor.stream({"input": question, "chat_history": formatted_history}):
             if "actions" in step:
                 continue
             

--- a/backend/app/rag/prompts.py
+++ b/backend/app/rag/prompts.py
@@ -83,5 +83,7 @@ IMPORTANT RULES:
 
 Begin!
 
+===== END OF SYSTEM INSTRUCTIONS =====
+{chat_history}
 Question: {input}
 Thought: {agent_scratchpad}"""

--- a/backend/app/routes/chat.py
+++ b/backend/app/routes/chat.py
@@ -261,16 +261,16 @@ def get_session_history(
     return ChatHistoryResponse(messages=formatted, document_id=None)
 
 
-def generate_answer(question: str, user_id: str, document_id: Optional[str] = None, hf_token: Optional[str] = None):
+def generate_answer(question: str, user_id: str, document_id: Optional[str] = None, hf_token: Optional[str] = None, chat_history: Optional[list] = None):
     from app.rag.agent import generate_answer as _generate_answer
 
-    return _generate_answer(question=question, user_id=user_id, document_id=document_id, hf_token=hf_token)
+    return _generate_answer(question=question, user_id=user_id, document_id=document_id, hf_token=hf_token, chat_history=chat_history)
 
 
-def generate_answer_stream(question: str, user_id: str, document_id: Optional[str] = None, hf_token: Optional[str] = None):
+def generate_answer_stream(question: str, user_id: str, document_id: Optional[str] = None, hf_token: Optional[str] = None, chat_history: Optional[list] = None):
     from app.rag.agent import generate_answer_stream as _generate_answer_stream
 
-    return _generate_answer_stream(question=question, user_id=user_id, document_id=document_id, hf_token=hf_token)
+    return _generate_answer_stream(question=question, user_id=user_id, document_id=document_id, hf_token=hf_token, chat_history=chat_history)
 
 
 @router.post(
@@ -329,11 +329,26 @@ def ask_question(
                 db.refresh(session)
             session_id = session.id
 
+        # Build chat history from last 6 exchanges
+        recent_messages = (
+            db.query(ChatMessage)
+            .filter(
+                ChatMessage.session_id == session_id,
+                ChatMessage.user_id == user.id,
+            )
+            .order_by(ChatMessage.created_at.desc())
+            .limit(12)
+            .all()
+        )
+        recent_messages.reverse()
+        chat_history = [{"role": m.role, "content": m.content} for m in recent_messages]
+
         result = generate_answer(
             question=payload.question,
             user_id=user.id,
             document_id=payload.document_id,
             hf_token=user.hf_token,
+            chat_history=chat_history,
         )
 
         # Save to chat history
@@ -404,6 +419,20 @@ def ask_question_stream(
             db.refresh(session)
         session_id = session.id
 
+    # Build chat history from last 6 exchanges (before saving current message)
+    recent_messages = (
+        db.query(ChatMessage)
+        .filter(
+            ChatMessage.session_id == session_id,
+            ChatMessage.user_id == user.id,
+        )
+        .order_by(ChatMessage.created_at.desc())
+        .limit(12)
+        .all()
+    )
+    recent_messages.reverse()
+    chat_history = [{"role": m.role, "content": m.content} for m in recent_messages]
+
     # Save user message immediately
     _save_message(db, user.id, payload.document_id, "user", payload.question, session_id=session_id)
 
@@ -418,6 +447,7 @@ def ask_question_stream(
                 user_id=user.id,
                 document_id=payload.document_id,
                 hf_token=user.hf_token,
+                chat_history=chat_history,
             ):
                 yield chunk
 

--- a/backend/tests/test_graphrag_agent.py
+++ b/backend/tests/test_graphrag_agent.py
@@ -21,8 +21,8 @@ def test_generate_answer_appends_graph_context_without_changing_sources(monkeypa
     mock_pdf_tool = MagicMock()
     mock_pdf_tool.last_sources = chunks
 
-    # Mock get_agent_executor to return our mocks
-    monkeypatch.setattr(agent, "get_agent_executor", lambda *args, **kwargs: (mock_executor, mock_pdf_tool))
+    # Mock get_agent_executor to return our mocks (3 values: executor, pdf_tool, formatted_history)
+    monkeypatch.setattr(agent, "get_agent_executor", lambda *args, **kwargs: (mock_executor, mock_pdf_tool, ""))
 
     result = agent.generate_answer("How are OpenAI and Microsoft related?", "user-1", "doc-1")
 
@@ -36,7 +36,7 @@ def test_generate_answer_appends_graph_context_without_changing_sources(monkeypa
             "confidence": 100.0,
         }
     ]
-    mock_executor.invoke.assert_called_once_with({"input": "How are OpenAI and Microsoft related?"})
+    mock_executor.invoke.assert_called_once_with({"input": "How are OpenAI and Microsoft related?", "chat_history": ""})
 
 
 def test_generate_answer_stream_appends_graph_context(monkeypatch):
@@ -64,7 +64,7 @@ def test_generate_answer_stream_appends_graph_context(monkeypatch):
     mock_pdf_tool = MagicMock()
     mock_pdf_tool.last_sources = chunks
 
-    monkeypatch.setattr(agent, "get_agent_executor", lambda *args, **kwargs: (mock_executor, mock_pdf_tool))
+    monkeypatch.setattr(agent, "get_agent_executor", lambda *args, **kwargs: (mock_executor, mock_pdf_tool, ""))
 
     events = list(agent.generate_answer_stream("OpenAI Microsoft", "user-1", "doc-1"))
 


### PR DESCRIPTION
## Summary

Adds conversation memory to the RAG agent by feeding the last 6 exchanges (user + assistant) into the ReAct agent prompt for each query. This allows the LLM to maintain context across turns -- follow-up questions like "tell me more about the second point" will now work correctly.

## Changes

### backend/app/rag/prompts.py
- Added `{chat_history}` placeholder to `AGENT_SYSTEM_PROMPT` between the system instructions and the current question

### backend/app/rag/agent.py
- Added `_format_chat_history()` helper that converts a list of `{"role": ..., "content": ...}` dicts into a plain-text "Previous conversation:" block
- Added optional `chat_history: Optional[List[Dict[str, str]]]` parameter to `get_agent_executor()`, `generate_answer()`, and `generate_answer_stream()`
- Both `executor.invoke()` and `executor.stream()` now pass `chat_history` alongside `input`

### backend/app/routes/chat.py
- In `ask_question()` and `ask_question_stream()`, after resolving the session ID, fetches the last 12 `ChatMessage` rows (6 exchanges x 2 roles) from the database
- Builds `{"role", "content"}` dicts and forwards them to the agent functions
- History is fetched *before* saving the current user message, so the current question is only passed via `{input}` (no duplication)

## Design decisions

- **Window size = 6**: The last 6 question-answer pairs (12 messages) are included. This keeps prompt size manageable while providing enough context for multi-turn conversations.
- **In-memory per session**: History is fetched from the existing `ChatMessage` table per session_id rather than adding a separate in-memory store. This is consistent with the existing persistence model and works across server restarts.
- **System prompt precedence**: Chat history is injected *after* the system instructions and *before* the current question, so the system prompt always takes priority.
- **No new dependencies**: Uses only the existing LangChain PromptTemplate variable injection.

Closes #119
