### PR TITLE
feat(api): extract PDF hyperlinks and URLs into document metadata

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -260,6 +260,7 @@ class Document(Base):
     last_error_traceback = Column(Text, nullable=True)
     processing_started_at = Column(DateTime, nullable=True)
     completed_at = Column(DateTime, nullable=True)
+    extracted_urls = Column(Text, nullable=True)
 
     # Relationships
     owner = relationship("User", back_populates="documents")

--- a/backend/app/rag/url_extractor.py
+++ b/backend/app/rag/url_extractor.py
@@ -1,0 +1,72 @@
+"""
+PDF URL extraction using PyMuPDF link annotations.
+
+Extracts all unique HTTP/HTTPS URLs from a PDF's link annotations
+and text-based URIs across all pages. Called during document ingestion
+so URLs are stored in the document metadata column.
+"""
+import logging
+import re
+from typing import List
+
+logger = logging.getLogger(__name__)
+
+# Matches http/https URLs in plain text as a fallback
+_URL_RE = re.compile(
+    r"https?://"
+    r"(?:[A-Za-z0-9\-._~:/?#\[\]@!$&'()*+,;=%])"
+    r"[A-Za-z0-9\-._~:/?#\[\]@!$&'()*+,;=%]*",
+    re.IGNORECASE,
+)
+
+
+def extract_urls_from_pdf(filepath: str) -> List[str]:
+    """Extract unique HTTP/HTTPS URLs from a PDF file.
+
+    Two passes per page:
+    1. Link annotations  — catches hyperlinks embedded by the PDF author.
+    2. Plain-text regex  — catches URLs typed inline that aren't annotated.
+
+    Args:
+        filepath: Absolute path to the PDF file.
+
+    Returns:
+        Deduplicated list of URLs preserving first-seen order.
+        Returns an empty list for non-PDF files or on any extraction error.
+    """
+    if not filepath.rsplit(".", 1)[-1].lower() == "pdf":
+        return []
+
+    try:
+        import fitz  # PyMuPDF — already in requirements.txt
+    except ImportError:
+        logger.warning("PyMuPDF not available; skipping URL extraction")
+        return []
+
+    seen: dict = {}   # preserves insertion order, deduplicates
+    doc = None
+
+    try:
+        doc = fitz.open(filepath)
+
+        for page_num, page in enumerate(doc):
+            # ── Pass 1: link annotations ──────────────────────────────────
+            for link in page.get_links():
+                uri = link.get("uri", "")
+                if uri and uri.lower().startswith(("http://", "https://")):
+                    seen.setdefault(uri.strip(), None)
+
+            # ── Pass 2: plain-text regex ──────────────────────────────────
+            text = page.get_text()
+            for match in _URL_RE.finditer(text):
+                url = match.group(0).rstrip(".,;:)\"'")
+                seen.setdefault(url, None)
+
+    except Exception as exc:
+        logger.warning("URL extraction failed for %s: %s", filepath, exc)
+        return []
+    finally:
+        if doc:
+            doc.close()
+
+    return list(seen.keys())

--- a/backend/app/routes/documents.py
+++ b/backend/app/routes/documents.py
@@ -62,6 +62,18 @@ router = APIRouter(prefix="/documents", tags=["Documents"])
 
 ALLOWED_MIME_TYPES = settings.ALLOWED_MIME_TYPES
 
