### PR TITLE
fix: add processing pipeline resilience with retry, progress tracking

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+relative_files = True

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -50,6 +50,12 @@ class Settings(BaseSettings):
     CELERY_RESULT_BACKEND: str = "redis://localhost:6379/1"
     CELERY_TASK_TRACK_STARTED: bool = True
 
+    # ── Document Processing ──────────────────────────────
+    DOC_PROCESSING_TIMEOUT_MINUTES: int = 30
+    DOC_PROCESSING_MAX_RETRIES: int = 3
+    DOC_PROCESSING_RETRY_DELAY_SECONDS: int = 30
+    DOC_CLEANUP_MAX_AGE_DAYS: int = 90
+
     # ── File Upload ──────────────────────────────────────
     UPLOAD_DIR: str = "./data/uploads"
     MAX_UPLOAD_SIZE_MB: int = 50

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -4,6 +4,7 @@ Uses synchronous SQLAlchemy for simplicity and compatibility.
 """
 import os
 import logging
+from contextlib import contextmanager
 from sqlalchemy import create_engine, inspect, text
 from sqlalchemy.orm import sessionmaker, declarative_base
 from app.config import get_settings
@@ -44,6 +45,24 @@ def get_db():
         yield db
     finally:
         db.close()
+
+
+@contextmanager
+def get_db_session():
+    """Sync context manager for background tasks and streaming.
+
+    Creates a new session, commits on success, rolls back on error,
+    and always closes. Safe to use outside FastAPI's DI lifecycle.
+    """
+    session = SessionLocal()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
 
 
 def _migrate_schema():

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -254,6 +254,12 @@ class Document(Base):
     drive_synced_at = Column(DateTime, nullable=True)
     is_deleted = Column(Boolean, default=False, nullable=False, index=True)
     deleted_at = Column(DateTime, nullable=True)
+    processing_progress = Column(Integer, default=0)
+    processing_stage = Column(String(20), default="queued")
+    retry_count = Column(Integer, default=0)
+    last_error_traceback = Column(Text, nullable=True)
+    processing_started_at = Column(DateTime, nullable=True)
+    completed_at = Column(DateTime, nullable=True)
 
     # Relationships
     owner = relationship("User", back_populates="documents")

--- a/backend/app/routes/chat.py
+++ b/backend/app/routes/chat.py
@@ -126,7 +126,14 @@ async def chat_ws(websocket: WebSocket, token: Optional[str] = Query(None)):
                 await websocket.close()
                 return
             if doc.status != "ready":
-                await websocket.send_json({"type": "error", "data": f"Document is still {doc.status}."})
+                progress = getattr(doc, "processing_progress", None)
+                stage = getattr(doc, "processing_stage", None)
+                detail = f"Document is still {doc.status}."
+                if progress is not None:
+                    detail += f" Progress: {progress}%"
+                if stage:
+                    detail += f" Stage: {stage}"
+                await websocket.send_json({"type": "error", "data": detail})
                 await websocket.close()
                 return
 
@@ -505,9 +512,16 @@ def ask_question(
                 raise HTTPException(status_code=404, detail="Document not found")
 
             if doc.status != "ready":
+                progress = getattr(doc, "processing_progress", None)
+                stage = getattr(doc, "processing_stage", None)
+                detail = f"Document is still {doc.status}. Please wait for processing to complete."
+                if progress is not None:
+                    detail += f" Progress: {progress}%"
+                if stage:
+                    detail += f" Stage: {stage}"
                 raise HTTPException(
                     status_code=400,
-                    detail=f"Document is still {doc.status}. Please wait for processing to complete.",
+                    detail=detail,
                 )
 
             # Update last_accessed_at timestamp
@@ -620,9 +634,16 @@ def ask_question_stream(
             raise HTTPException(status_code=404, detail="Document not found")
 
         if doc.status != "ready":
+            progress = getattr(doc, "processing_progress", None)
+            stage = getattr(doc, "processing_stage", None)
+            detail = f"Document is still {doc.status}. Please wait for processing to complete."
+            if progress is not None:
+                detail += f" Progress: {progress}%"
+            if stage:
+                detail += f" Stage: {stage}"
             raise HTTPException(
                 status_code=400,
-                detail=f"Document is still {doc.status}. Please wait for processing to complete.",
+                detail=detail,
             )
 
         # Update last_accessed_at timestamp

--- a/backend/app/routes/documents.py
+++ b/backend/app/routes/documents.py
@@ -710,3 +710,63 @@ def update_chunk_settings(
 
     # Return the updated document record with new chunk settings
     return DocumentResponse.model_validate(doc).model_copy(update={"task_id": task_id})
+
+
+@router.post("/{document_id}/retry", response_model=DocumentResponse)
+def retry_document_processing(
+    document_id: str,
+    background_tasks: BackgroundTasks = None,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Retry processing for a failed document.
+
+    Resets the document status back to 'pending', clears error fields,
+    and re-queues the document for ingestion.
+    """
+    doc = db.query(Document).filter(
+        Document.id == document_id,
+        Document.user_id == user.id,
+        Document.is_deleted.is_(False),
+    ).first()
+
+    if not doc:
+        raise HTTPException(status_code=404, detail="Document not found")
+
+    if doc.status != "failed":
+        raise HTTPException(status_code=400, detail="Only failed documents can be retried")
+
+    doc.status = "pending"
+    doc.processing_progress = 0
+    doc.processing_stage = "queued"
+    doc.error_message = None
+    doc.last_error_traceback = None
+    doc.completed_at = None
+    doc.chunk_count = 0
+    doc.page_count = 0
+    db.commit()
+
+    # Re-queue ingestion
+    filepath = os.path.join(settings.UPLOAD_DIR, user.id, doc.filename)
+    task_id = None
+    try:
+        task = process_document.delay(
+            document_id=doc.id,
+            filepath=filepath,
+            original_name=doc.original_name,
+            user_id=user.id,
+        )
+        task_id = task.id
+    except Exception as e:
+        logger.warning(f"Celery queue failed for retry, falling back to background task: {e}")
+        if background_tasks:
+            background_tasks.add_task(
+                ingest_document,
+                document_id=doc.id,
+                filepath=filepath,
+                original_name=doc.original_name,
+                user_id=user.id,
+            )
+        task_id = f"local_{uuid.uuid4().hex}"
+
+    return DocumentResponse.model_validate(doc).model_copy(update={"task_id": task_id})

