### PR TITLE
feat: stream intermediate agent reasoning and token-by-token final answers

### DIFF
--- a/backend/app/rag/agent.py
+++ b/backend/app/rag/agent.py
@@ -233,7 +233,10 @@ def generate_answer_stream(
 
         for step in executor.stream({"input": question, "chat_history": formatted_history}):
             if "actions" in step:
-                continue
+                for action in step["actions"]:
+                    log_content = getattr(action, "log", "")
+                    if log_content:
+                        yield f"data: {json.dumps({'type': 'thought', 'data': log_content.strip()})}\n\n"
 
             elif "intermediate_steps" in step:
                 if not sources_sent and getattr(pdf_tool, "last_sources", []):
@@ -251,6 +254,14 @@ def generate_answer_stream(
                     yield f"data: {json.dumps({'type': 'sources', 'data': sources})}\n\n"
                     sources_sent = True
 
+                for agent_step in step["intermediate_steps"]:
+                    if isinstance(agent_step, tuple) and len(agent_step) >= 2:
+                        observation = agent_step[1]
+                        obs_str = str(observation)
+                        if len(obs_str) > 1000:
+                            obs_str = obs_str[:1000] + "... (truncated)"
+                        yield f"data: {json.dumps({'type': 'thought', 'data': f'Observation: {obs_str}'})}\n\n"
+
             elif "output" in step:
                 full_answer = step["output"]
                 try:
@@ -258,7 +269,12 @@ def generate_answer_stream(
                 except OutputParserError as e:
                     logger.warning(f"Rejected malformed streamed LLM output: {e}")
                     clean_answer = MALFORMED_OUTPUT_MESSAGE
-                yield f"data: {json.dumps({'type': 'token', 'data': clean_answer})}\n\n"
+
+                import time
+                chunk_size = 4
+                for i in range(0, len(clean_answer), chunk_size):
+                    yield f"data: {json.dumps({'type': 'token', 'data': clean_answer[i:i+chunk_size]})}\n\n"
+                    time.sleep(0.01)
 
     except Exception as e:
         logger.error(f"Agent streaming error: {e}")

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -275,36 +275,38 @@ export default function ChatPanel({ activeDoc, onCitationClick }: Props) {
           reject(new Error("WebSocket connection timeout"));
         }, 800);
 
+        const ensureAssistantCreated = (initialThoughts?: string[], initialSources?: SourceChunk[]) => {
+          if (!assistantCreated) {
+            assistantCreated = true;
+            setIsTyping(false);
+            const assistantMsg: ChatMsg = {
+              id: assistantId,
+              role: "assistant",
+              content: "",
+              sources: initialSources || [],
+              isStreaming: true,
+              thoughts: initialThoughts || [],
+            };
+            setMessages((prev) => [...prev, assistantMsg]);
+          }
+        };
+
         ws.onmessage = (ev) => {
           clearTimeout(connectTimeout);
           try {
             const event = JSON.parse(ev.data);
             if (event.type === "token") {
-              if (!assistantCreated) {
-                assistantCreated = true;
-                setIsTyping(false);
-
-                const assistantMsg: ChatMsg = {
-                  id: assistantId,
-                  role: "assistant",
-                  content: event.data as string,
-                  sources: [],
-                  isStreaming: true,
-                };
-
-                setMessages((prev) => [...prev, assistantMsg]);
-              } else {
-                setMessages((prev) =>
-                  prev.map((m) => (m.id === assistantId ? { ...m, content: m.content + (event.data as string) } : m))
-                );
-              }
+              ensureAssistantCreated();
+              setMessages((prev) =>
+                prev.map((m) => (m.id === assistantId ? { ...m, content: m.content + (event.data as string) } : m))
+              );
             } else if (event.type === "sources") {
+              ensureAssistantCreated(undefined, event.data as SourceChunk[]);
               setMessages((prev) => prev.map((m) => (m.id === assistantId ? { ...m, sources: event.data as SourceChunk[] } : m)));
             } else if (event.type === "thought") {
-              // Append thoughts as a temporary assistant note (optional UI handling)
-              // For simplicity, add to assistant message content in brackets
+              ensureAssistantCreated([event.data as string]);
               setMessages((prev) =>
-                prev.map((m) => (m.id === assistantId ? { ...m, content: m.content + `\n[thought] ${event.data}` } : m))
+                prev.map((m) => (m.id === assistantId ? { ...m, thoughts: [...(m.thoughts || []), event.data as string] } : m))
               );
             } else if (event.type === "error") {
               setIsTyping(false);
@@ -354,28 +356,37 @@ export default function ChatPanel({ activeDoc, onCitationClick }: Props) {
           session_id: activeSessionId,
         }, abortController.signal);
 
+        let sseAssistantCreated = false;
+        const ensureSseAssistantCreated = (initialThoughts?: string[], initialSources?: SourceChunk[]) => {
+          if (!sseAssistantCreated) {
+            sseAssistantCreated = true;
+            setIsTyping(false);
+            const assistantMsg: ChatMsg = {
+              id: assistantId,
+              role: "assistant",
+              content: "",
+              sources: initialSources || [],
+              isStreaming: true,
+              thoughts: initialThoughts || [],
+            };
+            setMessages((prev) => [...prev, assistantMsg]);
+          }
+        };
+
         for await (const event of stream) {
           if (event.type === "token") {
-            if (!assistantCreated) {
-              assistantCreated = true;
-              setIsTyping(false);
-
-              const assistantMsg: ChatMsg = {
-                id: assistantId,
-                role: "assistant",
-                content: event.data as string,
-                sources: [],
-                isStreaming: true,
-              };
-
-              setMessages((prev) => [...prev, assistantMsg]);
-            } else {
-              setMessages((prev) =>
-                prev.map((m) => (m.id === assistantId ? { ...m, content: m.content + (event.data as string) } : m))
-              );
-            }
+            ensureSseAssistantCreated();
+            setMessages((prev) =>
+              prev.map((m) => (m.id === assistantId ? { ...m, content: m.content + (event.data as string) } : m))
+            );
           } else if (event.type === "sources") {
+            ensureSseAssistantCreated(undefined, event.data as SourceChunk[]);
             setMessages((prev) => prev.map((m) => (m.id === assistantId ? { ...m, sources: event.data as SourceChunk[] } : m)));
+          } else if (event.type === "thought") {
+            ensureSseAssistantCreated([event.data as string]);
+            setMessages((prev) =>
+              prev.map((m) => (m.id === assistantId ? { ...m, thoughts: [...(m.thoughts || []), event.data as string] } : m))
+            );
           } else if (event.type === "error") {
             setIsTyping(false);
             setMessages((prev) => prev.map((m) => (m.id === assistantId ? { ...m, content: `Error: ${event.data}`, isStreaming: false } : m)));

--- a/frontend/src/components/chat/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble.tsx
@@ -7,7 +7,7 @@ import rehypeHighlight from "rehype-highlight";
 import remarkGfm from "remark-gfm";
 import type { ChatMsg } from "@/store/chat-store";
 import { api } from "@/lib/api";
-import { Brain, User, Copy, Check, Share2, Link2, X, Play, Pause, GitBranch } from "lucide-react";
+import { Brain, User, Copy, Check, Share2, Link2, X, Play, Pause, GitBranch, ChevronDown } from "lucide-react";
 import { buttonVariants } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
@@ -64,6 +64,13 @@ export default function MessageBubble({ message }: Props) {
   const [shared, setShared] = useState(false);
   const [shareFailed, setShareFailed] = useState(false);
   const [isSpeaking, setIsSpeaking] = useState(false);
+  const [showThoughts, setShowThoughts] = useState(false);
+
+  useEffect(() => {
+    if (message.isStreaming && message.thoughts && message.thoughts.length > 0) {
+      setShowThoughts(true);
+    }
+  }, [message.isStreaming, message.thoughts]);
   const copiedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const sharedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const utteranceRef = useRef<SpeechSynthesisUtterance | null>(null);
@@ -294,6 +301,36 @@ const handleBranch = () => {
                   <TooltipContent>Branch conversation</TooltipContent>
                 </Tooltip>
               </>
+            )}
+
+            {message.thoughts && message.thoughts.length > 0 && (
+              <div className="mb-3 border border-border/60 rounded-lg bg-muted/40 overflow-hidden text-xs">
+                <button
+                  type="button"
+                  onClick={() => setShowThoughts((prev) => !prev)}
+                  className="w-full flex items-center justify-between px-3 py-2 text-muted-foreground hover:text-foreground font-medium transition-colors"
+                >
+                  <div className="flex items-center gap-1.5">
+                    <Brain className="w-3.5 h-3.5 animate-pulse text-primary" />
+                    <span>{message.isStreaming ? "Thinking..." : "View reasoning steps"}</span>
+                  </div>
+                  <ChevronDown
+                    className={cn(
+                      "w-3.5 h-3.5 transition-transform duration-200",
+                      showThoughts && "transform rotate-180"
+                    )}
+                  />
+                </button>
+                {showThoughts && (
+                  <div className="px-3 pb-3 pt-1 border-t border-border/40 space-y-2 max-h-60 overflow-y-auto font-mono text-[11px] leading-relaxed text-muted-foreground">
+                    {message.thoughts.map((thought, idx) => (
+                      <div key={idx} className="whitespace-pre-wrap border-l-2 border-primary/30 pl-2">
+                        {thought}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
             )}
 
             <div className={`prose-chat ${fontSizeClass} ${message.content ? "pr-20" : ""}`}>

--- a/frontend/src/store/chat-store.ts
+++ b/frontend/src/store/chat-store.ts
@@ -22,13 +22,14 @@ export interface SourceChunk {
 
 export interface ChatMsg {
   branch_id?: string;
-parent_message_id?: string;
+  parent_message_id?: string;
   id: string;
   role: "user" | "assistant";
   content: string;
   sources: SourceChunk[];
   feedback?: "up" | "down" | null;
   isStreaming?: boolean;
+  thoughts?: string[];
 }
 
 export interface ChatSession {


### PR DESCRIPTION

### 🔗 Related Issue
Closes #564

---

### 📝 What does this PR do?
Streams intermediate ReAct agent reasoning steps (thoughts, tool actions, and observations) in the WebSocket/SSE stream, and progressive token-by-token final answers in the chat stream.

Also updates the React frontend (`ChatPanel.tsx` and `MessageBubble.tsx`) to handle, parse, and display the intermediate reasoning steps within a collapsible animated accordion component.

---

### 🗂️ Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🔧 Refactor / code cleanup
- [ ] 📝 Documentation update
- [x] 🎨 UI / styling change
- [ ] ⚙️ CI / tooling / config change
- [ ] 🧪 Tests

---

### 🧪 How was this tested?
- [x] Ran the backend locally
- [x] Ran the frontend locally
- [x] Tested the affected API endpoints manually

---

### 📸 Screenshots (if UI change)

---

### ⚠️ Anything to flag for reviewers?
None.

---

### ✅ Self-Review Checklist
- [x] My branch is based on **`dev`**, not `main`
- [x] I have not added any secrets / API keys
- [x] I have not modified `main` branch or any HuggingFace deployment config
- [x] My code follows the existing style (no unnecessary formatting changes)
- [x] I have updated relevant docs / comments if needed
