### PR TITLE
fix(bm25): resolve ineffective whitespace tokenization in keyword search

### DIFF
--- a/backend/app/rag/bm25.py
+++ b/backend/app/rag/bm25.py
@@ -6,6 +6,7 @@ import os
 import glob
 import pickle
 import logging
+import re
 from typing import List, Dict, Any, Optional
 
 from app.config import get_settings
@@ -30,9 +31,8 @@ def get_bm25_path(user_id: str, document_id: str) -> str:
     return os.path.join(get_bm25_dir(user_id), f"{document_id}.pkl")
 
 def tokenize(text: str) -> List[str]:
-    """Simple tokenization for BM25."""
-    # Convert to lowercase and split by whitespace
-    return text.lower().split()
+    """Tokenize by converting to lowercase and extracting all alphanumeric words."""
+    return re.findall(r'\w+', text.lower())
 
 def store_bm25_index(chunks: List[Dict[str, Any]], document_id: str, filename: str, user_id: str):
     """

--- a/backend/tests/test_bm25.py
+++ b/backend/tests/test_bm25.py
@@ -1,0 +1,50 @@
+import pytest
+import os
+from app.rag import bm25
+
+def test_tokenize():
+    # Test that punctuation is stripped and tokens are lowercased
+    text = "This is a document."
+    assert bm25.tokenize(text) == ["this", "is", "a", "document"]
+
+    text_qwen = "The model used is Qwen."
+    assert bm25.tokenize(text_qwen) == ["the", "model", "used", "is", "qwen"]
+
+    text_mixed = "BM25 keyword-search module, testing!"
+    assert bm25.tokenize(text_mixed) == ["bm25", "keyword", "search", "module", "testing"]
+
+def test_store_and_query_bm25(tmp_path, monkeypatch):
+    # Mock settings.CHROMA_PERSIST_DIR to use the temp path
+    monkeypatch.setattr(bm25.settings, "CHROMA_PERSIST_DIR", str(tmp_path))
+
+    user_id = "test-user-123"
+    doc_id = "test-doc-abc"
+    chunks = [
+        {"text": "The model used is Qwen.", "page": 1},
+        {"text": "BM25 retrieval performs keyword search.", "page": 2},
+        {"text": "This is a completely unrelated third document chunk.", "page": 3},
+    ]
+
+    # Store index
+    bm25.store_bm25_index(chunks, doc_id, "test.pdf", user_id)
+
+    # Check that the index file was created
+    expected_path = bm25.get_bm25_path(user_id, doc_id)
+    assert os.path.exists(expected_path)
+
+    # Query with exact word (originally failed because of punctuation)
+    # The first chunk has "Qwen." (with period), query is "qwen"
+    results = bm25.query_bm25("qwen", user_id, doc_id, top_k=1)
+    assert len(results) == 1
+    assert "Qwen" in results[0]["text"]
+    assert results[0]["page"] == 1
+
+    # Query all indexes for user
+    results_all = bm25.query_bm25("keyword", user_id, top_k=2)
+    assert len(results_all) == 1
+    assert "BM25 retrieval" in results_all[0]["text"]
+    assert results_all[0]["page"] == 2
+
+    # Delete index
+    bm25.delete_bm25_index(doc_id, user_id)
+    assert not os.path.exists(expected_path)

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,9 @@
+{
+  "exclude": [
+    "**/node_modules",
+    "**/__pycache__"
+  ],
+  "extraPaths": [
+    "backend"
+  ]
+}


### PR DESCRIPTION
### Related Issue
Closes #401 

---

### What does this PR do?
This PR resolves the issue where trailing/leading punctuation attached to words in document chunks broke BM25 lexical keyword matching (e.g., query `"qwen"` failed to match `"qwen."` exact string).

- **BM25 Tokenization Refactoring**: Replaced the basic whitespace split with `re.findall(r'\w+', text.lower())` in `backend/app/rag/bm25.py` to extract clean alphanumeric tokens.
- **Unit Tests**: Added [test_bm25.py](file:///d:/Ongoing_projects/PDF-Assistant-RAG/backend/tests/test_bm25.py) to cover tokenization behavior and verify the store-query-delete pipeline on a mock document collection.
- **Language Server / IDE Config**: Created `pyrightconfig.json` to configure Pylance/Pyright search paths, clearing IDE warnings about `app` import resolution.

---

### Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔧 Refactor / code cleanup
- [ ] 📝 Documentation update
- [ ] 🎨 UI / styling change
- [x] ⚙️ CI / tooling / config change
- [x] 🧪 Tests

---

### How was this tested?
- [x] Added / updated tests
  - Ran the unit tests specifically with: `python -m pytest --noconftest tests/test_bm25.py`

---

### Screenshots
*Not applicable (Backend logic fix).*

---

### Anything to flag for reviewers?
*None.*

---

### Self-Review Checklist
- [x] My branch is based on **`dev`**, not `main`
- [x] I have not added any secrets / API keys
- [x] I have not modified `main` branch or any HuggingFace deployment config
- [x] My code follows the existing style (no unnecessary formatting changes)
- [x] I have updated relevant docs / comments if needed
