### PR TITLE
fix: prevent layout overlap on screens narrower than 375px

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -217,7 +217,8 @@ export default function DashboardPage() {
         <ChatSessionSidebar />
 
         {/* ── Center: Chat Panel ──────────────────────────────────── */}
-        <div className="flex-1 min-w-0 flex flex-col">
+        
+        <div className="flex-1 min-w-0 w-full flex flex-col overflow-hidden">
           <ChatPanel
             activeDoc={activeDoc}
             onCitationClick={(target) => {

--- a/frontend/src/components/chat/ChatSessionSidebar.tsx
+++ b/frontend/src/components/chat/ChatSessionSidebar.tsx
@@ -237,7 +237,7 @@ export default function ChatSessionSidebar() {
 
       <Button
         onClick={() => setMobileOpen(true)}
-        className="fixed bottom-4 left-4 z-30 h-11 w-11 rounded-full shadow-lg md:hidden"
+        className="fixed bottom-4 left-2 z-30 h-10 w-10 rounded-full shadow-lg md:hidden"
         size="icon"
         aria-label="Open chat sessions"
         aria-controls="mobile-chat-sessions"


### PR DESCRIPTION
## 📋 PR Checklist

> Thank you for contributing to **PDF-Assistant-RAG**! 🎉  
> Please fill out this template before submitting. PRs without it filled in will be closed.

---

### 🔗 Related Issue
Closes #17

---

### 📝 What does this PR do?
Added w-full and overflow-hidden to the chat panel container in dashboard/page.tsx to prevent layout overflow on screens narrower than 375px. Also reduced the mobile sidebar toggle button size and adjusted its position in ChatSessionSidebar.tsx to prevent clipping on very small screens like iPhone SE.

---

### 🗂️ Type of Change
<!-- Check all that apply -->
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔧 Refactor / code cleanup
- [ ] 📝 Documentation update
- [x] 🎨 UI / styling change
- [ ] ⚙️ CI / tooling / config change
- [ ] 🧪 Tests

---

### 🧪 How was this tested?
Tested at 375×667 viewport (iPhone SE) via browser DevTools. Confirmed no layout overflow at narrow widths.
- [ ] Ran the backend locally (`uvicorn app.main:app --reload`)
- [x] Ran the frontend locally (`npm run dev` inside `frontend/`)
- [ ] Tested the affected API endpoints manually
- [ ] Added / updated tests


---

### 📸 Screenshots (if UI change)
<img width="1302" height="610" alt="Screenshot 2026-06-06 183706" src="https://github.com/user-attachments/assets/7c051d39-1e7d-4302-aebe-c35d4471cb34" />


---

### ⚠️ Anything to flag for reviewers?
<!-- Anything tricky, uncertain, or worth discussing? -->

---

### ✅ Self-Review Checklist
- [x] My branch is based on **`dev`**, not `main`
- [x] I have not added any secrets / API keys
- [x] I have not modified `main` branch or any HuggingFace deployment config
- [x] My code follows the existing style (no unnecessary formatting changes)
- [ ] I have updated relevant docs / comments if needed