+def _deserialize_doc(doc: Document) -> DocumentResponse:
+    """Return a DocumentResponse with extracted_urls parsed from JSON string."""
+    import json as _json
+    response = DocumentResponse.model_validate(doc)
+    if doc.extracted_urls:
+        try:
+            response = response.model_copy(
+                update={"extracted_urls": _json.loads(doc.extracted_urls)}
+            )
+        except Exception:
+            response = response.model_copy(update={"extracted_urls": []})
+    return response
 
 async def validate_upload(file: UploadFile):
     """Validate an uploaded file and save it to a temporary file.
@@ -469,7 +481,7 @@ def list_documents(
             .scalars().all())
 
     return DocumentListResponse(
-        items=[DocumentResponse.model_validate(d) for d in docs],
+        items=[_deserialize_doc(d) for d in docs],
         total=totalDocuments,
         page=page,
         pages=pages
@@ -501,7 +513,7 @@ def rename_document(
     db.commit()
     db.refresh(doc)
 
-    return DocumentResponse.model_validate(doc)
+    return _deserialize_doc(doc)
 
 
 @router.get("/{document_id}", response_model=DocumentResponse)
@@ -537,7 +549,7 @@ def get_document(
     if not doc:
         raise NotFoundException("Document")
 
-    return DocumentResponse.model_validate(doc)
+    return _deserialize_doc(doc)
 
 
 @router.get("/{document_id}/pdf")
@@ -712,7 +724,7 @@ def update_chunk_settings(
         task_id = f"local_{uuid.uuid4().hex}"
 
     # Return the updated document record with new chunk settings
-    return DocumentResponse.model_validate(doc).model_copy(update={"task_id": task_id})
+    return _deserialize_doc(doc).model_copy(update={"task_id": task_id})
 
 
 @router.post("/{document_id}/retry", response_model=DocumentResponse)
@@ -772,4 +784,4 @@ def retry_document_processing(
             )
         task_id = f"local_{uuid.uuid4().hex}"
 
-    return DocumentResponse.model_validate(doc).model_copy(update={"task_id": task_id})
+    return _deserialize_doc(doc).model_copy(update={"task_id": task_id})

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -180,6 +180,7 @@ class DocumentResponse(BaseModel):
     uploaded_at: datetime
     summary: Optional[str] = None # New field for document summary
     task_id: Optional[str] = None
+    extracted_urls: Optional[List[str]] = None
 
     class Config:
         from_attributes = True

--- a/backend/app/services/document_ingestion.py
+++ b/backend/app/services/document_ingestion.py
@@ -117,6 +117,29 @@ def ingest_document(document_id: str, filepath: str, original_name: str, user_id
             logger.warning("Could not generate summary for document %s: %s", document_id, e)
             doc.summary = None
 
+        # ── URL extraction pass (PDF only) ────────────────────────────────
+        ext = filepath.rsplit(".", 1)[-1].lower()
+        if ext == "pdf":
+            try:
+                from app.rag.url_extractor import extract_urls_from_pdf
+                import json
+
+                urls = extract_urls_from_pdf(filepath)
+                doc.extracted_urls = json.dumps(urls) if urls else None
+                db.commit()
+                logger.info(
+                    "Extracted %s URLs from document %s",
+                    len(urls),
+                    document_id,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "URL extraction failed for document %s: %s",
+                    document_id,
+                    exc,
+                )
+        # ── End URL extraction pass ───────────────────────────────────────
+
         doc.chunk_count = chunk_count
         doc.status = "ready"
         doc.processing_progress = 100

--- a/backend/migrate_add_extracted_urls.py
+++ b/backend/migrate_add_extracted_urls.py
@@ -1,0 +1,32 @@
+"""
+Migration: add extracted_urls column to documents table.
+
+Run once:
+    python migrate_add_extracted_urls.py
+
+Safe to re-run — skips if the column already exists.
+"""
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from app.database import engine
+from sqlalchemy import text, inspect
+
+def migrate():
+    inspector = inspect(engine)
+    columns = [col["name"] for col in inspector.get_columns("documents")]
+
+    if "extracted_urls" in columns:
+        print("Column 'extracted_urls' already exists — skipping.")
+        return
+
+    with engine.begin() as conn:
+        conn.execute(text(
+            "ALTER TABLE documents ADD COLUMN extracted_urls TEXT DEFAULT NULL"
+        ))
+    print("Migration complete: added 'extracted_urls' to documents table.")
+
+if __name__ == "__main__":
+    migrate()


### PR DESCRIPTION
### 🔗 Related Issue
Closes #441

---

### 📝 What does this PR do?
Adds automated PDF link and URL extraction during document ingestion and
exposes the results in the document metadata API.

**`backend/app/rag/url_extractor.py`** (new):
- `extract_urls_from_pdf()` — two-pass extraction per page using PyMuPDF
  (already in `requirements.txt`): link annotations (`page.get_links()`)
  first, then plain-text regex fallback for inline URLs not marked as
  hyperlinks. Deduplicates while preserving first-seen order. Returns `[]`
  safely for non-PDF files or any extraction error.

**`backend/migrate_add_extracted_urls.py`** (new):
- Standalone migration script consistent with the project's existing
  `migrate_add_role.py` / `migrate_add_google_refresh_token.py` pattern.
- Adds `extracted_urls TEXT DEFAULT NULL` to the `documents` table.
- Safe to re-run — skips if the column already exists.

**`backend/app/models.py`**:
- Adds `extracted_urls = Column(Text, nullable=True)` to `Document`.

**`backend/app/schemas.py`**:
- Adds `extracted_urls: Optional[List[str]] = None` to `DocumentResponse`.

**`backend/app/services/document_ingestion.py`**:
- Adds a URL extraction pass after the summary step. Calls
  `extract_urls_from_pdf()`, JSON-serialises the result, and stores it in
  `doc.extracted_urls`. Wrapped in `try/except` — a failure never blocks
  ingestion.

**`backend/app/routes/documents.py`**:
- Adds `_deserialize_doc()` helper that parses the JSON string from the DB
  back into `List[str]` before returning `DocumentResponse`. Applied to
  `get_document`, `list_documents`, and `rename_document`.

---

### 🗂️ Type of Change
- [x] ✨ New feature

---

### 🧪 How was this tested?
- [x] Ran `python migrate_add_extracted_urls.py` — column added successfully
- [x] Ran the backend locally (`uvicorn app.main:app --reload`)
- [x] Uploaded a PDF containing hyperlinks; confirmed `extracted_urls` field
      in `GET /api/v1/documents/{id}` response contains correct URLs
- [x] Uploaded a PDF with no links; confirmed `extracted_urls` is `null`
- [x] Uploaded a non-PDF (DOCX/TXT); confirmed extraction is skipped and
      `extracted_urls` is `null`
- [x] Confirmed existing text/table/image ingestion is unaffected

---

### ✅ Self-Review Checklist
- [x] My branch is based on `dev`, not `main`
- [x] I have not added any secrets / API keys
- [x] I have not modified `main` branch or any HuggingFace deployment config
- [x] My code follows the existing style (no unnecessary formatting changes)
- [x] I have updated relevant docs / comments if needed