### PR TITLE
fix: validate HF token before initializing clients

### DIFF
--- a/backend/app/rag/agent.py
+++ b/backend/app/rag/agent.py
@@ -6,6 +6,8 @@ import logging
 import json
 from typing import List, Dict, Any, Optional, Generator
 
+from sympy import python
+
 from huggingface_hub import InferenceClient
 from langchain_classic.agents import create_react_agent, AgentExecutor
 from langchain_core.prompts import PromptTemplate
@@ -23,11 +25,18 @@ logger = logging.getLogger(__name__)
 settings = get_settings()
 
 
+
 def get_llm_client(hf_token: Optional[str] = None) -> InferenceClient:
-    """Create a HuggingFace InferenceClient per-request (for simple tasks)."""
-    return InferenceClient(
-        token=hf_token or settings.HF_TOKEN,
-    )
+    """Create a HuggingFace InferenceClient per-request."""
+
+    token = hf_token or settings.HF_TOKEN
+
+    if not token:
+        raise ValueError(
+            "Hugging Face API token is missing. Please configure HF_TOKEN."
+        )
+
+    return InferenceClient(token=token)
 
 
 def get_agent_executor(
@@ -36,14 +45,22 @@ def get_agent_executor(
     hf_token: Optional[str] = None,
 ):
     """Initialize the LangChain ReAct agent executor."""
+
     # Initialize tools
     pdf_tool = PDFSearchTool(user_id=user_id, document_id=document_id)
     tools = [pdf_tool, MathTool(), WebSearchTool()]
 
     # Initialize LLM
+    token = hf_token or settings.HF_TOKEN
+
+    if not token:
+        raise ValueError(
+            "Hugging Face API token is missing. Please configure HF_TOKEN."
+        )
+
     llm = HuggingFaceEndpoint(
         repo_id=settings.LLM_MODEL,
-        huggingfacehub_api_token=hf_token or settings.HF_TOKEN,
+        huggingfacehub_api_token=token,
         max_new_tokens=settings.LLM_MAX_NEW_TOKENS,
         temperature=settings.LLM_TEMPERATURE,
         timeout=300,
@@ -62,7 +79,6 @@ def get_agent_executor(
     )
 
     return executor, pdf_tool
-
 
 def is_greeting(question: str) -> bool:
     """Detect if the question is a casual greeting rather than a document query."""


### PR DESCRIPTION
## Related Issue

Fixes #352

## Description

Added validation checks for the Hugging Face API token before initializing:

* `InferenceClient`
* `HuggingFaceEndpoint`

Previously, if the Hugging Face token was missing or invalid, the backend failed silently and the frontend chat interface showed no response after sending queries.

This fix ensures the application fails gracefully with a clear descriptive error message instead of silently breaking the chat functionality.

## Changes Made

* Added token validation in `get_llm_client()`
* Added token validation in `get_agent_executor()`
* Improved backend error handling for missing HF tokens

## Result

The application now:

* Validates token availability before creating clients
* Prevents silent backend failures
* Returns a readable error message when HF token is missing

## Testing

* Verified that missing tokens now raise descriptive backend errors
* Confirmed no changes to normal token flow behavior
