### PR TITLE
chore: add Prettier formatting validation to frontend PRs

### DIFF
--- a/.github/workflows/prettier-check.yml
+++ b/.github/workflows/prettier-check.yml
@@ -2,7 +2,10 @@ name: Prettier Formatting Check
 
 on:
   pull_request:
-    branches: [ "dev" ] 
+    branches: [ "dev" ]
+
+permissions:
+  contents: read
 
 jobs:
   prettier-validation:
@@ -17,6 +20,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+
+      - name: Install Dependencies
+        working-directory: ./frontend
+        run: npm ci
 
       - name: Run Prettier Check
         working-directory: ./frontend

--- a/.github/workflows/prettier-check.yml
+++ b/.github/workflows/prettier-check.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -25,6 +27,15 @@ jobs:
         working-directory: ./frontend
         run: npm ci
 
-      - name: Run Prettier Check
-        working-directory: ./frontend
-        run: npx prettier --check "**/*.{ts,tsx,css,md}"
+      - name: Run Prettier on Changed Files Only
+        run: |
+          git fetch origin dev
+          CHANGED_FILES=$(git diff --name-only origin/dev...HEAD | grep -E '^frontend/.*\.(ts|tsx|css|md)$' || true)
+          
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "No frontend files were modified in this PR. Skipping formatting check."
+          else
+            echo "Inspecting the following modified files:"
+            echo "$CHANGED_FILES"
+            npx prettier --check $CHANGED_FILES
+          fi

--- a/.github/workflows/prettier-check.yml
+++ b/.github/workflows/prettier-check.yml
@@ -1,0 +1,23 @@
+name: Prettier Formatting Check
+
+on:
+  pull_request:
+    branches: [ "dev" ] 
+
+jobs:
+  prettier-validation:
+    name: Validate Frontend Formatting
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run Prettier Check
+        working-directory: ./frontend
+        run: npx prettier --check "**/*.{ts,tsx,css,md}"


### PR DESCRIPTION
## 📋 PR Checklist

> Thank you for contributing to **PDF-Assistant-RAG**! 🎉  
> Please fill out this template before submitting. PRs without it filled in will be closed.

---

### 🔗 Related Issue
Closes #455 

---

### 📝 What does this PR do?
Added a quick workflow to enforce Prettier formatting on the frontend. It automatically checks TS, CSS, and Markdown files on incoming PRs to dev so we don't have to worry about style inconsistencies during code reviews.

---

### 🗂️ Type of Change
<!-- Check all that apply -->
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔧 Refactor / code cleanup
- [ ] 📝 Documentation update
- [ ] 🎨 UI / styling change
- [x ] ⚙️ CI / tooling / config change
- [ ] 🧪 Tests

---

### 🧪 How was this tested?
<!-- Describe how you verified your changes work. -->
- [ ] Ran the backend locally (`uvicorn app.main:app --reload`)
- [ ] Ran the frontend locally (`npm run dev` inside `frontend/`)
- [ ] Tested the affected API endpoints manually
- [x] Added / updated tests
- [ ] *Note: I verified the YAML syntax and tested the `npx prettier --check` command locally to ensure it correctly flags unformatted files without altering them.*

---

### 📸 Screenshots (if UI change)
N/A

---

### ⚠️ Anything to flag for reviewers?
<!-- Anything tricky, uncertain, or worth discussing? -->

---

### ✅ Self-Review Checklist
- [x] My branch is based on **`dev`**, not `main`
- [x] I have not added any secrets / API keys
- [x] I have not modified `main` branch or any HuggingFace deployment config
- [x] My code follows the existing style (no unnecessary formatting changes)
- [x] I have updated relevant docs / comments if needed
