### PR TITLE
feat(api): add pagination and search filters to documents list endpoint

### DIFF
--- a/backend/app/routes/documents.py
+++ b/backend/app/routes/documents.py
@@ -77,6 +77,42 @@ def _deserialize_doc(doc: Document) -> DocumentResponse:
             response = response.model_copy(update={"extracted_urls": []})
     return response
 
+def _get_documents_query(
+    db: Session,
+    user_id: str,
+    q: Optional[str] = None,
+):
+    """
+    Build a filtered SQLAlchemy select query for documents belonging to a user.
+
+    Applies an optional case-insensitive substring filter on ``original_name``.
+    Does NOT apply pagination – callers are responsible for ``.limit()`` /
+    ``.offset()`` so this helper stays reusable.
+
+    Args:
+        db:      Active database session.
+        user_id: ID of the authenticated user whose documents to query.
+        q:       Optional keyword to filter document names (case-insensitive).
+
+    Returns:
+        A SQLAlchemy ``Select`` statement ready for count or paginated execution.
+    """
+    base_query = (
+        select(Document)
+        .where(
+            Document.user_id == user_id,
+            Document.is_deleted.is_(False),
+        )
+    )
+
+    if q and q.strip():
+        pattern = f"%{q.strip()}%"
+        base_query = base_query.where(
+            Document.original_name.ilike(pattern)
+        )
+
+    return base_query
+
 async def validate_upload(file: UploadFile):
     """Validate an uploaded file and save it to a temporary file.
 
@@ -432,46 +468,38 @@ def list_documents(
     per_page: int = Query(20, ge=1, le=100, description="Results per page"),
     limit: int = Query(None, ge=1, le=100, description="Alias for per_page"),
     q: Optional[str] = Query(None, description="Filter by document name (case-insensitive)"),
+    query: Optional[str] = Query(None, description="Alias for q – filter by document name"),
     user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
     """
-    List documents for the authenticated user with pagination and name search.
+    List documents for the authenticated user with offset pagination and
+    optional keyword search on document names.
 
-    Supports offset pagination via `page` / `per_page` (or `limit` alias)
-    and optional keyword filtering on the original document name.
+    Pagination is controlled by ``page`` and ``per_page`` (or its alias
+    ``limit``).  Search is applied via ``query`` (or its short alias ``q``),
+    which performs a case-insensitive substring match on ``original_name``.
 
     Args:
         page:     Page number to retrieve (1-indexed). Defaults to 1.
         per_page: Number of documents per page. Defaults to 20, max 100.
-        limit:    Alias for per_page — whichever is supplied takes effect.
+        limit:    Alias for per_page – whichever is supplied takes effect.
         q:        Case-insensitive substring filter on original_name.
+        query:    Alias for q – whichever is supplied takes effect.
         user:     Authenticated user injected by get_current_user.
         db:       Database session injected by get_db.
 
     Returns:
         DocumentListResponse with items, total, page, pages, total_pages,
-        and limit fields.
+        limit, and query fields.
     """
-    # Allow `limit` as an alias for `per_page`
+    # Allow `limit` as alias for `per_page`; `query` as alias for `q`
     effective_limit = limit if limit is not None else per_page
+    effective_query = query if query is not None else q
     skip = (page - 1) * effective_limit
 
-    # ── Base query ────────────────────────────────────────────────────────────
-    base_query = (
-        select(Document)
-        .where(
-            Document.user_id == user.id,
-            Document.is_deleted.is_(False),
-        )
-    )
-
-    # ── Keyword filter on document name ───────────────────────────────────────
-    if q and q.strip():
-        pattern = f"%{q.strip()}%"
-        base_query = base_query.where(
-            Document.original_name.ilike(pattern)
-        )
+    # ── Build filtered query via helper ───────────────────────────────────────
+    base_query = _get_documents_query(db, user.id, effective_query)
 
     # ── Total count (before pagination) ──────────────────────────────────────
     total = db.execute(
@@ -495,6 +523,7 @@ def list_documents(
         pages=total_pages,
         total_pages=total_pages,
         limit=effective_limit,
+        query=effective_query,
     )
 
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -247,6 +247,7 @@ class DocumentListResponse(BaseModel):
     pages: int
     total_pages: int
     limit: int
+    query: Optional[str] = None
 
 
 # Admin


### PR DESCRIPTION
### 🔗 Related Issue
Closes #428

---

### 📝 What does this PR do?

Adds pagination and keyword search filtering to the `GET /documents/` list endpoint.

- Extracts document filtering logic into a reusable `_get_documents_query()` helper function
- Adds `query` as a named parameter (alongside existing `q` alias) for filtering documents by name (case-insensitive substring match)
- Returns pagination metadata in the response: `total`, `page`, `total_pages`, `limit`, and the active `query` filter
- Updates `DocumentListResponse` schema to include the `query` field so clients can confirm which filter was applied

---

### 🗂️ Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [x] 🔧 Refactor / code cleanup
- [ ] 📝 Documentation update
- [ ] 🎨 UI / styling change
- [ ] ⚙️ CI / tooling / config change
- [ ] 🧪 Tests

---

### 🧪 How was this tested?

- [x] Ran the backend locally (`uvicorn app.main:app --reload`)
- [ ] Ran the frontend locally (`npm run dev` inside `frontend/`)
- [x] Tested the affected API endpoints manually

Verified the following via the `/docs` Swagger UI:

- `GET /documents/` returns all documents with correct `total`, `page`, `total_pages`, and `limit` fields
- `GET /documents/?query=report` returns only documents whose name contains "report" (case-insensitive)
- `GET /documents/?page=2&per_page=5` returns the correct page slice and metadata
- `GET /documents/?limit=10` works as alias for `per_page`
- `GET /documents/?q=invoice` still works (backward-compatible alias)
- Empty result sets return `total: 0`, `total_pages: 1`, `items: []` correctly

---

### ✅ Self-Review Checklist
- [x] My branch is based on **`dev`**, not `main`
- [x] I have not added any secrets / API keys
- [x] I have not modified `main` branch or any HuggingFace deployment config
- [x] My code follows the existing style (no unnecessary formatting changes)
- [x] I have updated relevant docs / comments if needed