### PR TITLE
feat(db): workspace and permissions schema

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -230,6 +230,85 @@ def _migrate_schema():
                 )
 
 
+    # ── Workspace tables ──────────────────────────────────────────────────
+    existing_tables = set(inspector.get_table_names())
+
+    if "workspaces" not in existing_tables:
+        try:
+            with engine.begin() as conn:
+                conn.execute(text("""
+                    CREATE TABLE workspaces (
+                        id         CHAR(36)     PRIMARY KEY,
+                        name       VARCHAR(255) NOT NULL,
+                        created_by CHAR(36)     NOT NULL REFERENCES users(id),
+                        created_at TIMESTAMP
+                    )
+                """))
+                conn.execute(text(
+                    "CREATE INDEX IF NOT EXISTS ix_workspaces_created_by "
+                    "ON workspaces (created_by)"
+                ))
+            logger.info("Migration: created table workspaces")
+        except Exception:
+            logger.warning("Migration skipped (may already exist): workspaces")
+
+    if "workspace_members" not in existing_tables:
+        try:
+            with engine.begin() as conn:
+                conn.execute(text("""
+                    CREATE TABLE workspace_members (
+                        id           CHAR(36)    PRIMARY KEY,
+                        workspace_id CHAR(36)    NOT NULL REFERENCES workspaces(id),
+                        user_id      CHAR(36)    NOT NULL REFERENCES users(id),
+                        role         VARCHAR(20) NOT NULL DEFAULT 'viewer',
+                        joined_at    TIMESTAMP,
+                        CONSTRAINT uq_workspace_member UNIQUE (workspace_id, user_id)
+                    )
+                """))
+                conn.execute(text(
+                    "CREATE INDEX IF NOT EXISTS ix_workspace_members_workspace_id "
+                    "ON workspace_members (workspace_id)"
+                ))
+                conn.execute(text(
+                    "CREATE INDEX IF NOT EXISTS ix_workspace_members_user_id "
+                    "ON workspace_members (user_id)"
+                ))
+            logger.info("Migration: created table workspace_members")
+        except Exception:
+            logger.warning("Migration skipped (may already exist): workspace_members")
+
+    if "workspace_invitations" not in existing_tables:
+        try:
+            with engine.begin() as conn:
+                conn.execute(text("""
+                    CREATE TABLE workspace_invitations (
+                        id             CHAR(36)     PRIMARY KEY,
+                        email          VARCHAR(120) NOT NULL,
+                        token_hash     VARCHAR(255) NOT NULL UNIQUE,
+                        inviter_id     CHAR(36)     NOT NULL REFERENCES users(id),
+                        workspace_name VARCHAR(255) NOT NULL,
+                        created_at     TIMESTAMP,
+                        expires_at     TIMESTAMP    NOT NULL,
+                        accepted_at    TIMESTAMP
+                    )
+                """))
+                conn.execute(text(
+                    "CREATE INDEX IF NOT EXISTS ix_workspace_invitations_email "
+                    "ON workspace_invitations (email)"
+                ))
+                conn.execute(text(
+                    "CREATE INDEX IF NOT EXISTS ix_workspace_invitations_token_hash "
+                    "ON workspace_invitations (token_hash)"
+                ))
+                conn.execute(text(
+                    "CREATE INDEX IF NOT EXISTS ix_workspace_invitations_inviter_id "
+                    "ON workspace_invitations (inviter_id)"
+                ))
+            logger.info("Migration: created table workspace_invitations")
+        except Exception:
+            logger.warning("Migration skipped (may already exist): workspace_invitations")
+
+
 def advisory_lock(lock_id: int):
     """Context manager that acquires a PostgreSQL advisory lock (xact scope).
 

--- a/backend/app/routes/workspaces.py
+++ b/backend/app/routes/workspaces.py
@@ -1,4 +1,4 @@
-"""Workspace invitation routes for admin-managed workspace access."""
+"""Workspace invitation and management routes."""
 
 import hashlib
 import logging
@@ -7,18 +7,75 @@ from urllib.parse import quote
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
+from sqlalchemy import select
+from typing import List
 
-from app.auth import create_invite_token, get_admin_user
+from app.auth import create_invite_token, get_admin_user, get_current_user
 from app.config import get_settings
 from app.database import get_db
 from app.email_service import send_email
-from app.models import User, WorkspaceInvitation
-from app.schemas import WorkspaceInviteRequest, WorkspaceInviteResponse
+from app.exceptions import (
+    ConflictException,
+    ForbiddenException,
+    NotFoundException,
+    ValidationException,
+)
+from app.models import User, Workspace, WorkspaceInvitation, WorkspaceMember, WorkspaceRole
+from app.schemas import (
+    WorkspaceCreate,
+    WorkspaceDetailResponse,
+    WorkspaceInviteRequest,
+    WorkspaceInviteResponse,
+    WorkspaceMemberAdd,
+    WorkspaceMemberResponse,
+    WorkspaceMemberRoleUpdate,
+    WorkspaceResponse,
+)
 
 router = APIRouter(prefix="/workspaces", tags=["Workspaces"])
 settings = get_settings()
 logger = logging.getLogger(__name__)
 
+
+# ── Private helpers ───────────────────────────────────────────────────────────
+
+def _get_workspace_or_404(workspace_id: str, db: Session) -> Workspace:
+    ws = db.get(Workspace, workspace_id)
+    if not ws:
+        raise NotFoundException("Workspace")
+    return ws
+
+
+def _get_membership_or_403(workspace: Workspace, user: User, db: Session) -> WorkspaceMember:
+    """Return the caller's WorkspaceMember row, or raise 403."""
+    membership = db.execute(
+        select(WorkspaceMember).where(
+            WorkspaceMember.workspace_id == workspace.id,
+            WorkspaceMember.user_id == user.id,
+        )
+    ).scalar_one_or_none()
+    if not membership:
+        raise ForbiddenException("You are not a member of this workspace")
+    return membership
+
+
+def _require_workspace_admin(membership: WorkspaceMember) -> None:
+    if membership.role != WorkspaceRole.admin:
+        raise ForbiddenException("Only workspace admins can perform this action")
+
+
+def _count_admins(workspace_id: str, db: Session) -> int:
+    return len(
+        db.execute(
+            select(WorkspaceMember).where(
+                WorkspaceMember.workspace_id == workspace_id,
+                WorkspaceMember.role == WorkspaceRole.admin,
+            )
+        ).scalars().all()
+    )
+
+
+# ── Invitation (existing) ─────────────────────────────────────────────────────
 
 @router.post("/invite", response_model=WorkspaceInviteResponse, status_code=status.HTTP_200_OK)
 def invite_workspace(
@@ -52,7 +109,7 @@ def invite_workspace(
     join_link = f"{settings.APP_URL.rstrip('/')}/invite?token={quote(token, safe='')}"
     subject = f"Invitation to join workspace '{payload.workspace_name}'"
     body_lines = [
-        f"Hello,",
+        "Hello,",
         "",
         f"You have been invited to join the workspace '{payload.workspace_name}'.",
         "Click the link below to accept the invitation:",
@@ -71,3 +128,310 @@ def invite_workspace(
         invite_link=join_link,
         expires_in_hours=settings.INVITE_TOKEN_EXPIRY_HOURS,
     )
+
+
+# ── Workspace CRUD ────────────────────────────────────────────────────────────
+
+@router.post(
+    "",
+    response_model=WorkspaceDetailResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create a workspace",
+)
+def create_workspace(
+    payload: WorkspaceCreate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Create a new workspace.
+
+    The authenticated user is automatically added as the first member with
+    the ``admin`` role.
+    """
+    workspace = Workspace(
+        name=payload.name,
+        created_by=current_user.id,
+    )
+    db.add(workspace)
+    db.flush()  # populate workspace.id before creating the membership row
+
+    membership = WorkspaceMember(
+        workspace_id=workspace.id,
+        user_id=current_user.id,
+        role=WorkspaceRole.admin,
+    )
+    db.add(membership)
+    db.commit()
+    db.refresh(workspace)
+
+    logger.info(
+        "Workspace '%s' (%s) created by user %s",
+        workspace.name,
+        workspace.id,
+        current_user.id,
+    )
+    return workspace
+
+
+@router.get(
+    "",
+    response_model=List[WorkspaceResponse],
+    summary="List my workspaces",
+)
+def list_workspaces(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Return every workspace the authenticated user is a member of."""
+    memberships = db.execute(
+        select(WorkspaceMember).where(WorkspaceMember.user_id == current_user.id)
+    ).scalars().all()
+
+    workspace_ids = [m.workspace_id for m in memberships]
+    if not workspace_ids:
+        return []
+
+    return db.execute(
+        select(Workspace).where(Workspace.id.in_(workspace_ids))
+    ).scalars().all()
+
+
+@router.get(
+    "/{workspace_id}",
+    response_model=WorkspaceDetailResponse,
+    summary="Get workspace detail",
+)
+def get_workspace(
+    workspace_id: str,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Return workspace details including the full member list.
+
+    Only workspace members may access this endpoint.
+    """
+    workspace = _get_workspace_or_404(workspace_id, db)
+    _get_membership_or_403(workspace, current_user, db)
+    return workspace
+
+
+@router.delete(
+    "/{workspace_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Delete a workspace",
+)
+def delete_workspace(
+    workspace_id: str,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Permanently delete a workspace and all its members.
+
+    Requires the caller to hold the workspace ``admin`` role.
+    """
+    workspace = _get_workspace_or_404(workspace_id, db)
+    membership = _get_membership_or_403(workspace, current_user, db)
+    _require_workspace_admin(membership)
+
+    db.delete(workspace)
+    db.commit()
+
+    logger.info(
+        "Workspace '%s' (%s) deleted by user %s",
+        workspace.name,
+        workspace_id,
+        current_user.id,
+    )
+    return None
+
+
+# ── Member management ─────────────────────────────────────────────────────────
+
+@router.post(
+    "/{workspace_id}/members",
+    response_model=WorkspaceMemberResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Add a member to a workspace",
+)
+def add_member(
+    workspace_id: str,
+    payload: WorkspaceMemberAdd,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Add an existing user to a workspace.
+
+    * Requires the caller to be a workspace ``admin``.
+    * The target user must already exist in the system (looked up by ``user_id``).
+    * Adding an existing member raises ``409 Conflict``.
+    * Defaults to the ``viewer`` role when no role is supplied.
+    """
+    workspace = _get_workspace_or_404(workspace_id, db)
+    caller_membership = _get_membership_or_403(workspace, current_user, db)
+    _require_workspace_admin(caller_membership)
+
+    target_user = db.get(User, payload.user_id)
+    if not target_user:
+        raise NotFoundException("User")
+
+    existing = db.execute(
+        select(WorkspaceMember).where(
+            WorkspaceMember.workspace_id == workspace_id,
+            WorkspaceMember.user_id == payload.user_id,
+        )
+    ).scalar_one_or_none()
+    if existing:
+        raise ConflictException("User is already a member of this workspace")
+
+    new_membership = WorkspaceMember(
+        workspace_id=workspace_id,
+        user_id=payload.user_id,
+        role=payload.role,
+    )
+    db.add(new_membership)
+    db.commit()
+    db.refresh(new_membership)
+
+    logger.info(
+        "User %s added to workspace %s as '%s' by %s",
+        payload.user_id,
+        workspace_id,
+        payload.role,
+        current_user.id,
+    )
+    return new_membership
+
+
+@router.get(
+    "/{workspace_id}/members",
+    response_model=List[WorkspaceMemberResponse],
+    summary="List workspace members",
+)
+def list_members(
+    workspace_id: str,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Return all members of a workspace.
+
+    Only workspace members may call this endpoint.
+    """
+    workspace = _get_workspace_or_404(workspace_id, db)
+    _get_membership_or_403(workspace, current_user, db)
+
+    return db.execute(
+        select(WorkspaceMember).where(WorkspaceMember.workspace_id == workspace_id)
+    ).scalars().all()
+
+
+@router.patch(
+    "/{workspace_id}/members/{user_id}",
+    response_model=WorkspaceMemberResponse,
+    summary="Change a member's role",
+)
+def update_member_role(
+    workspace_id: str,
+    user_id: str,
+    payload: WorkspaceMemberRoleUpdate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Change a member's role within the workspace.
+
+    * Requires the caller to be a workspace ``admin``.
+    * Demoting the last ``admin`` is rejected to prevent lockout.
+    """
+    workspace = _get_workspace_or_404(workspace_id, db)
+    caller_membership = _get_membership_or_403(workspace, current_user, db)
+    _require_workspace_admin(caller_membership)
+
+    target_membership = db.execute(
+        select(WorkspaceMember).where(
+            WorkspaceMember.workspace_id == workspace_id,
+            WorkspaceMember.user_id == user_id,
+        )
+    ).scalar_one_or_none()
+    if not target_membership:
+        raise NotFoundException("Workspace member")
+
+    if (
+        target_membership.role == WorkspaceRole.admin
+        and payload.role != WorkspaceRole.admin
+        and _count_admins(workspace_id, db) <= 1
+    ):
+        raise ValidationException(
+            "Cannot demote the last admin. Promote another member to admin first."
+        )
+
+    target_membership.role = payload.role
+    db.commit()
+    db.refresh(target_membership)
+
+    logger.info(
+        "User %s role in workspace %s changed to '%s' by %s",
+        user_id,
+        workspace_id,
+        payload.role,
+        current_user.id,
+    )
+    return target_membership
+
+
+@router.delete(
+    "/{workspace_id}/members/{user_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Remove a member from a workspace",
+)
+def remove_member(
+    workspace_id: str,
+    user_id: str,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Remove a member from a workspace.
+
+    * A workspace ``admin`` may remove any member.
+    * Any member may remove themselves (leave the workspace).
+    * Removing the last ``admin`` is rejected to prevent lockout.
+    """
+    workspace = _get_workspace_or_404(workspace_id, db)
+    caller_membership = _get_membership_or_403(workspace, current_user, db)
+
+    is_self = str(current_user.id) == str(user_id)
+    if not is_self:
+        _require_workspace_admin(caller_membership)
+
+    target_membership = db.execute(
+        select(WorkspaceMember).where(
+            WorkspaceMember.workspace_id == workspace_id,
+            WorkspaceMember.user_id == user_id,
+        )
+    ).scalar_one_or_none()
+    if not target_membership:
+        raise NotFoundException("Workspace member")
+
+    if (
+        target_membership.role == WorkspaceRole.admin
+        and _count_admins(workspace_id, db) <= 1
+    ):
+        raise ValidationException(
+            "Cannot remove the last admin. Promote another member to admin first."
+        )
+
+    db.delete(target_membership)
+    db.commit()
+
+    logger.info(
+        "User %s removed from workspace %s by %s",
+        user_id,
+        workspace_id,
+        current_user.id,
+    )
+    return None

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -5,7 +5,7 @@ import json
 from pydantic import BaseModel, EmailStr, Field, field_validator
 from typing import Optional, List, Any
 from datetime import datetime
-from app.models import UserRole
+from app.models import UserRole, WorkspaceRole
 from app.password_validation import validate_password
 
 
@@ -363,6 +363,54 @@ class ChatSessionResponse(BaseModel):
 
     class Config:
         from_attributes = True
+
+
+# ── Workspaces ────────────────────────────────────────
+
+class WorkspaceCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=255)
+
+
+class WorkspaceMemberResponse(BaseModel):
+    id: str
+    workspace_id: str
+    user_id: str
+    role: WorkspaceRole
+    joined_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class WorkspaceResponse(BaseModel):
+    id: str
+    name: str
+    created_by: str
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class WorkspaceDetailResponse(BaseModel):
+    """Workspace detail including the full member list."""
+    id: str
+    name: str
+    created_by: str
+    created_at: datetime
+    members: List[WorkspaceMemberResponse] = []
+
+    class Config:
+        from_attributes = True
+
+
+class WorkspaceMemberAdd(BaseModel):
+    user_id: str = Field(..., min_length=1)
+    role: WorkspaceRole = WorkspaceRole.viewer
+
+
+class WorkspaceMemberRoleUpdate(BaseModel):
+    role: WorkspaceRole
 
 
 # Rebuild models for forward references


### PR DESCRIPTION
### 🔗 Related Issue

Closes #232

---

### 📝 What does this PR do?

Introduces a complete workspace and permissions schema to support collaborative access management.

Key changes include:

* Adds Workspace CRUD endpoints:

  * `POST /workspaces`
  * `GET /workspaces`
  * `DELETE /workspaces`
* Adds WorkspaceMember management endpoints:

  * `POST /workspaces/{id}/members`
  * `GET /workspaces/{id}/members`
  * `PATCH /workspaces/{id}/members`
  * `DELETE /workspaces/{id}/members`
* Introduces role-based permissions using the `WorkspaceRole` enum:

  * `admin`
  * `editor`
  * `viewer`
* Prevents last-admin lockout during:

  * Member removal
  * Role updates
* Allows members to leave a workspace without requiring admin privileges
* Adds six Pydantic schemas:

  * `WorkspaceCreate`
  * `WorkspaceResponse`
  * `WorkspaceDetailResponse`
  * `WorkspaceMemberAdd`
  * `WorkspaceMemberResponse`
  * `WorkspaceMemberRoleUpdate`
* Extends `_migrate_schema()` to create workspace-related tables on existing databases
* Preserves the existing `/workspaces/invite` route and behavior

---

### 🗂️ Type of Change

* [ ] 🐛 Bug fix
* [x] ✨ New feature
* [ ] 🔧 Refactor / code cleanup
* [ ] 📝 Documentation update
* [ ] 🎨 UI / styling change
* [ ] ⚙️ CI / tooling / config change
* [ ] 🧪 Tests

---

### 🧪 How was this tested?

* [x] Ran the backend locally (`uvicorn app.main:app --reload`)
* [ ] Ran the frontend locally (`npm run dev` inside `frontend/`)
* [x] Tested the affected API endpoints manually
* [ ] Added / updated tests

Additional verification:

* Verified workspace creation, retrieval, and deletion flows
* Tested member addition, role updates, and removal operations
* Confirmed last-admin protection logic works as expected
* Verified members can leave workspaces without admin privileges
* Confirmed schema migration creates workspace tables on existing databases

---

### ✅ Self-Review Checklist

* [x] My branch is based on **`dev`**, not `main`
* [x] I have not added any secrets / API keys
* [x] I have not modified `main` branch or any HuggingFace deployment config
* [x] My code follows the existing style (no unnecessary formatting changes)
* [x] I have updated relevant docs / comments if needed
