### PR TITLE
feat: add thumbs up/down feedback on AI responses (#41)

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -110,6 +110,25 @@ def _migrate_schema():
                     "Migration skipped (may already exist): %s.%s", table, column
                 )
 
+    # Migrate chat_messages
+    try:
+        existing_chat_columns = {c["name"] for c in inspector.get_columns("chat_messages")}
+    except Exception:
+        existing_chat_columns = set()
+    chat_migrations = [
+        ("chat_messages", "feedback", "ALTER TABLE chat_messages ADD COLUMN feedback VARCHAR(10)"),
+    ]
+    for table, column, ddl in chat_migrations:
+        if column not in existing_chat_columns:
+            try:
+                with engine.begin() as conn:
+                    conn.execute(text(ddl))
+                logger.info("Migration: added column %s.%s", table, column)
+            except Exception:
+                logger.warning(
+                    "Migration skipped (may already exist): %s.%s", table, column
+                )
+
 
 
 def init_db():

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -205,6 +205,7 @@ class ChatMessage(Base):
     role = Column(String(20), nullable=False)  # "user" | "assistant"
     content = Column(Text, nullable=False)
     sources_json = Column(Text, nullable=True)  # JSON representation of retrieved sources
+    feedback = Column(String(10), nullable=True)  # "up" | "down"
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
 
     # Relationships

--- a/backend/app/routes/chat.py
+++ b/backend/app/routes/chat.py
@@ -24,6 +24,7 @@ from app.schemas import (
     ChatResponse,
     ChatMessageResponse,
     ChatHistoryResponse,
+    FeedbackRequest,
     ShareAnswerResponse,
     ShareLinkResponse,
     SourceChunk,
@@ -489,6 +490,7 @@ def get_chat_history(
             role=msg.role,
             content=msg.content,
             sources=sources,
+            feedback=msg.feedback,
             created_at=msg.created_at,
         ))
 
