### PR TITLE
fix: support async function tracing in trace_call and trace_function (#595)

### DIFF
--- a/backend/app/rag/tracing.py
+++ b/backend/app/rag/tracing.py
@@ -57,6 +57,28 @@ def _build_traceable(name: str, run_type: str, metadata: Optional[dict[str, Any]
         return _langsmith_traceable(name=name, run_type=run_type)
 
 
+import inspect
+
+async def async_trace_call(
+    name: str,
+    fn: Callable[..., Any],
+    *args: Any,
+    run_type: str = "chain",
+    metadata: Optional[dict[str, Any]] = None,
+    **kwargs: Any,
+) -> Any:
+    """Execute an asynchronous callable with LangSmith tracing when available."""
+    if not LANGSMITH_ENABLED:
+        return await fn(*args, **kwargs)
+
+    decorator = _build_traceable(name, run_type, metadata)
+    if decorator is None:
+        return await fn(*args, **kwargs)
+
+    traced_fn = decorator(fn)
+    return await traced_fn(*args, **kwargs)
+
+
 def trace_call(
     name: str,
     fn: Callable[..., Any],
@@ -65,7 +87,10 @@ def trace_call(
     metadata: Optional[dict[str, Any]] = None,
     **kwargs: Any,
 ) -> Any:
-    """Execute a callable with LangSmith tracing when available."""
+    """Execute a callable with LangSmith tracing when available. Supports both sync and async."""
+    if inspect.iscoroutinefunction(fn):
+        return async_trace_call(name, fn, *args, run_type=run_type, metadata=metadata, **kwargs)
+
     if not LANGSMITH_ENABLED:
         return fn(*args, **kwargs)
 
@@ -83,8 +108,22 @@ def trace_function(
     run_type: str = "chain",
     metadata_factory: Optional[Callable[..., dict[str, Any]]] = None,
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
-    """Decorator wrapper that becomes a no-op when LangSmith is disabled."""
+    """Decorator wrapper that becomes a no-op when LangSmith is disabled. Supports both sync and async."""
     def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
+        if inspect.iscoroutinefunction(fn):
+            @wraps(fn)
+            async def async_wrapped(*args: Any, **kwargs: Any) -> Any:
+                metadata = metadata_factory(*args, **kwargs) if metadata_factory else None
+                return await trace_call(
+                    name,
+                    fn,
+                    *args,
+                    run_type=run_type,
+                    metadata=metadata,
+                    **kwargs,
+                )
+            return async_wrapped
+
         @wraps(fn)
         def wrapped(*args: Any, **kwargs: Any) -> Any:
             metadata = metadata_factory(*args, **kwargs) if metadata_factory else None
@@ -96,7 +135,6 @@ def trace_function(
                 metadata=metadata,
                 **kwargs,
             )
-
         return wrapped
 
     return decorator


### PR DESCRIPTION
## 📋 PR Checklist

> Thank you for contributing to **PDF-Assistant-RAG**! 🎉  
> Please fill out this template before submitting. PRs without it filled in will be closed.

---

### 🔗 Related Issue
Closes #595

---

### 📝 What does this PR do?
This PR resolves an issue where asynchronous functions (`async def`) were not being traced properly by LangSmith. Previously, running an async function inside the synchronous wrapper returned an unawaited coroutine object immediately, resulting in inaccurate tracing spans that timed the coroutine creation rather than its actual async lifecyle and execution.

**Changes introduced:**
- Utilized `inspect.iscoroutinefunction(fn)` to check the execution type of target functions.
- Introduced a dedicated `async_trace_call` function path that accurately uses `await` on both the target function and the LangSmith traced function wrapper.
- Updated the `trace_function` decorator to dynamically provide an `async def async_wrapped` execution branch when decorating asynchronous codeblocks.

---

### 🗂️ Type of Change
- [x] 🐛 Bug fix

---

### 🧪 How was this tested?
- [x] Ran backend operations locally (`uvicorn app.main:app --reload`).
- [x] Verified that asynchronous functions (such as concurrent LLM API calls and embedding lookups) correctly await their results and produce accurate execution traces inside LangSmith without hanging or throwing unawaited coroutine warnings.

---

### 📸 Screenshots (if UI change)
*N/A*

---

### ⚠️ Anything to flag for reviewers?
None. Synchronous paths remain identical and un-impacted by this change.

---

### ✅ Self-Review Checklist
- [x] My branch is based on **`dev`**, not `main`
- [x] I have not added any secrets / API keys
- [x] I have not modified `main` branch or any HuggingFace deployment config
- [x] My code follows the existing style (no unnecessary formatting changes)
- [x] I have updated relevant docs / comments if needed