### PR TITLE
feat(ui): add text-to-speech control for AI responses

### DIFF
--- a/frontend/src/components/chat/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble.tsx
@@ -118,6 +118,7 @@ export default function MessageBubble({ message }: Props) {
       return;
     }
 
+    window.speechSynthesis.cancel();
     const utterance = new SpeechSynthesisUtterance(message.content);
     utteranceRef.current = utterance;
 
@@ -192,6 +193,28 @@ export default function MessageBubble({ message }: Props) {
                       <X className="w-3.5 h-3.5 text-destructive" />
                     ) : (
                       <Share2 className="w-3.5 h-3.5" />
+                    )}
+                  </Button>
+                )}
+
+                {/* Speech button */}
+                {!message.isStreaming && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-xs"
+                    className={`absolute top-2 right-16 text-muted-foreground hover:text-foreground transition-opacity ${
+                      isSpeaking
+                        ? "opacity-100"
+                        : "opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto"
+                    }`}
+                    onClick={handleSpeech}
+                    aria-label={isSpeaking ? "Stop reading" : "Read response"}
+                  >
+                    {isSpeaking ? (
+                      <Pause className="w-3.5 h-3.5" />
+                    ) : (
+                      <Play className="w-3.5 h-3.5" />
                     )}
                   </Button>
                 )}


### PR DESCRIPTION
### 🔗 Related Issue
Closes #228

---

## Changes Made

* Added a text-to-speech control to AI response bubbles.
* Connected the control to the existing browser `speechSynthesis` implementation.
* Added play/pause speech controls.
* Cancel any active speech before starting a new utterance to avoid overlapping playback.

## Testing

* Verified frontend runs locally with `npm run dev`.
* Verified linting passes (`npm run lint`), with only a pre-existing project warning unrelated to this change.
* Due to local authentication/setup limitations, I was unable to fully navigate to the chat interface for end-to-end playback testing, but the implementation was verified against the existing message rendering and speech synthesis logic.

