### PR TITLE
fix: Add chat sessions mock to Playwright E2E tests to prevent CI failures

### DIFF
--- a/frontend/e2e/auth-and-chat.spec.ts
+++ b/frontend/e2e/auth-and-chat.spec.ts
@@ -47,6 +47,12 @@ async function mockDashboardApis(page: Page, documents: typeof uploadedDocument[
       },
     });
   });
+
+  await page.route("**/api/v1/chat/sessions", async (route) => {
+    await route.fulfill({
+      json: [],
+    });
+  });
 }
 
 test("logs in with email and password", async ({ page }) => {
@@ -130,7 +136,6 @@ test("uploads a PDF document and chats with it", async ({ page }) => {
 
   await page.goto("/dashboard");
   
-  // Upload as a PDF
   await page.locator('input[type="file"]').setInputFiles({
     name: "test.pdf",
     mimeType: "application/pdf",
@@ -172,12 +177,9 @@ test("deletes a document successfully", async ({ page }) => {
   const documentButton = page.getByRole("button", { name: /test\.pdf/ });
   await expect(documentButton).toBeVisible();
   
-  // Handle confirm dialog (must be registered BEFORE click)
   page.on('dialog', dialog => dialog.accept());
 
-  // Delete the document
   await documentButton.hover();
-  // Find the button with Trash2 icon
   await page.locator('button.shrink-0:has(svg.lucide-trash2)').click();
 
   await expect(page.getByText("No documents yet")).toBeVisible();


### PR DESCRIPTION
## 🔗 Related Issue
Closes #496

---

## 📝 What does this PR do?
The Playwright E2E test `logs in with email and password was consistently failing in CI because the dashboard tries to fetch chat sessions on load, but no mock existed for this API endpoint. Since the backend is unavailable in CI, the request returned "Not Found", causing the dashboard to crash and never redirect to `/dashboard`.

This PR adds a missing mock for `GET /api/v1/chat/sessions` inside the `mockDashboardApis` helper function so all tests run independently of the backend.

**Root cause:**
Dashboard loads → fetches /api/v1/chat/sessions
→ No backend in CI → "Not Found" error
→ Dashboard crashes → redirect never happens
→ Test fails ❌


**Fix:**
```typescript
await page.route("**/api/v1/chat/sessions", async (route) => {
  await route.fulfill({
    json: [],
  });
});
```

---

## 🗂️ Type of Change
- [x] 🐛 Bug fix
- [x] 🧪 Tests
- [x] ⚙️ CI / tooling / config change

---

## 🧪 How was this tested?
- [x] Added / updated tests
- Verified same test was failing on `dev` branch:
  https://github.com/param20h/PDF-Assistant-RAG/actions/runs/27055704867/job/79859570701
- Fix adds missing mock → test passes without backend ✅

---

## ⚠️ Anything to flag for reviewers?
This fix also unblocks the following PR which were showing this same pre-existing CI failure:
- PR #495 — OAuth error handling page
Once this PR is merged, all CI checks on those PRs will pass cleanly. 
---

## ✅ Self-Review Checklist
- [x] My branch is based on **`dev`**, not `main`
- [x] I have not added any secrets / API keys
- [x] I have not modified `main` branch or any HuggingFace deployment config
- [x] My code follows the existing style
- [x] No unnecessary formatting changes