--- a/backend/app/scheduler.py
+++ b/backend/app/scheduler.py
@@ -44,6 +44,36 @@ def start_scheduler():
     else:
         logger.info("Drive PDF sync disabled")
 
+    # Document processing recovery — every 5 minutes
+    try:
+        from app.services.cleanup import cleanup_stale_documents, cleanup_old_deleted_documents
+
+        _scheduler.add_job(
+            cleanup_stale_documents,
+            trigger=IntervalTrigger(minutes=5),
+            id="recover_stale_processing",
+            name="Recover documents stuck in processing",
+            replace_existing=True,
+            max_instances=1,
+            coalesce=True,
+            misfire_grace_time=60,
+        )
+        logger.info("Stale document recovery scheduled every 5 minutes")
+
+        _scheduler.add_job(
+            cleanup_old_deleted_documents,
+            trigger=IntervalTrigger(days=1),
+            id="cleanup_old_deleted",
+            name="Purge old soft-deleted documents",
+            replace_existing=True,
+            max_instances=1,
+            coalesce=True,
+            misfire_grace_time=300,
+        )
+        logger.info("Old deleted document cleanup scheduled daily")
+    except Exception as e:
+        logger.warning("Could not schedule cleanup jobs: %s", e)
+
     _scheduler.start()
     return _scheduler
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -183,6 +183,12 @@ class DocumentStatusResponse(BaseModel):
     page_count: int
     chunk_count: int
     error_message: Optional[str] = None
+    processing_progress: Optional[int] = None
+    processing_stage: Optional[str] = None
+    retry_count: Optional[int] = None
+    last_error_traceback: Optional[str] = None
+    processing_started_at: Optional[datetime] = None
+    completed_at: Optional[datetime] = None
 
     class Config:
         from_attributes = True

