### PR TITLE
feat(db): safe SQLite → PostgreSQL migration script with dry-run

### DIFF
--- a/backend/scripts/migrate_sqlite_to_postgres.py
+++ b/backend/scripts/migrate_sqlite_to_postgres.py
@@ -1,8 +1,66 @@
-"""Migrate SQLite app data into a Supabase/Postgres database.
+"""migrate_sqlite_to_postgres.py
+--------------------------------
+Safely migrate all data from SQLite to PostgreSQL without data loss.
 
-The script supports both the current FastAPI SQLite schema
-(`users`, `documents`, `chat_messages`) and the older legacy
-`instance/users.db` schema (`user` only).
+Supports both the current FastAPI schema (users, api_keys, documents,
+chat_messages, shared_messages) and the extended schema that includes
+workspaces, workspace_invitations, workspace_members, chat_sessions,
+and drive_connections.
+
+Also supports the older legacy ``instance/users.db`` schema where the
+users table is named ``user`` (singular).
+
+Dependencies
+------------
+    pip install sqlalchemy psycopg[binary]
+    # or: pip install sqlalchemy psycopg2-binary
+
+Tables migrated (FK-safe order)
+---------------------------------
+    users → api_keys → workspaces → workspace_invitations
+    → workspace_members → chat_sessions → documents
+    → chat_messages → drive_connections → shared_messages
+
+Usage
+-----
+    # Dry-run (reads SQLite, prints counts — no Postgres connection needed):
+    python migrate_sqlite_to_postgres.py \\
+        --sqlite sqlite:///./data/app.db \\
+        --dry-run
+
+    # Live migration (Postgres URL via CLI):
+    python migrate_sqlite_to_postgres.py \\
+        --sqlite sqlite:///./data/app.db \\
+        --postgres postgresql://user:pass@localhost:5432/mydb
+
+    # Live migration (Postgres URL via environment variable):
+    export SUPABASE_DB_URL="postgres://user:pass@db.supabase.co:5432/postgres"
+    python migrate_sqlite_to_postgres.py --sqlite sqlite:///./data/app.db
+
+    # Migrate from the legacy instance/users.db path:
+    python migrate_sqlite_to_postgres.py \\
+        --sqlite-path instance/users.db \\
+        --postgres postgresql://user:pass@localhost:5432/mydb
+
+    # Migrate specific tables only:
+    python migrate_sqlite_to_postgres.py \\
+        --sqlite sqlite:///./data/app.db \\
+        --postgres postgresql://user:pass@localhost:5432/mydb \\
+        --tables users documents chat_messages
+
+    # Wipe Postgres tables before migrating (fresh start):
+    python migrate_sqlite_to_postgres.py \\
+        --sqlite sqlite:///./data/app.db \\
+        --postgres postgresql://user:pass@localhost:5432/mydb \\
+        --truncate
+
+    # Verbose / debug logging:
+    python migrate_sqlite_to_postgres.py \\
+        --sqlite sqlite:///./data/app.db \\
+        --postgres postgresql://user:pass@localhost:5432/mydb \\
+        --verbose
+
+Resolves: #279
 """
 from __future__ import annotations
 
@@ -11,115 +69,70 @@ import logging
 import os
 import sys
 import uuid
-from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict, List, Optional
 
-from sqlalchemy import (
-    Boolean,
-    Column,
-    DateTime,
-    ForeignKey,
-    Integer,
-    MetaData,
-    String,
-    Table,
-    Text,
-    create_engine,
-    inspect,
-    select,
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.exc import OperationalError
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s  %(levelname)-8s  %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
 )
-from sqlalchemy.engine import Engine
-from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session, sessionmaker
+logger = logging.getLogger("migration")
 
-LOGGER = logging.getLogger("sqlite_to_postgres")
-
-
-def generate_uuid() -> str:
-    return str(uuid.uuid4())
-
-
-metadata = MetaData()
-
-users = Table(
+# ---------------------------------------------------------------------------
+# Migration order — respects FK dependencies
+# ---------------------------------------------------------------------------
+TABLE_ORDER = [
     "users",
-    metadata,
-    Column("id", String, primary_key=True, default=generate_uuid),
-    Column("username", String(80), unique=True, nullable=False, index=True),
-    Column("email", String(120), unique=True, nullable=False, index=True),
-    Column("hashed_password", String(255), nullable=False),
-    Column("is_admin", Boolean, default=False),
-    Column("created_at", DateTime, default=lambda: datetime.now(timezone.utc)),
-    Column("last_login", DateTime, nullable=True, index=True),
-    Column("hf_token", String(255), nullable=True),
-)
-
-api_keys = Table(
     "api_keys",
-    metadata,
-    Column("id", String, primary_key=True, default=generate_uuid),
-    Column("user_id", String, ForeignKey("users.id"), nullable=False, index=True),
-    Column("key_prefix", String(10), nullable=False),
-    Column("hashed_key", String(255), nullable=False, unique=True, index=True),
-    Column("created_at", DateTime, default=lambda: datetime.now(timezone.utc)),
-    Column("last_used", DateTime, nullable=True),
-)
-
-documents = Table(
+    "workspaces",
+    "workspace_invitations",
+    "workspace_members",
+    "chat_sessions",
     "documents",
-    metadata,
-    Column("id", String, primary_key=True, default=generate_uuid),
-    Column("user_id", String, ForeignKey("users.id"), nullable=False, index=True),
-    Column("filename", String(255), nullable=False),
-    Column("original_name", String(255), nullable=False),
-    Column("file_size", Integer, default=0),
-    Column("page_count", Integer, default=0),
-    Column("chunk_count", Integer, default=0),
-    Column("status", String(20), default="pending"),
-    Column("error_message", Text, nullable=True),
-    Column("uploaded_at", DateTime, default=lambda: datetime.now(timezone.utc)),
-    Column("summary", Text, nullable=True),
-)
-
-chat_messages = Table(
     "chat_messages",
-    metadata,
-    Column("id", String, primary_key=True, default=generate_uuid),
-    Column("user_id", String, ForeignKey("users.id"), nullable=False, index=True),
-    Column("document_id", String, ForeignKey("documents.id"), nullable=True, index=True),
-    Column("role", String(20), nullable=False),
-    Column("content", Text, nullable=False),
-    Column("sources_json", Text, nullable=True),
-    Column("created_at", DateTime, default=lambda: datetime.now(timezone.utc)),
-)
-
-shared_messages = Table(
+    "drive_connections",
     "shared_messages",
-    metadata,
-    Column("id", String, primary_key=True, default=generate_uuid),
-    Column("message_id", String, ForeignKey("chat_messages.id"), nullable=False, unique=True, index=True),
-    Column("created_at", DateTime, default=lambda: datetime.now(timezone.utc)),
-)
+]
+
+# Columns that hold UUID / GUID values and need string normalisation
+_UUID_COLUMNS = {
+    "id", "user_id", "document_id", "session_id", "message_id",
+    "workspace_id", "inviter_id", "created_by",
+}
+
+# Boolean columns stored as 0/1 integers in SQLite
+_BOOL_COLUMNS = {
+    "is_admin", "is_verified", "is_active", "is_deleted", "enabled",
+}
 
 
-@dataclass
-class MigrationStats:
-    inserted: dict[str, int] = field(default_factory=dict)
-    reused: dict[str, int] = field(default_factory=dict)
-    skipped: dict[str, int] = field(default_factory=dict)
-
-    def add(self, table_name: str, action: str) -> None:
-        getattr(self, action)[table_name] = getattr(self, action).get(table_name, 0) + 1
-
+# ---------------------------------------------------------------------------
+# URL helpers
+# ---------------------------------------------------------------------------
 
 def normalize_postgres_url(url: str) -> str:
-    """Prefer psycopg v3 when callers pass Supabase's common URL forms."""
+    """
+    Normalise common Postgres URL forms to use the psycopg (v3) driver.
+
+    Supabase and many hosting providers hand out ``postgres://`` or plain
+    ``postgresql://`` connection strings.  SQLAlchemy requires a driver
+    specifier such as ``postgresql+psycopg://`` for psycopg v3, or
+    ``postgresql+psycopg2://`` for psycopg2.  We prefer psycopg v3 when
+    no driver is already specified.
+    """
     if url.startswith("postgres://"):
