### PR TITLE
fix: resolve bugs #561, #562, #563

### DIFF
--- a/backend/app/cache.py
+++ b/backend/app/cache.py
@@ -13,6 +13,7 @@ import hashlib
 import json
 import logging
 import os
+import threading
 from typing import Optional
 
 logger = logging.getLogger(__name__)
@@ -74,26 +75,30 @@ def _get_redis():
 
 _lru_store: dict = {}
 _lru_order: list = []
+_lru_lock = threading.Lock()
 
 
 def _lru_get(key: str) -> Optional[str]:
-    return _lru_store.get(key)
+    with _lru_lock:
+        return _lru_store.get(key)
 
 
 def _lru_set(key: str, value: str) -> None:
-    if key in _lru_store:
-        _lru_order.remove(key)
-    elif len(_lru_store) >= LRU_MAX_SIZE:
-        oldest = _lru_order.pop(0)
-        del _lru_store[oldest]
-    _lru_store[key] = value
-    _lru_order.append(key)
+    with _lru_lock:
+        if key in _lru_store:
+            _lru_order.remove(key)
+        elif len(_lru_store) >= LRU_MAX_SIZE:
+            oldest = _lru_order.pop(0)
+            del _lru_store[oldest]
+        _lru_store[key] = value
+        _lru_order.append(key)
 
 
 def _lru_delete(key: str) -> None:
-    if key in _lru_store:
-        del _lru_store[key]
-        _lru_order.remove(key)
+    with _lru_lock:
+        if key in _lru_store:
+            del _lru_store[key]
+            _lru_order.remove(key)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -250,6 +250,7 @@ app.include_router(chat_router, prefix="/api/v1")
 app.include_router(github_router, prefix="/api/v1")
 app.include_router(admin_router, prefix="/api/v1")
 app.include_router(workspaces_router, prefix="/api/v1")
+app.include_router(profile_router)
 
 setup_prometheus_metrics(app)
 
@@ -352,4 +353,3 @@ else:
             "docs": "/docs",
             "health": "/api/health",
         }
-app.include_router(profile_router)

--- a/backend/app/services/document_ingestion.py
+++ b/backend/app/services/document_ingestion.py
@@ -171,5 +171,6 @@ def ingest_document(document_id: str, filepath: str, original_name: str, user_id
                 db.commit()
         except Exception:
             logger.exception("Failed to mark document %s as failed", document_id)
+        raise
     finally:
         db.close()

--- a/backend/app/tasks.py
+++ b/backend/app/tasks.py
@@ -41,7 +41,10 @@ def process_document(
             original_name=original_name,
             user_id=user_id,
         )
-        return {"document_id": document_id, "status": "completed"}
+        with get_db_session() as db:
+            doc = db.query(Document).filter(Document.id == document_id).first()
+            status = doc.status if doc else "unknown"
+        return {"document_id": document_id, "status": status}
     except Exception as exc:
         logger.error("Document %s processing failed (attempt %s): %s", document_id, self.request.retries + 1, exc)
         with get_db_session() as db:


### PR DESCRIPTION
## Fix three bugs: #561, #562, #563

### #561 — Silent Exception Swallowing in `ingest_document` Breaks Celery Retry
- **`backend/app/services/document_ingestion.py`**: Added `raise` after the `except` block so that the original exception propagates to Celery's `autoretry_for` mechanism after DB cleanup.
- **`backend/app/tasks.py`**: Changed the return value to check the document's actual DB status instead of hardcoding `"completed"`, so the task result accurately reflects success/failure.

### #562 — Thread-Unsafe LRU Embedding Cache Causes Data Corruption Under Load
- **`backend/app/cache.py`**: Added `import threading` and a module-level `_lru_lock` (`threading.Lock()`). Wrapped `_lru_get`, `_lru_set`, and `_lru_delete` with `with _lru_lock:` to prevent race conditions (duplicate order entries, `ValueError` on remove, eviction corruption, partial-write reads).

### #563 — Frontend Catch-All Route Registration Order Shadows `profile_router`
- **`backend/app/main.py`**: Moved `app.include_router(profile_router)` from after the `/{full_path:path}` catch-all to join the other API route registrations, so profile endpoints are registered before the frontend catch-all and are reachable in production/Docker.

**Files changed:** 4
**Changes:** +22 / -13

Closes #561, Closes #562, Closes #563