--- a/backend/app/services/cleanup.py
+++ b/backend/app/services/cleanup.py
@@ -1,0 +1,88 @@
+"""Background cleanup jobs for stale and deleted documents."""
+import logging
+from datetime import datetime, timedelta, timezone
+
+from app.database import get_db_session
+from app.config import get_settings
+from app.models import Document
+
+logger = logging.getLogger(__name__)
+settings = get_settings()
+
+
+def cleanup_stale_documents():
+    """Mark documents stuck in 'processing' beyond the timeout as failed."""
+    timeout_minutes = settings.DOC_PROCESSING_TIMEOUT_MINUTES
+    cutoff = datetime.now(timezone.utc) - timedelta(minutes=timeout_minutes)
+
+    with get_db_session() as db:
+        stale = (
+            db.query(Document)
+            .filter(
+                Document.status == "processing",
+                Document.processing_started_at.isnot(None),
+                Document.processing_started_at < cutoff,
+                Document.is_deleted.is_(False),
+            )
+            .all()
+        )
+
+        for doc in stale:
+            logger.warning(
+                "Recovering stale document %s (stuck at '%s' since %s)",
+                doc.id,
+                doc.processing_stage,
+                doc.processing_started_at,
+            )
+            doc.status = "failed"
+            doc.processing_progress = 0
+            doc.error_message = f"Processing timed out after {timeout_minutes} minutes"
+            doc.last_error_traceback = "Timed out: no progress update received within the configured timeout window."
+
+        if stale:
+            logger.info("Marked %d stale document(s) as failed", len(stale))
+
+
+def cleanup_old_deleted_documents():
+    """Permanently delete documents soft-deleted beyond the max age."""
+    max_age_days = settings.DOC_CLEANUP_MAX_AGE_DAYS
+    cutoff = datetime.now(timezone.utc) - timedelta(days=max_age_days)
+
+    with get_db_session() as db:
+        old = (
+            db.query(Document)
+            .filter(
+                Document.is_deleted.is_(True),
+                Document.deleted_at.isnot(None),
+                Document.deleted_at < cutoff,
+            )
+            .all()
+        )
+
+        for doc in old:
+            logger.info(
+                "Purging old deleted document %s ('%s', deleted %s)",
+                doc.id,
+                doc.original_name,
+                doc.deleted_at,
+            )
+            try:
+                from app.rag.vectorstore import delete_document_chunks
+
+                delete_document_chunks(document_id=doc.id, user_id=doc.user_id)
+            except Exception as e:
+                logger.warning("Error cleaning vectors for %s: %s", doc.id, e)
+
+            try:
+                import os
+
+                filepath = os.path.join(settings.UPLOAD_DIR, doc.user_id, doc.filename)
+                if os.path.exists(filepath):
+                    os.remove(filepath)
+            except Exception as e:
+                logger.warning("Error deleting file for %s: %s", doc.id, e)
+
+            db.delete(doc)
+
+        if old:
+            logger.info("Permanently deleted %d old document(s)", len(old))

--- a/backend/app/services/document_ingestion.py
+++ b/backend/app/services/document_ingestion.py
@@ -1,11 +1,34 @@
 """Reusable document ingestion pipeline."""
+import traceback
 import logging
+from datetime import datetime, timezone
 
 from app.models import Document
 from app.rag.chunker import chunk_document, get_page_count
 from app.rag.vectorstore import store_chunks
+from app.config import get_settings
 
 logger = logging.getLogger(__name__)
+settings = get_settings()
+
+
+def _update_progress(document_id: str, progress: int, stage: str, error: str = None):
+    """Update document progress fields in the database."""
+    from app.database import SessionLocal
+
+    db = SessionLocal()
+    try:
+        doc = db.query(Document).filter(Document.id == document_id).first()
+        if doc:
+            doc.processing_progress = progress
+            doc.processing_stage = stage
+            if error:
+                doc.error_message = error
+            db.commit()
+    except Exception as e:
+        logger.warning("Failed to update progress for %s: %s", document_id, e)
+    finally:
+        db.close()
 
 
 def ingest_document(document_id: str, filepath: str, original_name: str, user_id: str):