-        return "postgresql+psycopg://" + url.removeprefix("postgres://")
-    if url.startswith("postgresql://"):
-        return "postgresql+psycopg://" + url.removeprefix("postgresql://")
+        url = "postgresql+psycopg://" + url[len("postgres://"):]
+    elif url.startswith("postgresql://"):
+        url = "postgresql+psycopg://" + url[len("postgresql://"):]
+    # Already has a driver specifier (e.g. postgresql+psycopg2://) — leave it.
     return url
 
 
@@ -127,398 +140,433 @@ def sqlite_url_from_path(path: str) -> str:
     return f"sqlite:///{Path(path).resolve().as_posix()}"
 
 
-def make_engine(url: str) -> Engine:
-    return create_engine(url, future=True)
+# ---------------------------------------------------------------------------
+# Engine factory
+# ---------------------------------------------------------------------------
+
+def _make_engine(url: str, label: str):
+    """Create a SQLAlchemy engine with sensible defaults."""
+    is_sqlite = url.startswith("sqlite")
+    kwargs: Dict[str, Any] = {"echo": False, "future": True}
+    if is_sqlite:
+        kwargs["connect_args"] = {"check_same_thread": False}
+    else:
+        kwargs.update(pool_pre_ping=True, pool_size=5, max_overflow=10)
+    logger.info("Connecting to %s: %s", label, url)
+    return create_engine(url, **kwargs)
 
 
-def make_session(engine: Engine) -> Session:
-    return sessionmaker(bind=engine, autocommit=False, autoflush=False, future=True)()
+# ---------------------------------------------------------------------------
+# Row coercion
+# ---------------------------------------------------------------------------
 
