### PR TITLE
fix: handle RequestValidationError globally to return 422 instead of …

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,7 +6,8 @@ import os
 import logging
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse, JSONResponse
@@ -75,6 +76,28 @@ app.add_exception_handler(
         content={"detail": "Rate limit exceeded. Please try again later."},
     ),
 )
+
+@app.exception_handler(RequestValidationError)
+async def validation_exception_handler(request: Request, exc: RequestValidationError):
+    def _sanitize_error(err):
+        if isinstance(err, dict):
+            sanitized = {}
+            for k, v in err.items():
+                if k == "ctx" and isinstance(v, dict) and "error" in v:
+                    ctx_error = v.get("error")
+                    if isinstance(ctx_error, Exception):
+                        v = {**v, "error": str(ctx_error)}
+                sanitized[k] = _sanitize_error(v)
+            return sanitized
+        if isinstance(err, list):
+            return [_sanitize_error(i) for i in err]
+        return err
+
+    return JSONResponse(
+        status_code=422,
+        content={"detail": [_sanitize_error(e) for e in exc.errors()]},
+    )
+
 app.add_middleware(SlowAPIMiddleware)
 
 # ── CORS (allow frontend dev server) ─────────────────


### PR DESCRIPTION
## 📋 PR Checklist

> Thank you for contributing to **PDF-Assistant-RAG**! 🎉  
> Please fill out this template before submitting. PRs without it filled in will be closed.

---

### 🔗 Related Issue
Closes #18

---

### 📝 What does this PR do?
Implemented a global exception handler for `RequestValidationError` in `app/main.py`. This ensures that when required fields (like `question`) are missing from the payload, the FastAPI application gracefully intercepts the error and correctly responds with a structured `422 Unprocessable Entity` containing field-level error details, instead of crashing into a generic `500 Internal Server Error`.

---

### 🗂️ Type of Change
<!-- Check all that apply -->
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔧 Refactor / code cleanup
- [ ] 📝 Documentation update
- [ ] 🎨 UI / styling change
- [ ] ⚙️ CI / tooling / config change
- [ ] 🧪 Tests

---

### 🧪 How was this tested?
<!-- Describe how you verified your changes work. -->
- [x] Ran the backend locally (`uvicorn app.main:app --reload`)
- [ ] Ran the frontend locally (`npm run dev` inside `frontend/`)
- [x] Tested the affected API endpoints manually (Verified via cURL that empty payloads return 422)
- [ ] Added / updated tests

---

### 📸 Screenshots (if UI change)
*N/A - Backend API Response fix only.*
<img width="1167" height="429" alt="Screenshot 2026-06-04 191114" src="https://github.com/user-attachments/assets/18d39c98-beef-413e-a9f4-32e1ace32618" />


---

### ⚠️ Anything to flag for reviewers?
This is a standard FastAPI exception handler override. No breaking changes introduced. 

---

### ✅ Self-Review Checklist
- [x] My branch is based on **`dev`**, not `main`
- [x] I have not added any secrets / API keys
- [x] I have not modified `main` branch or any HuggingFace deployment config
- [x] My code follows the existing style (no unnecessary formatting changes)
- [x] I have updated relevant docs / comments if needed