### PR TITLE
devops: add Dependabot update schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "pip"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "pip"
+    directory: "/bots/discord"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary

- add `.github/dependabot.yml` for weekly dependency update PRs
- cover the root Python app, backend Python app, Discord bot Python app, frontend npm app, and GitHub Actions workflows

Fixes #57

## Root Cause

The repository has multiple dependency manifests but no Dependabot configuration, so Python, npm, and workflow dependency updates are not automatically surfaced as reviewable PRs.

## Changes Made

- configured weekly `pip` updates for `/`, `/backend`, and `/bots/discord`
- configured weekly `npm` updates for `/frontend`
- configured weekly `github-actions` updates for repository workflows
- capped open Dependabot PRs per ecosystem entry to keep update noise manageable

## Testing

- parsed `.github/dependabot.yml` with Ruby YAML and verified all 5 update groups are present
- `git diff --cached --check`

## Impact

Maintainers will receive regular, scoped dependency update PRs for each active package ecosystem without manual scanning.
