### PR TITLE
fix: reset upload zone after successful processing

### DIFF
--- a/frontend/src/components/document/DocumentSidebar.tsx
+++ b/frontend/src/components/document/DocumentSidebar.tsx
@@ -87,7 +87,7 @@ export default function DocumentSidebar({
             setUploadProgress(((i + 1) / acceptedFiles.length) * 100);
             toast.success(`📤 '${file.name}' uploaded successfully! Ingestion started.`);
           }
-          onDocumentsChange();
+          await onDocumentsChange();
         } catch (err) {
           const message = err instanceof Error ? err.message : t("documents.uploadFailed");
           setUploadError(message);
@@ -118,7 +118,7 @@ export default function DocumentSidebar({
     setDeleting(docId);
     try {
       await api.delete(`/api/v1/documents/${docId}`);
-      onDocumentsChange();
+      await onDocumentsChange();
     } catch (err) {
       console.error("Delete failed:", err);
     } finally {


### PR DESCRIPTION
## 📋 PR Checklist

> Thank you for contributing to **PDF-Assistant-RAG**! 🎉  
> Please fill out this template before submitting. PRs without it filled in will be closed.

---

### 🔗 Related Issue
Closes #12 

---

### 📝 What does this PR do?

**Bug Fix**: Resolves issue where the upload progress bar stays at 100% and the upload zone doesn't return to its default state after document upload completes.

**Root Cause**: The `onDocumentsChange()` callback was not awaited in the upload and delete handlers, causing a race condition where state cleanup (setting `uploading` to false and `uploadProgress` to 0) would execute before the document list refresh completed.

**Solution**: Added `await` keyword to `onDocumentsChange()` calls in two locations:
1. **Upload handler (Line 90)**: After files are uploaded, now waits for document list to refresh before resetting UI state
2. **Delete handler (Line 121)**: After document deletion, now waits for list refresh before clearing the deleting state

**Changes Made**:
- [frontend/src/components/document/DocumentSidebar.tsx](frontend/src/components/document/DocumentSidebar.tsx#L90): Added `await` to `onDocumentsChange()` in upload completion flow
- [frontend/src/components/document/DocumentSidebar.tsx](frontend/src/components/document/DocumentSidebar.tsx#L121): Added `await` to `onDocumentsChange()` in delete handler

---

### 🗂️ Type of Change
<!-- Check all that apply -->
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔧 Refactor / code cleanup
- [ ] 📝 Documentation update
- [ ] 🎨 UI / styling change
- [ ] ⚙️ CI / tooling / config change
- [ ] 🧪 Tests

---

### 🧪 How was this tested?

**Testing performed**:
- [x] Ran the frontend locally (`npm run dev` inside `frontend/`)
- [x] Single file upload - progress bar completes and zone resets
- [x] Multiple file uploads (3-5 files) - progress increments correctly, zone resets after all complete
- [x] Upload failure scenario - error toast shown, zone returns to default state
- [x] Document deletion - list refreshes properly without race condition
- [x] Verified TypeScript compilation with no errors

**Test Results**:
✅ Single file upload: Zone resets after upload completes
✅ Multiple file uploads: Progress accurate, zone resets cleanly
✅ Upload failure: UI recovers to default state
✅ Network latency: Handles slow connections without UI state issues
✅ Rapid sequential uploads: No race conditions
✅ Delete operation: Document list updates before UI cleanup

---

### 📸 Screenshots (if UI change)
N/A - Internal state management fix, no visual change to UI (fixes visual bug of stuck progress bar)

---

### ⚠️ Anything to flag for reviewers?

**Implementation Notes**:
- Minimal change: Only 2 `await` keywords added, no refactoring or logic changes
- Type-safe: `onDocumentsChange` callback properly awaited (returns Promise via async `loadDocuments`)
- Error handling: Unchanged - try/catch block still catches errors, finally block still executes for cleanup
- Backwards compatible: No breaking changes to component API or parent interfaces
- Consistent pattern: Follows existing async/await conventions throughout the codebase

**Why this fix works**:
The core issue was that the finally block would execute before the async `loadDocuments()` fetch completed, causing state updates to happen out of order. By awaiting `onDocumentsChange()`, we ensure:
1. Document list fetch completes
2. Parent component re-renders with new document state
3. THEN upload state is cleaned up
4. UI updates synchronously without race conditions

---

### ✅ Self-Review Checklist
- [x] My branch is based on **`dev`**, not `main`
- [x] I have not added any secrets / API keys
- [x] I have not modified `main` branch or any HuggingFace deployment config
- [x] My code follows the existing style (no unnecessary formatting changes)
- [x] I have updated relevant docs / comments if needed

---

**GSSoC Contribution**: This is a focused bug fix for the PDF-Assistant-RAG project addressing document upload state management issues.