### PR TITLE
Add relative timestamps to chat message bubbles

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@tailwindcss/typography": "^0.5.19",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "date-fns": "^4.4.0",
         "i18next": "^26.3.0",
         "i18next-browser-languagedetector": "^8.2.1",
         "lucide-react": "^1.8.0",
@@ -4344,6 +4345,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "@tailwindcss/typography": "^0.5.19",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "date-fns": "^4.4.0",
     "i18next": "^26.3.0",
     "i18next-browser-languagedetector": "^8.2.1",
     "lucide-react": "^1.8.0",

--- a/frontend/src/components/chat/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
+import { formatDistanceToNow } from "date-fns";
 import ReactMarkdown, { type Components } from "react-markdown";
 import rehypeHighlight from "rehype-highlight";
 import remarkGfm from "remark-gfm";
@@ -299,9 +300,20 @@ export default function MessageBubble({ message }: Props) {
             )}
           </>
         )}
+        
+         <div
+          className={`text-xs text-muted-foreground mt-2 ${
+            isUser ? "text-right" : "text-left"
+          }`}
+          title={new Date(Number(message.id.split("-")[1])).toLocaleString()}
+        >
+          {formatDistanceToNow(
+            new Date(Number(message.id.split("-")[1])),
+            { addSuffix: true }
+          )}
+        </div>
       </div>
-
-      {isUser && (
+       {isUser && (
         <div className="w-8 h-8 rounded-lg bg-primary/20 flex items-center justify-center shrink-0 mt-0.5">
           <User className="w-4 h-4 text-primary-foreground" />
         </div>


### PR DESCRIPTION
## 📋 PR Checklist

### 🔗 Related Issue

Closes #22

---

### 📝 What does this PR do?

* Added relative timestamps below each chat message bubble
* Added tooltip showing exact datetime on hover
* Used `date-fns` for relative time formatting

---

### 🗂️ Type of Change

* [ ] 🐛 Bug fix
* [x] ✨ New feature
* [ ] 🔧 Refactor / code cleanup
* [ ] 📝 Documentation update
* [x] 🎨 UI / styling change
* [ ] ⚙️ CI / tooling / config change
* [ ] 🧪 Tests

---

### 🧪 How was this tested?

* [ ] Ran the backend locally (`uvicorn app.main:app --reload`)
* [x] Ran the frontend locally (`npm run dev` inside `frontend/`)
* [ ] Tested the affected API endpoints manually
* [ ] Added / updated tests

---

### 📸 Screenshots (if UI change)

UI timestamps added below chat messages.

---

### ⚠️ Anything to flag for reviewers?

No major issues. Backend auth API was not configured locally, so testing was limited to frontend rendering.

---

### ✅ Self-Review Checklist

* [x] My branch is based on **`dev`**, not `main`
* [x] I have not added any secrets / API keys
* [x] I have not modified `main` branch or any HuggingFace deployment config
* [x] My code follows the existing style (no unnecessary formatting changes)
* [ ] I have updated relevant docs / comments if needed

