### PR TITLE
feat(ui): improve PDF page jump input with Page X of Y format, error …

### DIFF
--- a/frontend/src/components/document/PDFViewer.tsx
+++ b/frontend/src/components/document/PDFViewer.tsx
@@ -58,6 +58,7 @@ export default function PDFViewer({
   const [scale, setScale] = useState(1.0);
   const [rotation, setRotation] = useState(0);
   const [pageInput, setPageInput] = useState(String(currentPage));
+  const [pageInputError, setPageInputError] = useState(false);
   const [prevCurrentPage, setPrevCurrentPage] = useState(currentPage);
   const viewerRef = useRef<HTMLDivElement>(null);
 
@@ -65,6 +66,7 @@ export default function PDFViewer({
   if (currentPage !== prevCurrentPage) {
     setPrevCurrentPage(currentPage);
     setPageInput(String(currentPage));
+    setPageInputError(false);
   }
 
   const pdfUrl = `${API_BASE}/api/v1/documents/${documentId}/pdf`;
@@ -75,8 +77,6 @@ export default function PDFViewer({
     url: pdfUrl,
     httpHeaders: token ? { Authorization: `Bearer ${token}` } : undefined,
   }), [pdfUrl, token]);
-
-
 
   useEffect(() => {
     if (viewerRef.current && highlightTarget?.page === currentPage) {
@@ -138,7 +138,19 @@ export default function PDFViewer({
     });
   }, [highlightTarget, currentPage]);
 
-
+  const handlePageJump = (value: string) => {
+    const pageNumber = parseInt(value.trim(), 10);
+    if (!Number.isNaN(pageNumber) && pageNumber >= 1 && pageNumber <= totalPages) {
+      setPageInputError(false);
+      onPageChange(pageNumber);
+    } else {
+      setPageInputError(true);
+      setTimeout(() => {
+        setPageInput(String(currentPage));
+        setPageInputError(false);
+      }, 1000);
+    }
+  };
 
   return (
     <div className="h-full flex flex-col bg-background" ref={viewerRef}>
@@ -159,27 +171,32 @@ export default function PDFViewer({
             <ChevronLeft className="w-4 h-4" />
           </Button>
 
+          {/* Page jump input — Page X of Y */}
           <form
             onSubmit={(event) => {
               event.preventDefault();
-              const pageNumber = parseInt(pageInput.trim(), 10);
-              if (!Number.isNaN(pageNumber) && pageNumber >= 1 && pageNumber <= totalPages) {
-                onPageChange(pageNumber);
-              } else {
-                setPageInput(String(currentPage));
-              }
+              handlePageJump(pageInput);
             }}
             className="flex items-center gap-1 text-xs"
             aria-label="PDF page navigation"
           >
+            <span className="text-muted-foreground text-[10px] hidden sm:inline">Page</span>
             <Input
               value={pageInput}
-              onChange={(e) => setPageInput(e.target.value)}
-              className="w-10 h-7 text-center text-xs p-0 bg-background/50"
-              aria-label={`PDF page number, current page ${currentPage} of ${totalPages}`}
+              onChange={(e) => {
+                setPageInput(e.target.value);
+                setPageInputError(false);
+              }}
+              onBlur={() => handlePageJump(pageInput)}
+              className={`h-7 text-center text-xs p-0 bg-background/50 transition-colors ${
+                String(currentPage).length >= 3 ? "w-14" : "w-10"
+              } ${pageInputError ? "border-destructive text-destructive" : ""}`}
+              aria-label={`Page number input, current page ${currentPage} of ${totalPages}`}
+              aria-invalid={pageInputError}
+              title={`Enter page number between 1 and ${totalPages}`}
               inputMode="numeric"
             />
-            <span className="text-muted-foreground">/ {totalPages}</span>
+            <span className="text-muted-foreground text-[10px]">of {totalPages}</span>
           </form>
 
           <Button


### PR DESCRIPTION

## 🔗 Related Issue
Closes #427

---
### 📝 What does this PR do?
Improves the existing PDF viewer toolbar page jump input to fully match the issue requirements.

**Changes in `frontend/src/components/document/PDFViewer.tsx`:**
- Added `Page X of Y` format — "Page" label and "of" instead of "/"
- Added red border error feedback when user types invalid page number
- Auto-resets input to current page after 1 second on invalid input
- Added `onBlur` validation — validates when user clicks away, not just on Enter
- Dynamic input width — wider for large page numbers (100+)
- Added `aria-invalid` for accessibility
- Added `title` tooltip showing valid range hint

---
### 🗂️ Type of Change
- [x] 🎨 UI / styling change
---
### 🧪 How was this tested?
- [x] Ran the frontend locally (`npm run dev` inside `frontend/`)

Verified `npm run build` passes successfully

---
### ⚠️ Anything to flag for reviewers?
- Feature was partially implemented before — this PR improves UX with proper format, error feedback and blur validation
- `date-fns` package was added as it was missing from dependencies but required by `MessageBubble.tsx`

---
### ✅ Self-Review Checklist
- [x] My branch is based on **`dev`**, not `main`
- [x] I have not added any secrets / API keys
- [x] I have not modified `main` branch or any HuggingFace deployment config
- [x] My code follows the existing style (no unnecessary formatting changes)
- [x] I have updated relevant docs / comments if needed