### PR TITLE
Fix/custom 404 page

### DIFF
--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -12,10 +12,11 @@ export default function NotFound() {
       </p>
 
       <div className="flex flex-wrap items-center justify-center gap-3">
-        <Button asChild>
-          <Link href="/">Return to Home</Link>
-        </Button>
-        
+        <Link href="/">
+          <Button>Return to Home</Button>
+        </Link>
+        <Link href="/dashboard">
+        </Link>
         <GoBackButton />
       </div>
     </div>

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -1,0 +1,23 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { GoBackButton } from "@/components/GoBackButton";
+
+export default function NotFound() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-6 px-4 text-center">
+      <h1 className="text-6xl font-bold tracking-tight">404</h1>
+      <h2 className="text-2xl font-semibold">Page Not Found</h2>
+      <p className="max-w-md text-muted-foreground">
+        The page you&apos;re looking for doesn&apos;t exist or may have been moved.
+      </p>
+
+      <div className="flex flex-wrap items-center justify-center gap-3">
+        <Button asChild>
+          <Link href="/">Return to Home</Link>
+        </Button>
+        
+        <GoBackButton />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/GoBackButton.tsx
+++ b/frontend/src/components/GoBackButton.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+
+export function GoBackButton() {
+  return (
+    <Button variant="outline" onClick={() => window.history.back()}>
+      Go Back
+    </Button>
+  );
+}


### PR DESCRIPTION
## 📋 PR Checklist

> Thank you for contributing to **PDF-Assistant-RAG**! 🎉  
> Please fill out this template before submitting. PRs without it filled in will be closed.

---

### 🔗 Related Issue
Closes #568

---

### 📝 What does this PR do?
Adds a custom 404 (not-found) page for the Next.js App Router frontend. Previously, navigating to an unmatched route showed a generic/unclear error response instead of a branded page.

The new page:
- Clearly indicates the requested page doesn't exist
- Provides navigation options: **Return to Home**, and **Go Back** (browser history)
- Matches the existing app's styling (Tailwind + shadcn/ui Button component)

---

### 🗂️ Type of Change
<!-- Check all that apply -->
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔧 Refactor / code cleanup
- [ ] 📝 Documentation update
- [x] 🎨 UI / styling change
- [ ] ⚙️ CI / tooling / config change
- [ ] 🧪 Tests

---

### 🧪 How was this tested?
<!-- Describe how you verified your changes work. -->
- [ ] Ran the backend locally (`uvicorn app.main:app --reload`)
- [x] Ran the frontend locally (`npm run dev` inside `frontend/`)
- [x] Tested the affected API endpoints manually
- [ ] Added / updated tests

---

### 📸 Screenshots (if UI change)

<img width="1680" height="1012" alt="Screenshot 2026-06-14 at 1 32 32 PM" src="https://github.com/user-attachments/assets/116bfe45-e044-45b0-8867-2ac1ca909981" />

---

### ⚠️ Anything to flag for reviewers?

- The `Button` component in this project (`@base-ui/react/button`-based) doesn't support an `asChild` prop, so the navigation links use `<Link><Button>...</Button></Link>` composition instead.
- A pre-existing console warning from `ThemeProvider`/`next-themes` ("Encountered a script tag while rendering React component") appears on this route too — verified via `git stash` that it exists independently of this change, so it's out of scope here.


---

### ✅ Self-Review Checklist
- [x] My branch is based on **`dev`**, not `main`
- [x] I have not added any secrets / API keys
- [x] I have not modified `main` branch or any HuggingFace deployment config
- [x] My code follows the existing style (no unnecessary formatting changes)
- [ ] I have updated relevant docs / comments if needed
