### PR TITLE
feat: add copied tooltip for assistant messages

### DIFF
--- a/frontend/src/components/chat/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble.tsx
@@ -64,7 +64,7 @@ export default function MessageBubble({ message }: Props) {
       await navigator.clipboard.writeText(message.content);
       setCopied(true);
       if (copiedTimeoutRef.current) clearTimeout(copiedTimeoutRef.current);
-      copiedTimeoutRef.current = setTimeout(() => setCopied(false), 2000);
+      copiedTimeoutRef.current = setTimeout(() => setCopied(false), 1500);
     } catch {
       setCopied(false);
     }
@@ -158,6 +158,15 @@ export default function MessageBubble({ message }: Props) {
                     <Copy className="w-3.5 h-3.5" />
                   )}
                 </Button>
+                {copied && (
+                  <div 
+                    className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-2 py-1 bg-zinc-800 text-white text-xs rounded-md whitespace-nowrap opacity-100 transition-opacity pointer-events-none"
+                    role="status"
+                    aria-live="polite"
+                  >
+                    Copied!
+                  </div>
+                )}
               </>
             )}
             <div className={`prose-chat text-sm ${message.content ? "pr-14" : ""}`}>


### PR DESCRIPTION
## 📋 PR Checklist

> Thank you for contributing to **PDF-Assistant-RAG**! 🎉  
> Please fill out this template before submitting. PRs without it filled in will be closed.

---


### 🔗 Related Issue

Closes #21 

### 📝 What does this PR do?

Adds a visible "Copied!" tooltip to assistant message bubbles that appears immediately after a user successfully copies the message content to their clipboard.

**Implementation Details:**
- Tooltip displays above the copy button with dark background styling (`bg-zinc-800`)
- Automatically dismisses after 1.5 seconds using the existing `copied` state and timeout mechanism
- Tooltip is only shown for assistant messages (not user messages)
- Added accessibility attributes (`role="status"` and `aria-live="polite"`) to ensure screen readers announce the success feedback to users with visual impairments
- Follows existing project Tailwind styling patterns and component conventions

**Changes:**
- Modified `frontend/src/components/chat/MessageBubble.tsx`:
  - Adjusted copy timeout from 2000ms to 1500ms to match tooltip display duration
  - Added conditional tooltip `<div>` element positioned above the copy button
  - Added ARIA attributes for accessibility compliance

### 🗂️ Type of Change

- [x] Enhancement/Feature (non-breaking)
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

### 🧪 How was this tested?

**Manual Testing:**
1. Opened the chat interface
2. Triggered an assistant message response
3. Clicked the copy button on an assistant message
4. Verified:
   - Tooltip "Copied!" appears immediately above the copy button
   - Check icon turns emerald-green (existing behavior)
   - Tooltip automatically disappears after ~1.5 seconds
   - Tooltip only appears on assistant messages, not user messages
   - Copy functionality works correctly on all message types
   - Tooltip doesn't interfere with message content or other UI elements

**Accessibility Testing:**
- Verified screen reader announces "Copied!" status when tooltip appears
- Tested with browser DevTools - ARIA attributes properly set
- Verified keyboard navigation still works as expected

### 📸 Screenshots (if UI change)

Visual changes:
- Before: Only check icon appears on successful copy (no text feedback)
- After: Check icon + "Copied!" tooltip appears on successful copy, then auto-dismisses

### ⚠️ Anything to flag for reviewers?

- **No breaking changes**: All existing copy functionality remains unchanged
- **Minimal scope**: Only one component modified; no backend, API, or dependency changes
- **Zero refactoring**: Implementation focused solely on the tooltip requirement
- **Accessibility-first**: Includes screen reader support out of the box
- **Timeout sync**: Clipboard timeout adjusted from 2000ms to 1500ms to match tooltip display requirement

### ✅ Self-Review Checklist

- [x] Code follows project style guidelines and conventions
- [x] TypeScript types are correct and no implicit `any` types used
- [x] Existing copy functionality remains unchanged
- [x] Tooltip only displays for assistant messages
- [x] Tooltip auto-dismisses after 1.5 seconds
- [x] Accessibility attributes added (`role="status"`, `aria-live="polite"`)
- [x] Tailwind styling matches existing project patterns
- [x] No new dependencies introduced
- [x] No refactoring of existing logic
- [x] Mobile responsiveness maintained (centered tooltip, `whitespace-nowrap`)
- [x] Error handling preserved (catch block unchanged)
- [x] No console errors or warnings
- [x] Tested on multiple screen sizes
- [x] PR is focused and limited to this single issue