### PR TITLE
test(backend): add unit tests for rate limiting middleware

### DIFF
--- a/backend/tests/test_rate_limit.py
+++ b/backend/tests/test_rate_limit.py
@@ -1,8 +1,19 @@
+"""
+Unit tests for rate limiting middleware and identifier resolution (#445).
+
+Verifies key function fallback resolutions (User ID vs IP Address), route
+attribute assignments, and that the global handler intercepts limit breaches
+to return a 429 status code.
+"""
 from types import SimpleNamespace
+import pytest
+from fastapi.testclient import TestClient
+from slowapi.errors import RateLimitExceeded
 
 from app.auth import create_access_token
 from app.rate_limit import CHAT_QUERY_RATE_LIMIT, rate_limit_key_func
 from app.routes.chat import ask_question, ask_question_stream
+from app.main import app
 
 
 class DummyRequest:
@@ -10,6 +21,8 @@ class DummyRequest:
         self.headers = headers or {}
         self.client = SimpleNamespace(host="203.0.113.10")
 
+
+# ── Your Original Key Resolution & Route Tests ───────────────────────────────
 
 def test_rate_limit_key_prefers_authenticated_user_id():
     token = create_access_token("user-123")
@@ -31,3 +44,30 @@ def test_chat_endpoints_use_required_rate_limit():
     assert CHAT_QUERY_RATE_LIMIT == "15/minute"
     assert ask_question.__rate_limits__ == [CHAT_QUERY_RATE_LIMIT]
     assert ask_question_stream.__rate_limits__ == [CHAT_QUERY_RATE_LIMIT]
+
+
+# ── Middleware 429 Response Verification ──────────────────────────────────────
+
+def test_rate_limit_handler_returns_429(client: TestClient):
+    """
+    Verify that hitting an endpoint that triggers a RateLimitExceeded exception
+    correctly triggers the global handler, returning a 429 status code and the
+    exact JSON error layout specified in app/main.py.
+    """
+    # Temporarily mount a mock endpoint on the app to force a rate limit breach
+    @app.get("/api/v1/test-rate-limiting-trigger-429")
+    def trigger_rate_limit():
+        raise RateLimitExceeded("Too Many Requests")
+
+    response = client.get("/api/v1/test-rate-limiting-trigger-429")
+    
+    # Verify the 429 status code requirement
+    assert response.status_code == 429
+    
+    # Verify the specific JSON payload structure from app/main.py
+    json_data = response.json()
+    assert "error" in json_data
+    assert json_data["error"]["code"] == "RATE_LIMIT_EXCEEDED"
+    assert "Rate limit exceeded. Please try again later." in json_data["error"]["message"]
+    assert "request_id" in json_data["error"]
+    assert isinstance(json_data["error"]["details"], dict)


### PR DESCRIPTION
### 🔗 Related Issue
Closes #445

---

### 📝 What does this PR do?
Adds comprehensive unit tests for the backend rate-limiting middleware (`slowapi`) in `backend/tests/test_rate_limit.py`. 

Specifically, this PR covers:
1. **Fallback Resolution Verification:** Ensures the active `rate_limit_key_func` correctly identifies and tracks authenticated sessions via User ID (`user:<id>`) and seamlessly falls back to the network IP address (`ip:<host>`) for unauthenticated traffic.
2. **Endpoint Compliance:** Assures that specified chat endpoints are decorated with the required `15/minute` threshold configuration.
3. **Status Code Enforcement:** Uses a mock route scenario to guarantee that the global `RateLimitExceeded` exception handler catches breaches, accurately terminates the cycle with a `429` status code, and yields the required structural JSON schema matching production design parameters.

---

### 🗂️ Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔧 Refactor / code cleanup
- [ ] 📝 Documentation update
- [ ] 🎨 UI / styling change
- [ ] ⚙️ CI / tooling / config change
- [x] 🧪 Tests

---

### 🧪 How was this tested?
- [x] Tested the affected API endpoints manually
- [x] Added / updated tests (All `pytest` test suites passing successfully)

---

### ✅ Self-Review Checklist
- [x] My branch is based on **`dev`**, not `main`
- [x] I have not added any secrets / API keys
- [x] I have not modified `main` branch or any HuggingFace deployment config
- [x] My code follows the existing style (no unnecessary formatting changes)
- [x] I have updated relevant docs / comments if needed