### PR TITLE
feat(api): return bounding box coordinates in chat responses

### DIFF
--- a/backend/app/rag/agent.py
+++ b/backend/app/rag/agent.py
@@ -129,6 +129,7 @@ def generate_answer(
                 "page": chunk["page"],
                 "score": chunk["score"],
                 "confidence": chunk.get("confidence", 0),
+                "bbox": chunk.get("bbox", ""),
             }
             for chunk in getattr(pdf_tool, "last_sources", [])
         ]
@@ -199,6 +200,7 @@ def generate_answer_stream(
                             "page": chunk["page"],
                             "score": chunk["score"],
                             "confidence": chunk.get("confidence", 0),
+                            "bbox": chunk.get("bbox", ""),
                         }
                         for chunk in pdf_tool.last_sources
                     ]

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -164,6 +164,7 @@ class SourceChunk(BaseModel):
     page: int
     score: float
     confidence: float
+    bbox: Optional[str] = None
 
 
 class ChatResponse(BaseModel):


### PR DESCRIPTION
## 📋 PR Checklist

### 🔗 Related Issue

Closes #222

---

### 📝 What does this PR do?

Adds bounding box coordinates to chat API source responses so the frontend can use the coordinates to render document highlights.

Changes include:

* Extending the `SourceChunk` schema with a `bbox` field.
* Forwarding bounding box metadata from retrieved source chunks into chat responses.
* Updating both standard and streaming chat response paths to include bounding box information.

---

### 🗂️ Type of Change

* [ ] 🐛 Bug fix
* [x] ✨ New feature
* [ ] 🔧 Refactor / code cleanup
* [ ] 📝 Documentation update
* [ ] 🎨 UI / styling change
* [ ] ⚙️ CI / tooling / config change
* [ ] 🧪 Tests

---

### 🧪 How was this tested?

* [x] Ran the backend locally (`uvicorn app.main:app --reload`)
* [x] Ran the frontend locally (`npm run dev` inside `frontend/`)
* [x] Tested the affected API endpoints manually
* [ ] Added / updated tests

Additional verification:

* Confirmed bounding box metadata is generated during PDF chunk extraction.
* Verified bounding box metadata is preserved through retrieval and included in chat response source objects.

---

### 📸 Screenshots (if UI change)

N/A

---

### ⚠️ Anything to flag for reviewers?

This change only exposes existing bounding box metadata through the chat API response. No changes were made to the PDF processing or vector retrieval logic.

---

### ✅ Self-Review Checklist

* [x] My branch is based on **`dev`**, not `main`
* [x] I have not added any secrets / API keys
* [x] I have not modified `main` branch or any HuggingFace deployment config
* [x] My code follows the existing style (no unnecessary formatting changes)
* [ ] I have updated relevant docs / comments if needed