@@ -26,11 +49,16 @@ def ingest_document(document_id: str, filepath: str, original_name: str, user_id
             return
 
         doc.status = "processing"
+        doc.processing_stage = "extracting"
+        doc.processing_progress = 10
         doc.error_message = None
+        doc.last_error_traceback = None
         db.commit()
 
         page_count = get_page_count(filepath)
         doc.page_count = page_count
+        doc.processing_progress = 20
+        db.commit()
 
         try:
             chunk_kwargs = {}
@@ -38,16 +66,23 @@ def ingest_document(document_id: str, filepath: str, original_name: str, user_id
                 chunk_kwargs["chunk_size"] = doc.chunk_size
             if doc.chunk_overlap is not None:
                 chunk_kwargs["chunk_overlap"] = doc.chunk_overlap
+            doc.processing_stage = "chunking"
+            doc.processing_progress = 30
+            db.commit()
             chunks = chunk_document(filepath, **chunk_kwargs)
         except TypeError:
-            # Preserve compatibility with patched/test implementations.
             chunks = chunk_document(filepath)
 
         if not chunks:
             doc.status = "failed"
+            doc.processing_progress = 0
             doc.error_message = "No text could be extracted from the document"
             db.commit()
             return
+
+        doc.processing_progress = 50
+        doc.processing_stage = "indexing"
+        db.commit()
 
         try:
             from app.rag.graph_builder import build_graph, save_graph
@@ -57,12 +92,19 @@ def ingest_document(document_id: str, filepath: str, original_name: str, user_id
         except Exception as e:
             logger.warning("Could not build knowledge graph for document %s: %s", document_id, e)
 
+        doc.processing_progress = 70
+        doc.processing_stage = "embedding"
+        db.commit()
+
         chunk_count = store_chunks(
             chunks=chunks,
             document_id=document_id,
             filename=original_name,
             user_id=user_id,
         )
+
+        doc.processing_progress = 85
+        db.commit()
 
         try:
             from app.rag.summarizer import generate_document_summary
@@ -77,6 +119,9 @@ def ingest_document(document_id: str, filepath: str, original_name: str, user_id
 
         doc.chunk_count = chunk_count
         doc.status = "ready"
+        doc.processing_progress = 100
+        doc.processing_stage = "completed"
+        doc.completed_at = datetime.now(timezone.utc)
         doc.error_message = None
         db.commit()
 
@@ -89,6 +134,7 @@ def ingest_document(document_id: str, filepath: str, original_name: str, user_id
 
     except Exception as e:
         logger.error("Ingestion error for %s: %s", document_id, e)
+        db.rollback()
         try:
             doc = db.query(Document).filter(
                 Document.id == document_id,
@@ -96,7 +142,9 @@ def ingest_document(document_id: str, filepath: str, original_name: str, user_id
             ).first()
             if doc:
                 doc.status = "failed"
+                doc.processing_progress = 0
                 doc.error_message = str(e)[:500]
+                doc.last_error_traceback = traceback.format_exc()[:2000]
                 db.commit()
         except Exception:
             logger.exception("Failed to mark document %s as failed", document_id)

--- a/backend/app/tasks.py
+++ b/backend/app/tasks.py
@@ -1,9 +1,24 @@
 """Celery tasks for document processing."""
+import traceback
+import logging
+
 from app.celery_app import celery_app
 from app.services.document_ingestion import ingest_document
+from app.database import get_db_session
+from app.models import Document
+
+logger = logging.getLogger(__name__)
 
 
-@celery_app.task(bind=True, name="app.tasks.process_document")
+@celery_app.task(
+    bind=True,
+    name="app.tasks.process_document",
+    max_retries=3,
+    default_retry_delay=30,
+    autoretry_for=(Exception,),
+    acks_late=True,
+    reject_on_worker_lost=True,
+)
 def process_document(
     self,
     document_id: str,
@@ -12,11 +27,29 @@ def process_document(
     user_id: str,
 ) -> dict[str, str]:
     """Run the RAG ingestion pipeline for a stored document."""
-    ingest_document(
-        document_id=document_id,
-        filepath=filepath,
-        original_name=original_name,
-        user_id=user_id,
-    )
-    return {"document_id": document_id, "status": "completed"}
+    try:
+        with get_db_session() as db:
+            doc = db.query(Document).filter(Document.id == document_id).first()
+            if doc:
+                doc.processing_started_at = __import__("datetime").datetime.now(__import__("datetime").timezone.utc)
+                doc.retry_count = (doc.retry_count or 0) + 1
+                db.commit()
+
+        ingest_document(
+            document_id=document_id,
+            filepath=filepath,
+            original_name=original_name,
+            user_id=user_id,
+        )
+        return {"document_id": document_id, "status": "completed"}
+    except Exception as exc:
+        logger.error("Document %s processing failed (attempt %s): %s", document_id, self.request.retries + 1, exc)
+        with get_db_session() as db:
+            doc = db.query(Document).filter(Document.id == document_id).first()
+            if doc and self.request.retries >= (self.max_retries or 3) - 1:
+                doc.status = "failed"
+                doc.last_error_traceback = traceback.format_exc()[:2000]
+                doc.processing_progress = 0
+                db.commit()
+        raise
 

--- a/frontend/e2e/auth-and-chat.spec.ts
+++ b/frontend/e2e/auth-and-chat.spec.ts
@@ -65,9 +65,10 @@ test("logs in with email and password", async ({ page }) => {
   await page.goto("/login");
   await page.locator("#login-email").fill(user.email);
   await page.locator("#login-password").fill("password123");
-  await page.locator("#sign-in-btn").click();
-
-  await expect(page).toHaveURL(/\/dashboard$/);
+  await Promise.all([
+    page.waitForURL("/dashboard"),
+    page.locator("#sign-in-btn").click(),
+  ]);
   await expect(page.getByText("No documents yet")).toBeVisible();
 });
 

--- a/frontend/e2e/auth-and-chat.spec.ts
+++ b/frontend/e2e/auth-and-chat.spec.ts
@@ -48,6 +48,10 @@ async function mockDashboardApis(page: Page, documents: typeof uploadedDocument[
       },
     });
   });
+
+  await page.route("**/api/v1/chat/sessions", async (route) => {
+    await route.fulfill({ json: [] });
+  });
 }
 
 test("logs in with email and password", async ({ page }) => {


### PR DESCRIPTION
## Description

Adds retry logic, progress tracking, and automated cleanup for the
document ingestion pipeline to handle transient failures gracefully.

### New files
- `backend/app/services/cleanup.py` — `cleanup_stale_documents()` marks
  documents stuck in "processing" beyond the timeout as failed;
  `cleanup_old_deleted_documents()` permanently purges soft-deleted
  documents older than the configured max age.

### Changes
- `backend/app/models.py` — added `processing_progress`, `processing_stage`,
  `retry_count`, `last_error_traceback`, `processing_started_at`,
  `completed_at` fields to `Document`.
- `backend/app/config.py` — added `DOC_PROCESSING_TIMEOUT_MINUTES`,
  `DOC_PROCESSING_MAX_RETRIES`, `DOC_PROCESSING_RETRY_DELAY_SECONDS`,
  `DOC_CLEANUP_MAX_AGE_DAYS`.
- `backend/app/tasks.py` — Celery task configured with `max_retries=3`,
  `default_retry_delay=30`, `autoretry_for=(Exception,)`, `acks_late`,
  `reject_on_worker_lost`; updates progress fields and records
  traceback on final failure.
- `backend/app/services/document_ingestion.py` — reports progress at
  each stage (extracting→chunking→indexing→embedding→completed);
  captures `last_error_traceback` on failure.
- `backend/app/scheduler.py` — registers cleanup jobs (stale recovery
  every 5 min, old purge daily).
- `backend/app/schemas.py` — `DocumentStatusResponse` now includes
  `processing_progress`, `processing_stage`, `retry_count`,
  `last_error_traceback`, `processing_started_at`, `completed_at`.
- `backend/app/routes/documents.py` — added `POST /{document_id}/retry`
  endpoint to re-queue failed documents.
- `backend/app/routes/chat.py` — error messages for non-ready documents
  now include progress percentage and stage.
  
  Fixes #485 