### PR TITLE
ci: Add Codecov upload step and coverage badge to README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,14 @@ jobs:
             htmlcov/
           retention-days: 7
 
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage.xml
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+
       - name: Coverage summary comment (PR only)
         if: github.event_name == 'pull_request'
         uses: py-cov-action/python-coverage-comment-action@v3


### PR DESCRIPTION
### 🔗 Related Issue
Closes #452

---
###  What does this PR do?
The CI was already generating `coverage.xml` via pytest-cov and saving it as a GitHub artifact. This PR adds the missing Codecov upload step so coverage reports are automatically sent to Codecov after every test run.
Also adds a Codecov badge to README for public visibility.

**Changes:**
- `.github/workflows/ci.yml` → added `codecov/codecov-action@v4` upload step after existing artifact upload
- `README.md` → added Codecov badge at the top

---
### 🗂️ Type of Change
- [x] ⚙️ CI / tooling / config change

---
### 🧪 How was this tested?
Verified that `coverage.xml` is already being generated by the existing pytest step — the new Codecov action simply uploads that file.

---
### 📸 Screenshots (if UI change)
N/A — CI change only

---
### ⚠️ Anything to flag for reviewers?
- Requires `CODECOV_TOKEN` to be added as a GitHub Actions secret by the repo owner
- `fail_ci_if_error: false` is set so CI won't break if Codecov upload fails
- No new dependencies added — `pytest-cov` already in `requirements.txt`

---
### ✅ Self-Review Checklist
- [x] My branch is based on **`dev`**, not `main`
- [x] I have not added any secrets / API keys
- [x] I have not modified `main` branch or any HuggingFace deployment config
- [x] My code follows the existing style (no unnecessary formatting changes)
- [x] I have updated relevant docs / comments if needed

hi @param20h ,Kindly review the fix and please let me know if there is any shortcoming to fix