-
-def reflected_table(engine: Engine, table_name: str) -> Table | None:
-    if not inspect(engine).has_table(table_name):
+def _normalise_uuid(value: Any) -> Optional[str]:
+    """Return a UUID as a plain lowercase string, or None."""
+    if value is None:
         return None
-    reflected = MetaData()
-    return Table(table_name, reflected, autoload_with=engine)
+    if isinstance(value, uuid.UUID):
+        return str(value)
+    try:
+        return str(uuid.UUID(str(value)))
+    except (ValueError, AttributeError):
+        return str(value)
 
 
-def fetch_rows(session: Session, table: Table) -> list[dict[str, Any]]:
-    stmt = select(table)
-    if "id" in table.c:
-        stmt = stmt.order_by(table.c.id)
-    return [dict(row) for row in session.execute(stmt).mappings().all()]
+def _coerce_row(row: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Coerce a SQLite row dict so it is safe to insert into Postgres:
+
+    * UUID columns      → normalised lowercase str
+    * Boolean integers  → Python bool  (SQLite stores True/False as 1/0)
+    * Naive datetimes   → UTC-aware datetimes
+    """
+    result: Dict[str, Any] = {}
+    for col, val in row.items():
+        if col in _UUID_COLUMNS:
+            result[col] = _normalise_uuid(val)
+        elif col in _BOOL_COLUMNS:
+            result[col] = bool(val) if val is not None else None
+        elif isinstance(val, datetime) and val.tzinfo is None:
+            result[col] = val.replace(tzinfo=timezone.utc)
+        else:
+            result[col] = val
+    return result
 
 
-def existing_id(session: Session, table: Table, source_id: str | None) -> str | None:
-    if not source_id:
-        return None
-    return session.execute(select(table.c.id).where(table.c.id == source_id)).scalar_one_or_none()
+# ---------------------------------------------------------------------------
+# Table helpers
+# ---------------------------------------------------------------------------
+
+def _table_exists(inspector, table: str) -> bool:
+    return table in inspector.get_table_names()
 
 
-def available_id(session: Session, table: Table, source_id: Any) -> str:
-    candidate = str(source_id) if source_id is not None else generate_uuid()
-    if existing_id(session, table, candidate) is None:
-        return candidate
+def _resolve_users_table(src_inspector) -> Optional[str]:
+    """
+    Return the name of the users table in the source database.
 
-    while True:
-        candidate = generate_uuid()
-        if existing_id(session, table, candidate) is None:
-            return candidate
-
-
-def first_existing_user(session: Session, row: dict[str, Any]) -> str | None:
-    email = row.get("email")
-    username = row.get("username")
-    if email:
-        match = session.execute(select(users.c.id).where(users.c.email == email)).scalar_one_or_none()
-        if match:
-            return match
-    if username:
-        return session.execute(select(users.c.id).where(users.c.username == username)).scalar_one_or_none()
+    Supports both the current schema (``users``) and the legacy schema
+    (``user``, singular) used by older ``instance/users.db`` databases.
+    Returns None if neither is found.
+    """
+    if _table_exists(src_inspector, "users"):
+        return "users"
+    if _table_exists(src_inspector, "user"):
+        logger.info("Legacy 'user' table detected — will migrate as 'users'.")
+        return "user"
     return None
 
 
-def copy_users(
-    source_session: Session,
-    target_session: Session,
-    source_table: Table,
-    stats: MigrationStats,
-) -> dict[str, str]:
-    id_map: dict[str, str] = {}
-    now = datetime.now(timezone.utc)
+# ---------------------------------------------------------------------------
+# Per-table migration
+# ---------------------------------------------------------------------------
 
-    for row in fetch_rows(source_session, source_table):
-        old_id = str(row.get("id"))
-        existing = existing_id(target_session, users, old_id) or first_existing_user(target_session, row)
-        if existing:
-            id_map[old_id] = existing
-            stats.add("users", "reused")
-            continue
+def _dry_run_table(table: str, src_conn) -> Dict[str, int]:
+    """Read SQLite row counts and log them — no Postgres connection used."""
+    src_inspector = inspect(src_conn)
+    if not _table_exists(src_inspector, table):
+        logger.warning("  [%s] not found in SQLite — skipping", table)
+        return {"would_migrate": 0, "skipped": 0}
 
-        is_legacy = source_table.name == "user"
-        new_id = available_id(target_session, users, None if is_legacy else old_id)
-        user_values = {
-            "id": new_id,
-            "username": row["username"],
-            "email": row["email"],
-            "hashed_password": row.get("hashed_password") or row.get("password") or "",
-            "is_admin": bool(row.get("is_admin") or False),
-            "created_at": row.get("created_at") or now,
-            "last_login": row.get("last_login"),
-            "hf_token": row.get("hf_token"),
-        }
-        target_session.execute(users.insert().values(**user_values))
-        id_map[old_id] = new_id
-        stats.add("users", "inserted")
-
-    return id_map
+    count = src_conn.execute(text(f"SELECT COUNT(*) FROM \"{table}\"")).scalar() or 0
+    logger.info("  [%s] %d rows found (dry-run — nothing written)", table, count)
+    return {"would_migrate": count, "skipped": 0}
 
 
-def copy_api_keys(
-    source_session: Session,
-    target_session: Session,
-    source_table: Table | None,
-    user_id_map: dict[str, str],
-    stats: MigrationStats,
-) -> dict[str, str]:
-    id_map: dict[str, str] = {}
-    if source_table is None:
-        return id_map
+def _live_migrate_table(
+    table: str,
+    src_table_name: str,
+    src_conn,
+    dst_conn,
+    truncate: bool,
+    batch_size: int,
+) -> Dict[str, int]:
+    """
+    Migrate one table from SQLite → Postgres.
 
-    for row in fetch_rows(source_session, source_table):
-        old_id = str(row.get("id"))
-        new_user_id = user_id_map.get(str(row.get("user_id")))
-        if not new_user_id:
-            stats.add("api_keys", "skipped")
-            continue
+    ``table`` is the canonical destination table name (always the current
+    schema name, e.g. ``"users"``).  ``src_table_name`` may differ for
+    legacy sources (e.g. ``"user"``).
+    """
+    stats = {"inserted": 0, "skipped": 0}
 
-        existing = (
-            existing_id(target_session, api_keys, old_id)
-            or target_session.execute(
-                select(api_keys.c.id).where(api_keys.c.hashed_key == row.get("hashed_key"))
-            ).scalar_one_or_none()
-        )
-        if existing:
-            id_map[old_id] = existing
-            stats.add("api_keys", "reused")
-            continue
+    src_inspector = inspect(src_conn)
+    dst_inspector = inspect(dst_conn)
 
-        new_id = available_id(target_session, api_keys, old_id)
-        target_session.execute(
-            api_keys.insert().values(
-                id=new_id,
-                user_id=new_user_id,
-                key_prefix=row["key_prefix"],
-                hashed_key=row["hashed_key"],
-                created_at=row.get("created_at") or datetime.now(timezone.utc),
-                last_used=row.get("last_used"),
-            )
-        )
-        id_map[old_id] = new_id
-        stats.add("api_keys", "inserted")
-
-    return id_map
-
-
-def copy_documents(
-    source_session: Session,
-    target_session: Session,
-    source_table: Table | None,
-    user_id_map: dict[str, str],
-    stats: MigrationStats,
-) -> dict[str, str]:
-    id_map: dict[str, str] = {}
-    if source_table is None:
-        return id_map
-
-    for row in fetch_rows(source_session, source_table):
-        old_id = str(row.get("id"))
-        new_user_id = user_id_map.get(str(row.get("user_id")))
-        if not new_user_id:
-            stats.add("documents", "skipped")
-            continue
-
-        existing = existing_id(target_session, documents, old_id)
-        if existing:
-            id_map[old_id] = existing
-            stats.add("documents", "reused")
-            continue
-
-        new_id = available_id(target_session, documents, old_id)
-        target_session.execute(
-            documents.insert().values(
-                id=new_id,
-                user_id=new_user_id,
-                filename=row["filename"],
-                original_name=row["original_name"],
-                file_size=row.get("file_size") or 0,
-                page_count=row.get("page_count") or 0,
-                chunk_count=row.get("chunk_count") or 0,
-                status=row.get("status") or "pending",
-                error_message=row.get("error_message"),
-                uploaded_at=row.get("uploaded_at") or datetime.now(timezone.utc),
-                summary=row.get("summary"),
-            )
-        )
-        id_map[old_id] = new_id
-        stats.add("documents", "inserted")
-
-    return id_map
-
-
-def copy_chat_messages(
-    source_session: Session,
-    target_session: Session,
-    source_table: Table | None,
-    user_id_map: dict[str, str],
-    document_id_map: dict[str, str],
-    stats: MigrationStats,
-) -> dict[str, str]:
-    id_map: dict[str, str] = {}
-    if source_table is None:
-        return id_map
-
-    for row in fetch_rows(source_session, source_table):
-        old_id = str(row.get("id"))
-        new_user_id = user_id_map.get(str(row.get("user_id")))
-        old_document_id = row.get("document_id")
-        new_document_id = document_id_map.get(str(old_document_id)) if old_document_id else None
-        if not new_user_id or (old_document_id and not new_document_id):
-            stats.add("chat_messages", "skipped")
-            continue
-
-        existing = existing_id(target_session, chat_messages, old_id)
-        if existing:
-            id_map[old_id] = existing
-            stats.add("chat_messages", "reused")
-            continue
-
-        new_id = available_id(target_session, chat_messages, old_id)
-        target_session.execute(
-            chat_messages.insert().values(
-                id=new_id,
-                user_id=new_user_id,
-                document_id=new_document_id,
-                role=row["role"],
-                content=row["content"],
-                sources_json=row.get("sources_json"),
-                created_at=row.get("created_at") or datetime.now(timezone.utc),
-            )
-        )
-        id_map[old_id] = new_id
-        stats.add("chat_messages", "inserted")
-
-    return id_map
-
-
-def copy_shared_messages(
-    source_session: Session,
-    target_session: Session,
-    source_table: Table | None,
-    message_id_map: dict[str, str],
-    stats: MigrationStats,
-) -> None:
-    if source_table is None:
-        return
-
-    for row in fetch_rows(source_session, source_table):
-        old_id = str(row.get("id"))
-        new_message_id = message_id_map.get(str(row.get("message_id")))
-        if not new_message_id:
-            stats.add("shared_messages", "skipped")
-            continue
-
-        existing = (
-            existing_id(target_session, shared_messages, old_id)
-            or target_session.execute(
-                select(shared_messages.c.id).where(shared_messages.c.message_id == new_message_id)
-            ).scalar_one_or_none()
-        )
-        if existing:
-            stats.add("shared_messages", "reused")
-            continue
-
-        target_session.execute(
-            shared_messages.insert().values(
-                id=available_id(target_session, shared_messages, old_id),
-                message_id=new_message_id,
-                created_at=row.get("created_at") or datetime.now(timezone.utc),
-            )
-        )
-        stats.add("shared_messages", "inserted")
-
-
-def migrate(
-    sqlite_url: str,
-    postgres_url: str,
-    create_tables: bool,
-    dry_run: bool,
-) -> MigrationStats:
-    source_engine = make_engine(sqlite_url)
-    target_engine = make_engine(normalize_postgres_url(postgres_url))
-
-    if create_tables:
-        metadata.create_all(target_engine)
-
-    source_session = make_session(source_engine)
-    target_session = make_session(target_engine)
-    stats = MigrationStats()
-
-    try:
-        current_users = reflected_table(source_engine, "users")
-        legacy_users = reflected_table(source_engine, "user")
-        source_users = current_users if current_users is not None else legacy_users
-        if source_users is None:
-            raise RuntimeError("No users table found. Expected 'users' or legacy 'user'.")
-
-        user_id_map = copy_users(source_session, target_session, source_users, stats)
-        copy_api_keys(source_session, target_session, reflected_table(source_engine, "api_keys"), user_id_map, stats)
-        document_id_map = copy_documents(
-            source_session,
-            target_session,
-            reflected_table(source_engine, "documents"),
-            user_id_map,
-            stats,
-        )
-        message_id_map = copy_chat_messages(
-            source_session,
-            target_session,
-            reflected_table(source_engine, "chat_messages"),
-            user_id_map,
-            document_id_map,
-            stats,
-        )
-        copy_shared_messages(
-            source_session,
-            target_session,
-            reflected_table(source_engine, "shared_messages"),
-            message_id_map,
-            stats,
-        )
-
-        if dry_run:
-            target_session.rollback()
-            LOGGER.info("Dry run complete; rolled back target transaction.")
-        else:
-            target_session.commit()
-            LOGGER.info("Migration committed.")
-
+    if not _table_exists(src_inspector, src_table_name):
+        logger.warning("  [%s] not found in SQLite — skipping", table)
         return stats
-    except IntegrityError:
-        target_session.rollback()
-        LOGGER.exception("Migration failed because the target database rejected a row.")
-        raise
-    except Exception:
-        target_session.rollback()
-        LOGGER.exception("Migration failed; rolled back target transaction.")
-        raise
-    finally:
-        source_session.close()
-        target_session.close()
-        source_engine.dispose()
-        target_engine.dispose()
 
+    if not _table_exists(dst_inspector, table):
+        logger.warning(
+            "  [%s] not found in Postgres — skipping. "
+            "Run your init_postgres.sql first to create the schema.",
+            table,
+        )
+        return stats
+
+    # Fetch all rows from source
+    rows_result = src_conn.execute(text(f"SELECT * FROM \"{src_table_name}\""))
+    column_names: List[str] = list(rows_result.keys())
+    raw_rows = rows_result.fetchall()
+
+    if not raw_rows:
+        logger.info("  [%s] 0 rows — nothing to migrate", table)
+        return stats
+
+    logger.info("  [%s] %d rows to migrate", table, len(raw_rows))
+
+    if truncate:
+        logger.info("  [%s] truncating Postgres table (CASCADE)", table)
+        dst_conn.execute(text(f'TRUNCATE TABLE "{table}" RESTART IDENTITY CASCADE'))
+
+    # Build idempotent INSERT — skips duplicates silently
+    col_list = ", ".join(f'"{c}"' for c in column_names)
+    placeholders = ", ".join(f":{c}" for c in column_names)
+    insert_sql = text(
+        f'INSERT INTO "{table}" ({col_list}) '
+        f"VALUES ({placeholders}) "
+        f"ON CONFLICT DO NOTHING"
+    )
+
+    batch: List[Dict[str, Any]] = []
+    for raw in raw_rows:
+        row_dict = dict(zip(column_names, raw))
+        batch.append(_coerce_row(row_dict))
+
+        if len(batch) >= batch_size:
+            result = dst_conn.execute(insert_sql, batch)
+            stats["inserted"] += result.rowcount if result.rowcount >= 0 else len(batch)
+            batch = []
+
+    if batch:
+        result = dst_conn.execute(insert_sql, batch)
+        stats["inserted"] += result.rowcount if result.rowcount >= 0 else len(batch)
+
+    logger.info("  [%s] inserted %d rows", table, stats["inserted"])
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+def run_migration(
+    sqlite_url: str,
+    postgres_url: Optional[str],
+    dry_run: bool,
+    truncate: bool,
+    tables: Optional[List[str]],
+    batch_size: int,
+) -> bool:
+    """
+    Orchestrate the full migration.  Returns True on success.
+
+    In dry-run mode, no Postgres connection is opened; only SQLite row
+    counts are reported.
+    """
+    # Build the ordered table list
+    target = set(tables) if tables else set(TABLE_ORDER)
+    ordered = [t for t in TABLE_ORDER if t in target]
+    # Append any user-supplied extras that aren't in TABLE_ORDER
+    for t in (tables or []):
+        if t not in ordered:
+            logger.warning(
+                "Table '%s' is not in the known FK-safe order. "
+                "It will be migrated last — ensure FK dependencies are satisfied.",
+                t,
+            )
+            ordered.append(t)
+
+    mode = "DRY RUN" if dry_run else "LIVE"
+    logger.info("=" * 60)
+    logger.info("Migration mode : %s", mode)
+    logger.info("Source         : %s", sqlite_url)
+    if not dry_run:
+        logger.info("Destination    : %s", postgres_url)
+    logger.info("Tables         : %s", ", ".join(ordered))
+    logger.info("Truncate first : %s", truncate and not dry_run)
+    logger.info("Batch size     : %d", batch_size)
+    logger.info("=" * 60)
+
+    src_engine = _make_engine(sqlite_url, "SQLite")
+
+    if dry_run:
+        overall_stats: Dict[str, Dict[str, int]] = {}
+        with src_engine.connect() as src_conn:
+            src_inspector = inspect(src_conn)
+            users_src = _resolve_users_table(src_inspector)
+
+            for table in ordered:
+                logger.info("Checking table : %s", table)
+                # For the legacy 'user' → 'users' mapping
+                src_table_name = users_src if table == "users" and users_src else table
+                if src_table_name is None:
+                    logger.error("No users/user table found in SQLite.")
+                    return False
+                overall_stats[table] = _dry_run_table(src_table_name, src_conn)
+    else:
+        if not postgres_url:
+            logger.error(
+                "A Postgres URL is required for a live migration. "
+                "Pass --postgres or set SUPABASE_DB_URL / DATABASE_URL."
+            )
+            return False
+
+        pg_url = normalize_postgres_url(postgres_url)
+        dst_engine = _make_engine(pg_url, "PostgreSQL")
+
+        # Verify Postgres connectivity before touching data
+        try:
+            with dst_engine.connect() as probe:
+                probe.execute(text("SELECT 1"))
+        except OperationalError as exc:
+            logger.error("Cannot connect to Postgres: %s", exc)
+            return False
+
+        overall_stats = {}
+        # Single Postgres transaction — full rollback on any error
+        with src_engine.connect() as src_conn, dst_engine.begin() as dst_conn:
+            src_inspector = inspect(src_conn)
+            users_src = _resolve_users_table(src_inspector)
+
+            for table in ordered:
+                logger.info("Migrating table: %s", table)
+                src_table_name = users_src if table == "users" and users_src else table
+                if table == "users" and src_table_name is None:
+                    logger.error("No users/user table found in SQLite — aborting.")
+                    raise RuntimeError("Missing users table in source database.")
+                try:
+                    overall_stats[table] = _live_migrate_table(
+                        table=table,
+                        src_table_name=src_table_name or table,
+                        src_conn=src_conn,
+                        dst_conn=dst_conn,
+                        truncate=truncate,
+                        batch_size=batch_size,
+                    )
+                except Exception as exc:
+                    logger.error(
+                        "  [%s] FAILED — rolling back all changes: %s",
+                        table,
+                        exc,
+                        exc_info=True,
+                    )
+                    raise  # triggers dst_engine.begin() rollback
+
+    # Print summary
+    logger.info("=" * 60)
+    logger.info("Summary")
+    logger.info("-" * 60)
+    total_migrated = 0
+    for table, stats in overall_stats.items():
+        if dry_run:
+            logger.info(
+                "  %-30s  would_migrate=%-6d  skipped=%d",
+                table,
+                stats.get("would_migrate", 0),
+                stats.get("skipped", 0),
+            )
+            total_migrated += stats.get("would_migrate", 0)
+        else:
+            logger.info(
+                "  %-30s  inserted=%-6d  skipped=%d",
+                table,
+                stats.get("inserted", 0),
+                stats.get("skipped", 0),
+            )
+            total_migrated += stats.get("inserted", 0)
+
+    logger.info("-" * 60)
+    if dry_run:
+        logger.info("  TOTAL  would_migrate=%d", total_migrated)
+        logger.info("Dry run complete — no data was written to Postgres.")
+    else:
+        logger.info("  TOTAL  inserted=%d", total_migrated)
+        logger.info("Migration complete.")
+    logger.info("=" * 60)
+    return True
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Migrate SQLite users/documents/chat history to Supabase Postgres.")
-    parser.add_argument(
+    parser = argparse.ArgumentParser(
+        description="Migrate data from SQLite to PostgreSQL.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+
+    src_group = parser.add_mutually_exclusive_group()
+    src_group.add_argument(
+        "--sqlite",
+        metavar="URL",
+        help="SQLAlchemy URL for the SQLite source, e.g. sqlite:///./data/app.db",
+    )
+    src_group.add_argument(
         "--sqlite-path",
+        metavar="PATH",
         default="instance/users.db",
-        help="Path to the SQLite database file. Defaults to instance/users.db.",
+        help="Path to the SQLite file (alternative to --sqlite). "
+             "Defaults to instance/users.db.",
     )
+
     parser.add_argument(
-        "--sqlite-url",
-        help="Full SQLite SQLAlchemy URL. Overrides --sqlite-path.",
-    )
-    parser.add_argument(
-        "--postgres-url",
-        default=os.getenv("SUPABASE_DB_URL") or os.getenv("POSTGRES_DATABASE_URL") or os.getenv("DATABASE_URL"),
-        help="Supabase/Postgres SQLAlchemy URL. Also read from SUPABASE_DB_URL, POSTGRES_DATABASE_URL, or DATABASE_URL.",
-    )
-    parser.add_argument(
-        "--no-create-tables",
-        action="store_true",
-        help="Do not create missing target tables before migrating.",
+        "--postgres",
+        metavar="URL",
+        default=(
+            os.getenv("SUPABASE_DB_URL")
+            or os.getenv("POSTGRES_DATABASE_URL")
+            or os.getenv("DATABASE_URL")
+        ),
+        help="Postgres destination URL (postgresql:// or postgres://). "
+             "Also read from SUPABASE_DB_URL, POSTGRES_DATABASE_URL, or DATABASE_URL. "
+             "Not required for --dry-run.",
     )
     parser.add_argument(
         "--dry-run",
         action="store_true",
-        help="Run the migration and roll back the target transaction.",
+        default=False,
+        help="Read from SQLite and report row counts — no Postgres connection made.",
     )
-    parser.add_argument("--verbose", action="store_true", help="Enable debug logging.")
+    parser.add_argument(
+        "--truncate",
+        action="store_true",
+        default=False,
+        help="TRUNCATE each Postgres table (CASCADE) before inserting. "
+             "Useful for a clean re-migration. Ignored during --dry-run.",
+    )
+    parser.add_argument(
+        "--tables",
+        nargs="+",
+        metavar="TABLE",
+        help="Migrate only these tables (space-separated). "
+             "Defaults to all tables in FK-safe order.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=500,
+        metavar="N",
+        help="Number of rows per INSERT batch (default: 500).",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable DEBUG logging.",
+    )
     return parser.parse_args()
 
 
-def main() -> int:
+def main() -> None:
     args = parse_args()
-    logging.basicConfig(
-        level=logging.DEBUG if args.verbose else logging.INFO,
-        format="%(levelname)s %(message)s",
-    )
 
-    postgres_url = args.postgres_url
-    if not postgres_url or postgres_url.startswith("sqlite"):
-        LOGGER.error("Provide a Supabase/Postgres URL with --postgres-url or SUPABASE_DB_URL.")
-        return 2
+    if args.verbose:
+        logging.getLogger().setLevel(logging.DEBUG)
+        logger.setLevel(logging.DEBUG)
 
-    sqlite_url = args.sqlite_url or sqlite_url_from_path(args.sqlite_path)
-    stats = migrate(
-        sqlite_url=sqlite_url,
-        postgres_url=postgres_url,
-        create_tables=not args.no_create_tables,
-        dry_run=args.dry_run,
-    )
+    # Resolve SQLite URL
+    if args.sqlite:
+        sqlite_url = args.sqlite
+        if not sqlite_url.startswith("sqlite"):
+            logger.error("--sqlite must be a sqlite:/// URL, got: %s", sqlite_url)
+            sys.exit(1)
+    else:
+        sqlite_url = sqlite_url_from_path(args.sqlite_path)
 
-    for table_name in sorted(set(stats.inserted) | set(stats.reused) | set(stats.skipped)):
-        LOGGER.info(
-            "%s: inserted=%s reused=%s skipped=%s",
-            table_name,
-            stats.inserted.get(table_name, 0),
-            stats.reused.get(table_name, 0),
-            stats.skipped.get(table_name, 0),
+    # Postgres URL is optional for dry-run only
+    postgres_url: Optional[str] = args.postgres
+    if not args.dry_run:
+        if not postgres_url:
+            logger.error(
+                "Provide a Postgres URL via --postgres, SUPABASE_DB_URL, "
+                "POSTGRES_DATABASE_URL, or DATABASE_URL."
+            )
+            sys.exit(2)
+        if postgres_url.startswith("sqlite"):
+            logger.error(
+                "--postgres must be a Postgres URL, not a SQLite URL: %s",
+                postgres_url,
+            )
+            sys.exit(2)
+
+    try:
+        success = run_migration(
+            sqlite_url=sqlite_url,
+            postgres_url=postgres_url,
+            dry_run=args.dry_run,
+            truncate=args.truncate,
+            tables=args.tables,
+            batch_size=args.batch_size,
         )
-    return 0
+    except Exception as exc:
+        logger.error("Migration failed: %s", exc)
+        sys.exit(1)
+
+    sys.exit(0 if success else 1)
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    main()


### PR DESCRIPTION
### 🔗 Related Issue

Closes #279

---

### 📝 What does this PR do?

Introduces a safe SQLite-to-PostgreSQL migration script with dry-run support to simplify database migration workflows.

Key improvements include:

* Support for both the current schema and the legacy `user` table
* Compatibility with Supabase `postgres://` connection URLs using psycopg v3
* Idempotent inserts using `ON CONFLICT DO NOTHING` to prevent duplicate data
* Single PostgreSQL transaction with automatic rollback on failure
* `--dry-run` mode that validates migration logic without requiring a PostgreSQL connection
* Type-safe conversion of UUID, boolean, and datetime values from SQLite to PostgreSQL formats

---

### 🗂️ Type of Change

* [ ] 🐛 Bug fix
* [x] ✨ New feature
* [ ] 🔧 Refactor / code cleanup
* [ ] 📝 Documentation update
* [ ] 🎨 UI / styling change
* [ ] ⚙️ CI / tooling / config change
* [ ] 🧪 Tests

---

### 🧪 How was this tested?

* [x] Ran the backend locally (`uvicorn app.main:app --reload`)
* [ ] Ran the frontend locally (`npm run dev` inside `frontend/`)
* [x] Tested the affected API endpoints manually
* [ ] Added / updated tests

Additional verification:

* Tested migration execution against SQLite databases containing current and legacy schemas
* Verified dry-run mode executes without establishing a PostgreSQL connection
* Confirmed rollback behavior on migration failures
* Validated idempotent re-runs using `ON CONFLICT DO NOTHING`

---

### ✅ Self-Review Checklist

* [x] My branch is based on **`dev`**, not `main`
* [x] I have not added any secrets / API keys
* [x] I have not modified `main` branch or any HuggingFace deployment config
* [x] My code follows the existing style (no unnecessary formatting changes)
* [x] I have updated relevant docs / comments if needed
