### PR TITLE
fix: resolve runtime decorator reconstruction overhead in trace_call (#594)

### DIFF
--- a/backend/app/rag/tracing.py
+++ b/backend/app/rag/tracing.py
@@ -41,20 +41,37 @@ def _sanitize_metadata(metadata: Optional[dict[str, Any]]) -> dict[str, Any]:
     return {key: value for key, value in (metadata or {}).items() if value is not None}
 
 
-def _build_traceable(name: str, run_type: str, metadata: Optional[dict[str, Any]] = None):
-    """Build a LangSmith traceable decorator safely across versions."""
+from functools import lru_cache
+
+@lru_cache(maxsize=1024)
+def _get_cached_decorator(name: str, run_type: str, metadata_tuple: Optional[tuple[tuple[str, Any], ...]]) -> Optional[Callable[..., Any]]:
+    """Internal helper to instantiate and cache LangSmith decorators exactly once."""
     if _langsmith_traceable is None:
         return None
 
-    sanitized = _sanitize_metadata(metadata)
+    metadata = dict(metadata_tuple) if metadata_tuple else None
     try:
         return _langsmith_traceable(
             name=name,
             run_type=run_type,
-            metadata=sanitized or None,
+            metadata=metadata or None,
         )
     except TypeError:
         return _langsmith_traceable(name=name, run_type=run_type)
+
+
+def _build_traceable(name: str, run_type: str, metadata: Optional[dict[str, Any]] = None):
+    """Build a LangSmith traceable decorator safely across versions using a cache."""
+    sanitized = _sanitize_metadata(metadata)
+    # Convert mutable dict to an immutable, sorted tuple of items for lru_cache key safety
+    metadata_tuple = tuple(sorted(sanitized.items())) if sanitized else None
+    return _get_cached_decorator(name, run_type, metadata_tuple)
+
+
+@lru_cache(maxsize=1024)
+def _get_cached_traced_fn(decorator: Callable[..., Any], fn: Callable[..., Any]) -> Callable[..., Any]:
+    """Cache the application of the decorator onto the specific target function."""
+    return decorator(fn)
 
 
 def trace_call(
@@ -73,7 +90,8 @@ def trace_call(
     if decorator is None:
         return fn(*args, **kwargs)
 
-    traced_fn = decorator(fn)
+    # Completely eliminates runtime instantiation churn for both decorator and wrapped function
+    traced_fn = _get_cached_traced_fn(decorator, fn)
     return traced_fn(*args, **kwargs)
 
 


### PR DESCRIPTION


### 🔗 Related Issue
Closes #594

---

### 📝 What does this PR do?
This PR eliminates a significant CPU performance bottleneck occurring during high-throughput execution loops (such as batch processing or streaming data chunks in the RAG pipeline). 

Previously, `_build_traceable()` was called inside `trace_call` on every single invocation, dynamically reconstructing the underlying LangSmith SDK decorator. This caused massive dynamic allocation churn and high CPU overhead. 

**Changes introduced:**
- Added a cached helper `_get_cached_decorator` using `functools.lru_cache` to store and reuse identical decorator definitions.
- Converted the mutable `metadata` dictionary into an immutable, sorted `tuple` key structure so it can safely be memoized by the cache.
- Added `_get_cached_traced_fn` to cache the application of the decorator to a given target function, avoiding redundant runtime execution paths entirely.

---

### 🗂️ Type of Change
- [x] 🐛 Bug fix
- [x] 🔧 Refactor / code cleanup

---

### 🧪 How was this tested?
- [x] Ran the backend locally (`uvicorn app.main:app --reload`)
- [x] Tested the affected API endpoints manually to ensure LangSmith traces are still successfully registering and passing correct metadata configurations.

---

### 📸 Screenshots (if UI change)
*N/A*

---

### ⚠️ Anything to flag for reviewers?
The `lru_cache` bounds have been explicitly limited (`maxsize=1024`) to ensure memory consumption stays tightly bounded, preventing potential memory leaks from long-running application runtimes or dynamic tracing setups.

---

### ✅ Self-Review Checklist
- [x] My branch is based on **`dev`**, not `main`
- [x] I have not added any secrets / API keys
- [x] I have not modified `main` branch or any HuggingFace deployment config
- [x] My code follows the existing style (no unnecessary formatting changes)
- [x] I have updated relevant docs / comments if needed