### PR TITLE
feat(api): add POST /auth/change-password with current password valid…

### DIFF
--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -39,6 +39,7 @@ from app.schemas import (
     TokenResponse,
     UpdatePassword,
     UpdatePasswordResponse,
+    ChangePasswordRequest,
     UserLogin,
     UserRegister,
     UserResponse,
@@ -525,6 +526,46 @@ def update_password(payload:UpdatePassword,
     except SQLAlchemyError:
         db.rollback()
         raise ValidationException("Database error")
+
+
+@router.post("/change-password", response_model=MessageResponse)
+def change_password(
+    payload: ChangePasswordRequest,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Securely rotate the authenticated user's password.
+
+    Validates that the provided current password matches the stored hash
+    before updating to the new password. This is the secure, recommended
+    way for users to change their own password since it confirms the
+    requester actually knows the existing credentials.
+
+    Args:
+        payload: ChangePasswordRequest containing `current_password` and `new_password`.
+        user: The currently authenticated user, obtained from the `get_current_user` dependency.
+        db: SQLAlchemy database session, obtained from the dependency.
+
+    Returns:
+        MessageResponse: Confirmation message on success.
+
+    Raises:
+        HTTPException: 401 if `current_password` does not match the stored hash.
+        HTTPException: 400 if a database error occurs during commit.
+    """
+    if not verify_password(payload.current_password, user.hashed_password):
+        raise UnauthorizedException("Current password is incorrect")
+
+    try:
+        user.hashed_password = hash_password(payload.new_password)
+        db.commit()
+        db.refresh(user)
+    except SQLAlchemyError:
+        db.rollback()
+        raise ValidationException("Database error")
+
+    return MessageResponse(message="Password updated successfully")
+
 
 @router.post("/api-keys", response_model=ApiKeyCreateResponse, status_code=status.HTTP_201_CREATED)
 def create_api_key(

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -93,6 +93,16 @@ class UpdatePasswordResponse(BaseModel):
     email: EmailStr
     password_changed: bool = True
 
+class ChangePasswordRequest(BaseModel):
+    current_password: str
+    new_password: str = Field(..., min_length=8)
+
+    @field_validator("new_password")
+    @classmethod
+    def validate_password_strength(cls, value: str) -> str:
+        validate_password(value)
+        return value    
+
 
 class WorkspaceInviteRequest(BaseModel):
     email: EmailStr


### PR DESCRIPTION

### 🔗 Related Issue
Closes #430

---
### 📝 What does this PR do?
Adds a secure `POST /auth/change-password` endpoint for password rotation.

The existing `PUT /auth/password` route did not validate the user's current password before updating — a security gap. This new endpoint requires the current password to match before allowing the change.

**Changes:**
- `backend/app/schemas.py` → added `ChangePasswordRequest` schema with `current_password` and `new_password` (validated for strength)
- `backend/app/routes/auth.py` → added `POST /auth/change-password` route that verifies current password hash before updating

---
### 🗂️ Type of Change

- [x] ✨ New feature

---
### 🧪 How was this tested?
- [ ] Ran the backend locally (`uvicorn app.main:app --reload`)
- [ ] Ran the frontend locally (`npm run dev` inside `frontend/`)
- [ ] Tested the affected API endpoints manually
- [ ] Added / updated tests

Verified via `Select-String` that both the route and schema are correctly 
registered in `auth.py` and `schemas.py`.

---
### 📸 Screenshots (if UI change)
N/A — backend API change only

---
### ⚠️ Anything to flag for reviewers?
- Existing `PUT /auth/password` route remains unchanged for backward compatibility — this PR adds the new secure endpoint as specified in the issue
- New password is validated for strength via existing `validate_password` function
- Returns 401 via `UnauthorizedException` if `current_password` doesn't match

---
### ✅ Self-Review Checklist
- [x] My branch is based on **`dev`**, not `main`
- [x] I have not added any secrets / API keys
- [x] I have not modified `main` branch or any HuggingFace deployment config
- [x] My code follows the existing style (no unnecessary formatting changes)
- [x] I have updated relevant docs / comments if needed