@@ -592,6 +594,51 @@ def clear_chat_history(
     db.commit()
 
     return {"message": "Chat history cleared"}
+
+
+@router.patch("/feedback/{message_id}")
+def submit_feedback(
+    message_id: str,
+    payload: FeedbackRequest,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Submit thumbs up/down feedback for an assistant message.
+
+    Args:
+        message_id: The ID of the chat message to add feedback to.
+        payload: FeedbackRequest containing `feedback` ("up", "down", or null to clear).
+        user: The currently authenticated user.
+        db: SQLAlchemy database session.
+
+    Returns:
+        ChatMessageResponse: The updated message with feedback.
+
+    Raises:
+        HTTPException: 404 if the message does not exist or does not belong to the user.
+        HTTPException: 400 if the message is not an assistant message.
+    """
+    msg = db.query(ChatMessage).filter(
+        ChatMessage.id == message_id,
+        ChatMessage.user_id == user.id,
+    ).first()
+
+    if not msg:
+        raise HTTPException(status_code=404, detail="Message not found")
+    if msg.role != "assistant":
+        raise HTTPException(status_code=400, detail="Can only provide feedback on assistant messages")
+
+    msg.feedback = payload.feedback
+    db.commit()
+    db.refresh(msg)
+
+    return ChatMessageResponse(
+        id=msg.id,
+        role=msg.role,
+        content=msg.content,
+        feedback=msg.feedback,
+        created_at=msg.created_at,
+    )
 
 
 def _save_message(

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -172,11 +172,16 @@ class ChatResponse(BaseModel):
     document_id: Optional[str] = None
 
 
+class FeedbackRequest(BaseModel):
+    feedback: Optional[str] = Field(None, pattern="^(up|down)?$")
+
+
 class ChatMessageResponse(BaseModel):
     id: str
     role: str
     content: str
     sources: List[SourceChunk] = []
+    feedback: Optional[str] = None
     created_at: datetime
 
     class Config:

--- a/frontend/src/components/chat/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble.tsx
@@ -6,8 +6,9 @@ import rehypeHighlight from "rehype-highlight";
 import remarkGfm from "remark-gfm";
 import type { ChatMsg } from "@/store/chat-store";
 import { api } from "@/lib/api";
-import { Brain, User, Copy, Check, Share2, Link2, X, Play, Pause } from "lucide-react";
+import { Brain, User, Copy, Check, Share2, Link2, X, Play, Pause, ThumbsUp, ThumbsDown } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { useChatStore } from "@/store/chat-store";
 
 interface Props {
   message: ChatMsg;
@@ -68,6 +69,9 @@ export default function MessageBubble({ message }: Props) {
     };
   }, []);
 
+  const [feedbackState, setFeedbackState] = useState<"up" | "down" | null>(message.feedback ?? null);
+  const setMessages = useChatStore((s) => s.setMessages);
+
   const handleCopy = async () => {
     if (!message.content) return;
     try {
@@ -107,7 +111,6 @@ export default function MessageBubble({ message }: Props) {
   const handleSpeech = () => {
     if (!message.content || message.isStreaming) return;
 
-    // Already speaking — cancel ചെയ്യും
     if (isSpeaking) {
       window.speechSynthesis.cancel();
       setIsSpeaking(false);
@@ -127,11 +130,25 @@ export default function MessageBubble({ message }: Props) {
       utteranceRef.current = null;
     };
 
-    // Chrome bug fix: onstart reliable അല്ല, speak() മുൻപ് set ചെയ്യണം
     setIsSpeaking(true);
     window.speechSynthesis.speak(utterance);
   };
 
+  const handleFeedback = async (value: "up" | "down") => {
+    const next = feedbackState === value ? null : value;
+    setFeedbackState(next);
+    setMessages((prev) =>
+      prev.map((msg) => (msg.id === message.id ? { ...msg, feedback: next } : msg)),
+    );
+    try {
+      await api.patch(`/api/v1/chat/feedback/${message.id}`, { feedback: next });
+    } catch {
+      setFeedbackState(message.feedback ?? null);
+      setMessages((prev) =>
+        prev.map((msg) => (msg.id === message.id ? { ...msg, feedback: message.feedback } : msg)),
+      );
+    }
+  };
   return (
     <div
       className={`flex gap-3 py-3 animate-fade-in-up ${isUser ? "justify-end" : "justify-start"}`}
@@ -230,6 +247,35 @@ export default function MessageBubble({ message }: Props) {
                 <span className="inline-block w-0.5 h-4 bg-primary/60 animate-pulse ml-0.5 align-text-bottom" />
               )}
             </div>
+            {!message.isStreaming && !isUser && (
+              <div className="flex items-center gap-1 pt-2 border-t border-border/40 mt-3">
+                <span className="text-[11px] text-muted-foreground/60 mr-1">Was this helpful?</span>
+                <button
+                  type="button"
+                  onClick={() => handleFeedback("up")}
+                  className={`p-1 rounded transition-colors ${
+                    feedbackState === "up"
+                      ? "text-emerald-500 bg-emerald-500/10"
+                      : "text-muted-foreground/50 hover:text-muted-foreground hover:bg-muted/40"
+                  }`}
+                  aria-label="Thumbs up"
+                >
+                  <ThumbsUp className="w-3.5 h-3.5" />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleFeedback("down")}
+                  className={`p-1 rounded transition-colors ${
+                    feedbackState === "down"
+                      ? "text-red-500 bg-red-500/10"
+                      : "text-muted-foreground/50 hover:text-muted-foreground hover:bg-muted/40"
+                  }`}
+                  aria-label="Thumbs down"
+                >
+                  <ThumbsDown className="w-3.5 h-3.5" />
+                </button>
+              </div>
+            )}
           </>
         )}
       </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -254,6 +254,28 @@ class ApiClient {
     return res.json();
   }
 
+  async patch<T>(path: string, body?: unknown, options?: FetchOptions): Promise<T> {
+    const res = await this.fetchWithConnectionError(`${this.baseUrl}${path}`, {
+      method: "PATCH",
+      headers: this.getHeaders(options?.token),
+      body: body ? JSON.stringify(body) : undefined,
+      ...options,
+    });
+
+    if (res.status === 401 && !options?._skipRefresh) {
+      const newToken = await this.tryRefreshToken();
+      if (newToken) {
+        return this.patch<T>(path, body, { ...options, token: newToken, _skipRefresh: true });
+      }
+    }
+
+    if (!res.ok) {
+      throw new Error(await this.getErrorMessage(res, res.statusText || "Request failed"));
+    }
+
+    return res.json();
+  }
+
   async delete<T>(path: string, options?: FetchOptions): Promise<T> {
     const res = await this.fetchWithConnectionError(`${this.baseUrl}${path}`, {
       method: "DELETE",

--- a/frontend/src/store/chat-store.ts
+++ b/frontend/src/store/chat-store.ts
@@ -16,6 +16,7 @@ export interface ChatMsg {
   role: "user" | "assistant";
   content: string;
   sources: SourceChunk[];
+  feedback?: "up" | "down" | null;
   isStreaming?: boolean;
 }
 


### PR DESCRIPTION
## Description
Adds thumbs up/down feedback buttons below each assistant message, stored in the database linked to the message ID for future fine-tuning or analytics.

### Changes
**Backend:**
- Added  column (nullable, values: `up`/ `down`) to `ChatMessage` model
- New `PATCH /chat/feedback/{message_id}` endpoint with ownership validation and assistant-only check
- Added `FeedbackRequest` schema and `feedback` field to `ChatMessageResponse`
- DB migration for existing databases added to `_migrate_schema()`

**Frontend:**
- Added `feedback?` field to `ChatMsg` type in Zustand store
- Added `patch()` method to API client with auto-refresh support
- Thumbs up/down buttons below each assistant message with:
  - Optimistic UI update (instant feedback)
  - Toggle off on re-click
  - Rollback to previous state on API error
  - Visual highlighting: green for up, red for down

### Testing
- Frontend build passes (`npm run build`)
- Backend model imports correctly

Closes #41