### PR TITLE
chore(docker): add CPU and GPU compose profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,8 +590,13 @@ Pass `--document-id <document-id>` to evaluate one indexed document.
 
 | Command | Description |
 |---------|-------------|
-| `docker compose up --build` | Build and start the full stack |
+| `docker compose --profile cpu up --build` | Build and start the full stack (CPU-only, no GPU required) |
+| `docker compose --profile gpu up --build` | Build and start the full stack with NVIDIA GPU acceleration |
+| `docker compose --profile debug up` | Also start pgAdmin at http://localhost:5050 |
 | `docker compose down` | Stop all containers |
+
+> **CPU profile** — works on any machine. Embeddings run on CPU via `all-MiniLM-L6-v2`.  
+> **GPU profile** — requires [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html). Sets `DEVICE=cuda` for accelerated embedding inference.
 
 <br/>
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,10 +36,11 @@ services:
       retries: 5
       start_period: 10s
 
-  # ── Application ──────────────────────────────────────────
+  # ── Application (CPU profile) ────────────────────────────
   app:
     build: .
     container_name: pdf_rag_app
+    profiles: ["cpu"]
     ports:
       - "7860:7860"
     volumes:
@@ -53,6 +54,7 @@ services:
       - GRAPH_PERSIST_DIR=/app/data/graphs
       - CELERY_BROKER_URL=redis://redis:6379/0
       - CELERY_RESULT_BACKEND=redis://redis:6379/1
+      - DEVICE=cpu
     depends_on:
       postgres:
         condition: service_healthy
@@ -66,10 +68,50 @@ services:
       retries: 3
       start_period: 60s
 
-  # Celery worker for document extraction, chunking, embeddings, and vector storage
+  # ── Application (GPU profile) ────────────────────────────
+  app-gpu:
+    build: .
+    container_name: pdf_rag_app
+    profiles: ["gpu"]
+    ports:
+      - "7860:7860"
+    volumes:
+      - app_data:/app/data
+    environment:
+      - SECRET_KEY=${SECRET_KEY:-dev-secret-key-change-me}
+      - HF_TOKEN=${HF_TOKEN}
+      - DATABASE_URL=postgresql://${POSTGRES_USER:-pdf_rag_user}:${POSTGRES_PASSWORD:-pdf_rag_pass}@postgres:5432/${POSTGRES_DB:-pdf_rag}
+      - UPLOAD_DIR=/app/data/uploads
+      - CHROMA_PERSIST_DIR=/app/data/chroma_db
+      - GRAPH_PERSIST_DIR=/app/data/graphs
+      - CELERY_BROKER_URL=redis://redis:6379/0
+      - CELERY_RESULT_BACKEND=redis://redis:6379/1
+      - DEVICE=cuda
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:7860/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
+  # Celery worker (CPU profile)
   worker:
     build: .
     container_name: pdf_rag_worker
+    profiles: ["cpu"]
     command: >
       sh -c "cd /app/backend &&
       celery -A app.celery_app.celery_app worker --loglevel=info"
@@ -84,6 +126,41 @@ services:
       - GRAPH_PERSIST_DIR=/app/data/graphs
       - CELERY_BROKER_URL=redis://redis:6379/0
       - CELERY_RESULT_BACKEND=redis://redis:6379/1
+      - DEVICE=cpu
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    restart: unless-stopped
+
+  # Celery worker (GPU profile)
+  worker-gpu:
+    build: .
+    container_name: pdf_rag_worker
+    profiles: ["gpu"]
+    command: >
+      sh -c "cd /app/backend &&
+             celery -A app.celery_app.celery_app worker --loglevel=info"
+    volumes:
+      - app_data:/app/data
+    environment:
+      - SECRET_KEY=${SECRET_KEY:-dev-secret-key-change-me}
+      - HF_TOKEN=${HF_TOKEN}
+      - DATABASE_URL=postgresql://${POSTGRES_USER:-pdf_rag_user}:${POSTGRES_PASSWORD:-pdf_rag_pass}@postgres:5432/${POSTGRES_DB:-pdf_rag}
+      - UPLOAD_DIR=/app/data/uploads
+      - CHROMA_PERSIST_DIR=/app/data/chroma_db
+      - GRAPH_PERSIST_DIR=/app/data/graphs
+      - CELERY_BROKER_URL=redis://redis:6379/0
+      - CELERY_RESULT_BACKEND=redis://redis:6379/1
+      - DEVICE=cuda
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
### 🔗 Related Issue
Closes #456

---

### 📝 What does this PR do?
Adds `cpu` and `gpu` Docker Compose profiles so contributors without a local GPU can spin up
the full RAG stack using CPU-only inference, while GPU users get NVIDIA-accelerated embeddings.

- Splits `app` and `worker` into two named service variants each (`app` / `app-gpu`,
  `worker` / `worker-gpu`) assigned to their respective profiles
- Infrastructure services (`redis`, `postgres`) remain profile-less and always start
- Passes a `DEVICE` env var (`cpu` or `cuda`) to each variant for device-aware inference
- Preserves the existing `debug` profile on `pgadmin` untouched
- Updates the README Docker section with `--profile cpu` / `--profile gpu` usage and a link
  to the NVIDIA Container Toolkit for GPU setup

---

### 🗂️ Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔧 Refactor / code cleanup
- [ ] 📝 Documentation update
- [ ] 🎨 UI / styling change
- [x] ⚙️ CI / tooling / config change
- [ ] 🧪 Tests

---

### 🧪 How was this tested?
- [x] Ran `docker compose --profile cpu up --build` — all services started, app healthy at
      `http://localhost:7860/api/health`
- [x] Confirmed `redis` and `postgres` start without a profile flag (infrastructure-only run)
- [x] Verified `app-gpu` and `worker-gpu` services do **not** start under `--profile cpu`
      and vice versa (correct profile isolation)
- [x] Confirmed the existing `--profile debug` still brings up `pgadmin` at port 5050
- [ ] Ran the backend locally (`uvicorn app.main:app --reload`)
- [ ] Ran the frontend locally (`npm run dev` inside `frontend/`)
- [ ] Tested the affected API endpoints manually
- [ ] Added / updated tests

---

### 📸 Screenshots (if UI change)
N/A — config-only change, no UI affected.

---

### ✅ Self-Review Checklist
- [x] My branch is based on **`dev`**, not `main`
- [x] I have not added any secrets / API keys
- [x] I have not modified `main` branch or any HuggingFace deployment config
- [x] My code follows the existing style (no unnecessary formatting changes)
- [x] I have updated relevant docs / comments if needed