### PR TITLE
feat(ui): add interactive graph visualization using React Flow

### DIFF
--- a/backend/app/routes/graph.py
+++ b/backend/app/routes/graph.py
@@ -1,0 +1,175 @@
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.auth import get_current_user
+from app.database import get_db
+from app.models import Document, User
+from app.rag.graph_builder import load_graph
+
+router = APIRouter(prefix="/graph", tags=["Knowledge Graph"])
+logger = logging.getLogger(__name__)
+
+
+# ── Response schemas ──────────────────────────────────────────────────────────
+
+class GraphNode(BaseModel):
+    id: str
+    name: str
+    label: str          # NER type, e.g. "PERSON", "ORG", "GPE"
+    mentions: int
+    pages: List[int]
+
+
+class GraphEdge(BaseModel):
+    source: str
+    target: str
+    weight: int
+    pages: List[int]
+
+
+class GraphResponse(BaseModel):
+    document_id: str
+    document_name: str
+    node_count: int
+    edge_count: int
+    nodes: List[GraphNode]
+    edges: List[GraphEdge]
+
+
+class GraphSummaryResponse(BaseModel):
+    document_id: str
+    document_name: str
+    node_count: int
+    edge_count: int
+    top_entities: List[Dict[str, Any]]
+    graph_available: bool
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _get_owned_document(document_id: str, user: User, db: Session) -> Document:
+    """Return the document if it exists and belongs to the current user."""
+    doc = (
+        db.query(Document)
+        .filter(Document.id == document_id, Document.user_id == user.id)
+        .first()
+    )
+    if not doc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Document not found",
+        )
+    return doc
+
+
+# ── Routes ────────────────────────────────────────────────────────────────────
+
+@router.get("/{document_id}", response_model=GraphResponse)
+def get_graph(
+    document_id: str,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Return the full knowledge graph (nodes + edges) for a document.
+
+    The graph is built by ``graph_builder.py`` during ingestion and stored as
+    a JSON file on disk.  If the graph file does not exist yet (document still
+    processing, or graph extraction was skipped) a 404 is returned so the
+    frontend can show an appropriate empty state.
+    """
+    doc = _get_owned_document(document_id, current_user, db)
+
+    graph = load_graph(str(current_user.id), document_id)
+    if graph is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Knowledge graph not available for this document yet. "
+                   "The document may still be processing.",
+        )
+
+    nodes: List[GraphNode] = []
+    for node_id, data in graph.nodes(data=True):
+        nodes.append(
+            GraphNode(
+                id=node_id,
+                name=data.get("name", node_id),
+                label=data.get("label", "UNKNOWN"),
+                mentions=data.get("mentions", 1),
+                pages=sorted(data.get("pages", [])),
+            )
+        )
+
+    edges: List[GraphEdge] = []
+    for source, target, data in graph.edges(data=True):
+        edges.append(
+            GraphEdge(
+                source=source,
+                target=target,
+                weight=data.get("weight", 1),
+                pages=sorted(data.get("pages", [])),
+            )
+        )
+
+    return GraphResponse(
+        document_id=document_id,
+        document_name=doc.original_name,
+        node_count=graph.number_of_nodes(),
+        edge_count=graph.number_of_edges(),
+        nodes=nodes,
+        edges=edges,
+    )
+
+
+@router.get("/{document_id}/summary", response_model=GraphSummaryResponse)
+def get_graph_summary(
+    document_id: str,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Return lightweight graph statistics without the full node/edge payload.
+
+    Useful for deciding whether to show the graph toggle button in the UI.
+    """
+    doc = _get_owned_document(document_id, current_user, db)
+
+    graph = load_graph(str(current_user.id), document_id)
+    if graph is None:
+        return GraphSummaryResponse(
+            document_id=document_id,
+            document_name=doc.original_name,
+            node_count=0,
+            edge_count=0,
+            top_entities=[],
+            graph_available=False,
+        )
+
+    # Top 10 nodes by mention count
+    top_entities = sorted(
+        [
+            {
+                "id": node_id,
+                "name": data.get("name", node_id),
+                "label": data.get("label", "UNKNOWN"),
+                "mentions": data.get("mentions", 1),
+            }
+            for node_id, data in graph.nodes(data=True)
+        ],
+        key=lambda x: x["mentions"],
+        reverse=True,
+    )[:10]
+
+    return GraphSummaryResponse(
+        document_id=document_id,
+        document_name=doc.original_name,
+        node_count=graph.number_of_nodes(),
+        edge_count=graph.number_of_edges(),
+        top_entities=top_entities,
+        graph_available=True,
+    )

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@base-ui/react": "^1.4.1",
         "@tailwindcss/typography": "^0.5.19",
+        "@xyflow/react": "^12.11.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.4.0",
@@ -3301,6 +3302,55 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -3392,7 +3442,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -4134,6 +4184,76 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@xyflow/react": {
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.11.0.tgz",
+      "integrity": "sha512-na4IO33FSs2OS72hASgZDmTYwFAkef7Z74uBUVrong3ARmQQHfnRUVaCFn1kTt5LbS6pK03TbYjCPGLjLFfziA==",
+      "license": "MIT",
+      "dependencies": {
+        "@xyflow/system": "0.0.77",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=17",
+        "@types/react-dom": ">=17",
+        "react": ">=17",
+        "react-dom": ">=17"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@xyflow/react/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.77",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.77.tgz",
+      "integrity": "sha512-qCDCMCQAAgUu8yHnhloHG9F5mwPX5E+Wl8McpYIOPSSXfzFJJoZcwOcsDiAjitVKIg2de1WmJbCHfpcvxprsgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -4831,6 +4951,12 @@
         "url": "https://polar.sh/cva"
       }
     },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
+    },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
@@ -5128,6 +5254,111 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -6631,7 +6862,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@base-ui/react": "^1.4.1",
     "@tailwindcss/typography": "^0.5.19",
-    "@xyflow/react": "^12.9.0",
+    "@xyflow/react": "^12.11.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@base-ui/react": "^1.4.1",
     "@tailwindcss/typography": "^0.5.19",
+    "@xyflow/react": "^12.9.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.4.0",

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -178,10 +178,12 @@ export default function DashboardPage() {
     return () => clearInterval(interval);
   }, [documents, loadDocuments]);
 
-  // Close graph panel when active document changes
-  useEffect(() => {
-    setGraphOpen(false);
-  }, [activeDoc?.id]);
+  // Close graph panel when active document changes — derive from render
+  const prevDocIdRef = useRef<string | null>(null);
+  if (activeDoc?.id !== prevDocIdRef.current) {
+    prevDocIdRef.current = activeDoc?.id ?? null;
+    if (graphOpen) setGraphOpen(false);
+  }
 
   if (!initialized || !user) {
     return (

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { useEffect, useState, useCallback, useRef } from "react";
 import dynamic from "next/dynamic";
 import { useRouter } from "next/navigation";
@@ -10,6 +8,7 @@ import Header from "@/components/layout/Header";
 import DocumentSidebar from "@/components/document/DocumentSidebar";
 import ChatSessionSidebar from "@/components/chat/ChatSessionSidebar";
 import ChatPanel from "@/components/chat/ChatPanel";
+
 function PDFViewerSkeleton() {
   return (
     <div
@@ -40,6 +39,12 @@ const PDFViewer = dynamic(() => import("@/components/document/PDFViewer"), {
   ssr: false,
   loading: () => <PDFViewerSkeleton />,
 });
+
+// Lazy-load the graph panel — it pulls in @xyflow/react which is sizeable
+const KnowledgeGraph = dynamic(
+  () => import("@/components/graph/KnowledgeGraph"),
+  { ssr: false },
+);
 
 export interface DocInfo {
   chunk_size?: number;
@@ -76,6 +81,7 @@ export default function DashboardPage() {
   } | null>(null);
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const [viewerOpen, setViewerOpen] = useState(true);
+  const [graphOpen, setGraphOpen] = useState(false);
   const [connectionError, setConnectionError] = useState("");
   const [documentsLoading, setDocumentsLoading] = useState(true);
 
@@ -95,7 +101,6 @@ export default function DashboardPage() {
   useEffect(() => {
     if (user) {
       const hasHfToken = !!(user.hf_token || localStorage.getItem("hf_token"));
-
       if (!hasHfToken) {
         console.info(
           "Hugging Face API token is not configured. Personal model access will fall back to the system default unless set in the user profile menu."
@@ -138,7 +143,6 @@ export default function DashboardPage() {
     const nextPrevDocs: Record<string, string> = {};
     (documents || []).forEach((doc) => {
       nextPrevDocs[doc.id] = doc.status;
-
       const oldStatus = prev[doc.id];
       if (oldStatus && oldStatus !== doc.status) {
         if (doc.status === "ready") {
@@ -157,10 +161,14 @@ export default function DashboardPage() {
       (d) => d.status === "pending" || d.status === "processing"
     );
     if (!hasPending) return;
-
     const interval = setInterval(loadDocuments, 3000);
     return () => clearInterval(interval);
   }, [documents, loadDocuments]);
+
+  // Close graph panel when active document changes
+  useEffect(() => {
+    setGraphOpen(false);
+  }, [activeDoc?.id]);
 
   if (!initialized || !user) {
     return (
@@ -170,7 +178,6 @@ export default function DashboardPage() {
     );
   }
 
-  // Shared sidebar content — used by both desktop panel and mobile sheet
   const sidebarContent = (
     <DocumentSidebar
       documents={documents}
@@ -186,13 +193,20 @@ export default function DashboardPage() {
   );
 
   return (
-    // min-w-[375px] ensures the layout never squishes below iPhone SE width
     <div className="h-screen flex flex-col overflow-hidden min-w-[375px]">
       <Header
         sidebarOpen={sidebarOpen}
         onToggleSidebar={() => setSidebarOpen(!sidebarOpen)}
         viewerOpen={viewerOpen}
         onToggleViewer={() => setViewerOpen(!viewerOpen)}
+        graphOpen={graphOpen}
+        onToggleGraph={() => {
+          if (!activeDoc) {
+            toast.info("Select a document first to view its knowledge graph.");
+            return;
+          }
+          setGraphOpen((v) => !v);
+        }}
         mobileSheetContent={sidebarContent}
       />
 
@@ -206,17 +220,17 @@ export default function DashboardPage() {
       )}
 
       <div className="flex-1 flex overflow-hidden">
-        {/* ── Left: Document Sidebar — desktop only (md+) ─────────── */}
+        {/* ── Left: Document Sidebar — desktop only ───────────────────── */}
         {sidebarOpen && (
           <div className="hidden md:block w-72 flex-shrink-0 border-r border-border/50 overflow-hidden animate-fade-in-up">
             {sidebarContent}
           </div>
         )}
 
-        {/* ── Left-Center: Chat Sessions Sidebar ──── */}
+        {/* ── Left-Center: Chat Sessions Sidebar ──────────────────────── */}
         <ChatSessionSidebar />
 
-        {/* ── Center: Chat Panel ──────────────────────────────────── */}
+        {/* ── Center: Chat Panel ───────────────────────────────────────── */}
         <div className="flex-1 min-w-0 flex flex-col">
           <ChatPanel
             activeDoc={activeDoc}
@@ -228,8 +242,8 @@ export default function DashboardPage() {
           />
         </div>
 
-        {/* ── Right: PDF Viewer — hidden on mobile ────────────────── */}
-        {viewerOpen && activeDoc && activeDoc.original_name.endsWith(".pdf") && (
+        {/* ── Right: PDF Viewer — hidden on mobile ─────────────────────── */}
+        {viewerOpen && !graphOpen && activeDoc && activeDoc.original_name.endsWith(".pdf") && (
           <div className="hidden md:block w-[480px] flex-shrink-0 border-l border-border/50 overflow-hidden animate-fade-in-up">
             <PDFViewer
               documentId={activeDoc.id}
@@ -242,6 +256,16 @@ export default function DashboardPage() {
               }}
               totalPages={activeDoc.page_count}
               highlightTarget={pdfHighlightTarget}
+            />
+          </div>
+        )}
+
+        {/* ── Right: Knowledge Graph panel ─────────────────────────────── */}
+        {graphOpen && activeDoc && (
+          <div className="hidden md:flex w-[520px] flex-shrink-0 border-l border-border/50 overflow-hidden animate-fade-in-up">
+            <KnowledgeGraph
+              documentId={activeDoc.id}
+              onClose={() => setGraphOpen(false)}
             />
           </div>
         )}

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect, useState, useCallback, useRef } from "react";
 import dynamic from "next/dynamic";
 import { useRouter } from "next/navigation";

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -3,7 +3,11 @@ import dynamic from "next/dynamic";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/lib/auth";
 import { toast } from "sonner";
-import { api, CONNECTION_ERROR_BANNER_MESSAGE, CONNECTION_ERROR_MESSAGE } from "@/lib/api";
+import {
+  api,
+  CONNECTION_ERROR_BANNER_MESSAGE,
+  CONNECTION_ERROR_MESSAGE,
+} from "@/lib/api";
 import Header from "@/components/layout/Header";
 import DocumentSidebar from "@/components/document/DocumentSidebar";
 import ChatSessionSidebar from "@/components/chat/ChatSessionSidebar";
@@ -87,9 +91,13 @@ export default function DashboardPage() {
 
   const handleDocumentRenamed = useCallback((renamedDocument: DocInfo) => {
     setDocuments((current) =>
-      current.map((document) => (document.id === renamedDocument.id ? renamedDocument : document))
+      current.map((document) =>
+        document.id === renamedDocument.id ? renamedDocument : document,
+      ),
     );
-    setActiveDoc((current) => (current?.id === renamedDocument.id ? renamedDocument : current));
+    setActiveDoc((current) =>
+      current?.id === renamedDocument.id ? renamedDocument : current,
+    );
   }, []);
 
   // Auth guard
@@ -103,7 +111,7 @@ export default function DashboardPage() {
       const hasHfToken = !!(user.hf_token || localStorage.getItem("hf_token"));
       if (!hasHfToken) {
         console.info(
-          "Hugging Face API token is not configured. Personal model access will fall back to the system default unless set in the user profile menu."
+          "Hugging Face API token is not configured. Personal model access will fall back to the system default unless set in the user profile menu.",
         );
       }
     }
@@ -114,16 +122,17 @@ export default function DashboardPage() {
     setDocumentsLoading(true);
     try {
       const data = await api.get<{ documents?: DocInfo[]; items?: DocInfo[] }>(
-        "/api/v1/documents/"
+        "/api/v1/documents/",
       );
       setDocuments(data?.documents ?? data?.items ?? []);
       setConnectionError("");
     } catch (err) {
-      const message = err instanceof Error ? err.message : CONNECTION_ERROR_MESSAGE;
+      const message =
+        err instanceof Error ? err.message : CONNECTION_ERROR_MESSAGE;
       setConnectionError(
         message === CONNECTION_ERROR_MESSAGE
           ? CONNECTION_ERROR_BANNER_MESSAGE
-          : `⚠️ ${message}`
+          : `⚠️ ${message}`,
       );
     } finally {
       setDocumentsLoading(false);
@@ -146,9 +155,13 @@ export default function DashboardPage() {
       const oldStatus = prev[doc.id];
       if (oldStatus && oldStatus !== doc.status) {
         if (doc.status === "ready") {
-          toast.success(`🎉 Ingestion complete: '${doc.original_name}' is ready!`);
+          toast.success(
+            `🎉 Ingestion complete: '${doc.original_name}' is ready!`,
+          );
         } else if (doc.status === "failed") {
-          toast.error(`❌ Ingestion failed for '${doc.original_name}': ${doc.error_message || "Unknown error"}`);
+          toast.error(
+            `❌ Ingestion failed for '${doc.original_name}': ${doc.error_message || "Unknown error"}`,
+          );
         }
       }
     });
@@ -158,7 +171,7 @@ export default function DashboardPage() {
   // Poll for processing status
   useEffect(() => {
     const hasPending = (documents || []).some(
-      (d) => d.status === "pending" || d.status === "processing"
+      (d) => d.status === "pending" || d.status === "processing",
     );
     if (!hasPending) return;
     const interval = setInterval(loadDocuments, 3000);
@@ -236,29 +249,35 @@ export default function DashboardPage() {
             activeDoc={activeDoc}
             onCitationClick={(target) => {
               setPdfPage(target.page);
-              setPdfHighlightTarget({ page: target.page, rects: target.highlightRects });
+              setPdfHighlightTarget({
+                page: target.page,
+                rects: target.highlightRects,
+              });
               if (!viewerOpen) setViewerOpen(true);
             }}
           />
         </div>
 
         {/* ── Right: PDF Viewer — hidden on mobile ─────────────────────── */}
-        {viewerOpen && !graphOpen && activeDoc && activeDoc.original_name.endsWith(".pdf") && (
-          <div className="hidden md:block w-[480px] flex-shrink-0 border-l border-border/50 overflow-hidden animate-fade-in-up">
-            <PDFViewer
-              documentId={activeDoc.id}
-              currentPage={pdfPage}
-              onPageChange={(page) => {
-                setPdfPage(page);
-                if (pdfHighlightTarget?.page !== page) {
-                  setPdfHighlightTarget(null);
-                }
-              }}
-              totalPages={activeDoc.page_count}
-              highlightTarget={pdfHighlightTarget}
-            />
-          </div>
-        )}
+        {viewerOpen &&
+          !graphOpen &&
+          activeDoc &&
+          activeDoc.original_name.endsWith(".pdf") && (
+            <div className="hidden md:block w-[480px] flex-shrink-0 border-l border-border/50 overflow-hidden animate-fade-in-up">
+              <PDFViewer
+                documentId={activeDoc.id}
+                currentPage={pdfPage}
+                onPageChange={(page) => {
+                  setPdfPage(page);
+                  if (pdfHighlightTarget?.page !== page) {
+                    setPdfHighlightTarget(null);
+                  }
+                }}
+                totalPages={activeDoc.page_count}
+                highlightTarget={pdfHighlightTarget}
+              />
+            </div>
+          )}
 
         {/* ── Right: Knowledge Graph panel ─────────────────────────────── */}
         {graphOpen && activeDoc && (

--- a/frontend/src/components/graph/KnowledgeGraph.tsx
+++ b/frontend/src/components/graph/KnowledgeGraph.tsx
@@ -1,0 +1,461 @@
+/**
+ * KnowledgeGraph — interactive entity relationship visualiser.
+ *
+ * Uses @xyflow/react (React Flow v12, fully React-19-compatible).
+ * Fetches graph data from GET /api/v1/graph/{documentId} and renders
+ * a force-positioned node-link diagram with zoom, pan, and node-click.
+ *
+ * Props
+ * -----
+ * documentId  – UUID of the active document
+ * onClose     – called when the user dismisses the panel
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  ReactFlow,
+  Background,
+  Controls,
+  MiniMap,
+  addEdge,
+  useNodesState,
+  useEdgesState,
+  type Node,
+  type Edge,
+  type NodeMouseHandler,
+  type OnConnect,
+  BackgroundVariant,
+  Panel,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+
+import { X, RefreshCw, Info, ZoomIn, ZoomOut } from "lucide-react";
+import { api } from "@/lib/api";
+
+// ── API types ─────────────────────────────────────────────────────────────────
+
+interface GraphNode {
+  id: string;
+  name: string;
+  label: string;
+  mentions: number;
+  pages: number[];
+}
+
+interface GraphEdge {
+  source: string;
+  target: string;
+  weight: number;
+  pages: number[];
+}
+
+interface GraphData {
+  document_id: string;
+  document_name: string;
+  node_count: number;
+  edge_count: number;
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+}
+
+// ── NER label colour palette ──────────────────────────────────────────────────
+// Deliberately constrained: enough to distinguish entity types at a glance,
+// chosen for legibility on both light and dark backgrounds.
+
+const LABEL_COLOURS: Record<string, { bg: string; border: string; text: string }> = {
+  PERSON:  { bg: "#dbeafe", border: "#3b82f6", text: "#1e3a8a" },
+  ORG:     { bg: "#dcfce7", border: "#22c55e", text: "#14532d" },
+  GPE:     { bg: "#fef9c3", border: "#eab308", text: "#713f12" },
+  LOC:     { bg: "#ffedd5", border: "#f97316", text: "#7c2d12" },
+  DATE:    { bg: "#f3e8ff", border: "#a855f7", text: "#4a1d96" },
+  MONEY:   { bg: "#fce7f3", border: "#ec4899", text: "#831843" },
+  PRODUCT: { bg: "#e0f2fe", border: "#0ea5e9", text: "#0c4a6e" },
+  EVENT:   { bg: "#fff7ed", border: "#fb923c", text: "#7c2d12" },
+  LAW:     { bg: "#f1f5f9", border: "#64748b", text: "#0f172a" },
+  UNKNOWN: { bg: "#f8fafc", border: "#94a3b8", text: "#334155" },
+};
+
+function colourFor(label: string) {
+  return LABEL_COLOURS[label] ?? LABEL_COLOURS.UNKNOWN;
+}
+
+// ── Force-layout helpers ──────────────────────────────────────────────────────
+// Simple deterministic radial + jitter layout so the graph isn't a pile-up
+// on first render. React Flow's built-in dragging lets users reorganise.
+
+const CENTRE_X = 500;
+const CENTRE_Y = 350;
+
+function radialPosition(index: number, total: number, radius: number) {
+  const angle = (2 * Math.PI * index) / total - Math.PI / 2;
+  return {
+    x: CENTRE_X + radius * Math.cos(angle) + (Math.random() - 0.5) * 40,
+    y: CENTRE_Y + radius * Math.sin(angle) + (Math.random() - 0.5) * 40,
+  };
+}
+
+// ── Node detail panel ─────────────────────────────────────────────────────────
+
+interface NodeDetailProps {
+  node: GraphNode;
+  connectedNames: string[];
+  onClose: () => void;
+}
+
+function NodeDetail({ node, connectedNames, onClose }: NodeDetailProps) {
+  const colour = colourFor(node.label);
+  return (
+    <div
+      className="absolute bottom-4 left-4 z-20 w-64 rounded-xl border shadow-lg bg-white dark:bg-zinc-900 overflow-hidden"
+      style={{ borderColor: colour.border }}
+    >
+      {/* Header */}
+      <div
+        className="flex items-start justify-between px-3 py-2"
+        style={{ backgroundColor: colour.bg }}
+      >
+        <div className="min-w-0">
+          <p className="text-xs font-semibold uppercase tracking-widest" style={{ color: colour.border }}>
+            {node.label}
+          </p>
+          <p className="text-sm font-bold leading-tight mt-0.5 truncate" style={{ color: colour.text }}>
+            {node.name}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="ml-2 mt-0.5 shrink-0 rounded p-0.5 hover:bg-black/10 transition-colors"
+          aria-label="Close node detail"
+        >
+          <X className="h-3.5 w-3.5" style={{ color: colour.text }} />
+        </button>
+      </div>
+
+      {/* Stats */}
+      <div className="px-3 py-2 space-y-2 text-xs text-zinc-600 dark:text-zinc-400">
+        <div className="flex justify-between">
+          <span>Mentions</span>
+          <span className="font-semibold text-zinc-900 dark:text-zinc-100">{node.mentions}</span>
+        </div>
+        <div className="flex justify-between">
+          <span>Pages</span>
+          <span className="font-semibold text-zinc-900 dark:text-zinc-100">
+            {node.pages.length > 0 ? node.pages.slice(0, 6).join(", ") + (node.pages.length > 6 ? "…" : "") : "—"}
+          </span>
+        </div>
+        {connectedNames.length > 0 && (
+          <div>
+            <p className="mb-1">Connected to</p>
+            <ul className="space-y-0.5">
+              {connectedNames.slice(0, 5).map((name) => (
+                <li key={name} className="truncate font-medium text-zinc-800 dark:text-zinc-200">
+                  · {name}
+                </li>
+              ))}
+              {connectedNames.length > 5 && (
+                <li className="text-zinc-400">+{connectedNames.length - 5} more</li>
+              )}
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Legend ────────────────────────────────────────────────────────────────────
+
+function Legend({ labels }: { labels: string[] }) {
+  if (labels.length === 0) return null;
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {labels.map((label) => {
+        const c = colourFor(label);
+        return (
+          <span
+            key={label}
+            className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium border"
+            style={{ backgroundColor: c.bg, borderColor: c.border, color: c.text }}
+          >
+            {label}
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+interface KnowledgeGraphProps {
+  documentId: string;
+  onClose: () => void;
+}
+
+export default function KnowledgeGraph({ documentId, onClose }: KnowledgeGraphProps) {
+  const [graphData, setGraphData] = useState<GraphData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedNode, setSelectedNode] = useState<GraphNode | null>(null);
+  const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
+  const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
+
+  // ── Fetch graph data ────────────────────────────────────────────────────────
+
+  const fetchGraph = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    setSelectedNode(null);
+    try {
+      const data = await api.get<GraphData>(`/api/v1/graph/${documentId}`);
+      setGraphData(data);
+
+      // ── Build React Flow nodes ──────────────────────────────────────────────
+      const maxMentions = Math.max(...data.nodes.map((n) => n.mentions), 1);
+      const radius = Math.min(Math.max(data.nodes.length * 18, 200), 500);
+
+      const rfNodes: Node[] = data.nodes.map((n, i) => {
+        const colour = colourFor(n.label);
+        // Scale node size by mention frequency (min 36px, max 72px diameter)
+        const size = 36 + Math.round((n.mentions / maxMentions) * 36);
+        const pos = radialPosition(i, data.nodes.length, radius);
+
+        return {
+          id: n.id,
+          position: pos,
+          data: {
+            label: (
+              <div
+                className="flex items-center justify-center text-center font-semibold leading-tight px-1"
+                style={{ fontSize: Math.max(9, size * 0.22), color: colour.text }}
+                title={n.name}
+              >
+                {n.name.length > 14 ? n.name.slice(0, 13) + "…" : n.name}
+              </div>
+            ),
+            _raw: n,
+          },
+          style: {
+            width: size,
+            height: size,
+            borderRadius: "50%",
+            backgroundColor: colour.bg,
+            border: `2px solid ${colour.border}`,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            cursor: "pointer",
+            boxShadow: "0 1px 4px rgba(0,0,0,0.12)",
+          },
+        };
+      });
+
+      // ── Build React Flow edges ──────────────────────────────────────────────
+      const maxWeight = Math.max(...data.edges.map((e) => e.weight), 1);
+
+      const rfEdges: Edge[] = data.edges.map((e, i) => {
+        // Stronger co-occurrence = thicker, more opaque line
+        const opacity = 0.2 + 0.6 * (e.weight / maxWeight);
+        const strokeWidth = 1 + Math.round((e.weight / maxWeight) * 3);
+
+        return {
+          id: `e-${i}`,
+          source: e.source,
+          target: e.target,
+          animated: false,
+          style: {
+            stroke: `rgba(100,116,139,${opacity})`,
+            strokeWidth,
+          },
+          data: { _raw: e },
+        };
+      });
+
+      setNodes(rfNodes);
+      setEdges(rfEdges);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Failed to load knowledge graph";
+      setError(msg);
+    } finally {
+      setLoading(false);
+    }
+  }, [documentId, setNodes, setEdges]);
+
+  useEffect(() => {
+    fetchGraph();
+  }, [fetchGraph]);
+
+  // ── Node click → show detail panel ─────────────────────────────────────────
+
+  const onNodeClick = useCallback<NodeMouseHandler>(
+    (_event, node) => {
+      const raw = (node.data as { _raw?: GraphNode })._raw;
+      if (raw) setSelectedNode(raw);
+    },
+    [],
+  );
+
+  // Names of nodes connected to the selected node
+  const connectedNames = useMemo(() => {
+    if (!selectedNode || !graphData) return [];
+    const nodeMap = Object.fromEntries(graphData.nodes.map((n) => [n.id, n.name]));
+    return graphData.edges
+      .filter((e) => e.source === selectedNode.id || e.target === selectedNode.id)
+      .map((e) => nodeMap[e.source === selectedNode.id ? e.target : e.source])
+      .filter(Boolean);
+  }, [selectedNode, graphData]);
+
+  // Distinct NER labels present in this graph
+  const presentLabels = useMemo(
+    () => [...new Set((graphData?.nodes ?? []).map((n) => n.label))].sort(),
+    [graphData],
+  );
+
+  const onConnect = useCallback<OnConnect>(
+    (params) => setEdges((eds) => addEdge(params, eds)),
+    [setEdges],
+  );
+
+  // ── Render ──────────────────────────────────────────────────────────────────
+
+  return (
+    <div className="flex flex-col h-full bg-background">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-2.5 border-b border-border/50 bg-card/50 shrink-0">
+        <div className="min-w-0">
+          <h2 className="text-sm font-semibold truncate">
+            Knowledge Graph
+            {graphData && (
+              <span className="ml-2 text-xs font-normal text-muted-foreground">
+                {graphData.node_count} entities · {graphData.edge_count} connections
+              </span>
+            )}
+          </h2>
+          {graphData && (
+            <p className="text-xs text-muted-foreground truncate">{graphData.document_name}</p>
+          )}
+        </div>
+        <div className="flex items-center gap-1 shrink-0 ml-3">
+          <button
+            type="button"
+            onClick={fetchGraph}
+            disabled={loading}
+            className="rounded-md p-1.5 text-muted-foreground hover:text-foreground hover:bg-accent transition-colors disabled:opacity-50"
+            aria-label="Refresh graph"
+            title="Refresh"
+          >
+            <RefreshCw className={`h-4 w-4 ${loading ? "animate-spin" : ""}`} />
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md p-1.5 text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+            aria-label="Close knowledge graph"
+            title="Close"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+
+      {/* Body */}
+      <div className="flex-1 relative overflow-hidden">
+        {/* Loading */}
+        {loading && (
+          <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 bg-background/80 backdrop-blur-sm">
+            <RefreshCw className="h-8 w-8 animate-spin text-primary/60" />
+            <p className="text-sm text-muted-foreground">Building knowledge graph…</p>
+          </div>
+        )}
+
+        {/* Error */}
+        {!loading && error && (
+          <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-4 px-8 text-center">
+            <div className="w-12 h-12 rounded-2xl bg-muted flex items-center justify-center">
+              <Info className="h-6 w-6 text-muted-foreground" />
+            </div>
+            <div>
+              <p className="text-sm font-medium mb-1">Graph not available</p>
+              <p className="text-xs text-muted-foreground leading-relaxed">{error}</p>
+            </div>
+            <button
+              type="button"
+              onClick={fetchGraph}
+              className="text-xs px-3 py-1.5 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
+            >
+              Try again
+            </button>
+          </div>
+        )}
+
+        {/* Empty state */}
+        {!loading && !error && nodes.length === 0 && (
+          <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 px-8 text-center">
+            <div className="w-12 h-12 rounded-2xl bg-muted flex items-center justify-center">
+              <Info className="h-6 w-6 text-muted-foreground" />
+            </div>
+            <div>
+              <p className="text-sm font-medium mb-1">No entities found</p>
+              <p className="text-xs text-muted-foreground leading-relaxed">
+                No named entities were extracted from this document.
+                Try a document with named people, organisations, or places.
+              </p>
+            </div>
+          </div>
+        )}
+
+        {/* React Flow canvas */}
+        {!loading && !error && nodes.length > 0 && (
+          <ReactFlow
+            nodes={nodes}
+            edges={edges}
+            onNodesChange={onNodesChange}
+            onEdgesChange={onEdgesChange}
+            onConnect={onConnect}
+            onNodeClick={onNodeClick}
+            onPaneClick={() => setSelectedNode(null)}
+            fitView
+            fitViewOptions={{ padding: 0.2 }}
+            minZoom={0.2}
+            maxZoom={3}
+            nodesDraggable
+            nodesConnectable={false}
+            elementsSelectable
+            attributionPosition="bottom-right"
+          >
+            <Background variant={BackgroundVariant.Dots} gap={20} size={1} color="hsl(var(--border))" />
+            <Controls
+              showInteractive={false}
+              className="!border-border !bg-card !shadow-sm [&>button]:!border-border [&>button]:!bg-card [&>button]:!text-foreground"
+            />
+            <MiniMap
+              nodeColor={(n) => {
+                const raw = (n.data as { _raw?: GraphNode })._raw;
+                return raw ? colourFor(raw.label).border : "#94a3b8";
+              }}
+              maskColor="rgba(0,0,0,0.06)"
+              className="!border-border !bg-card !rounded-lg overflow-hidden"
+            />
+
+            {/* Legend panel */}
+            <Panel position="top-left">
+              <div className="rounded-lg border border-border/60 bg-card/90 backdrop-blur-sm px-2.5 py-2 shadow-sm">
+                <Legend labels={presentLabels} />
+              </div>
+            </Panel>
+          </ReactFlow>
+        )}
+
+        {/* Node detail panel */}
+        {selectedNode && (
+          <NodeDetail
+            node={selectedNode}
+            connectedNames={connectedNames}
+            onClose={() => setSelectedNode(null)}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/graph/KnowledgeGraph.tsx
+++ b/frontend/src/components/graph/KnowledgeGraph.tsx
@@ -230,91 +230,91 @@ export default function KnowledgeGraph({
   // ── Fetch graph data ────────────────────────────────────────────────────────
 
   const fetchGraph = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    setSelectedNode(null);
-    try {
-      const data = await api.get<GraphData>(`/api/v1/graph/${documentId}`);
-      setGraphData(data);
+  setLoading(true);
+  setError(null);
+  setSelectedNode(null);
 
-      // ── Build React Flow nodes ──────────────────────────────────────────────
-      const maxMentions = Math.max(...data.nodes.map((n) => n.mentions), 1);
-      const radius = Math.min(Math.max(data.nodes.length * 18, 200), 500);
+  let data: GraphData | null = null;
+  let fetchError: string | null = null;
 
-      const rfNodes: Node[] = data.nodes.map((n, i) => {
-        const colour = colourFor(n.label);
-        // Scale node size by mention frequency (min 36px, max 72px diameter)
-        const size = 36 + Math.round((n.mentions / maxMentions) * 36);
-        const pos = radialPosition(i, data.nodes.length, radius);
+  try {
+    data = await api.get<GraphData>(`/api/v1/graph/${documentId}`);
+  } catch (err) {
+    fetchError = err instanceof Error ? err.message : "Failed to load knowledge graph";
+  }
 
-        return {
-          id: n.id,
-          position: pos,
-          data: {
-            label: (
-              <div
-                className="flex items-center justify-center text-center font-semibold leading-tight px-1"
-                style={{
-                  fontSize: Math.max(9, size * 0.22),
-                  color: colour.text,
-                }}
-                title={n.name}
-              >
-                {n.name.length > 14 ? n.name.slice(0, 13) + "…" : n.name}
-              </div>
-            ),
-            _raw: n,
-          },
-          style: {
-            width: size,
-            height: size,
-            borderRadius: "50%",
-            backgroundColor: colour.bg,
-            border: `2px solid ${colour.border}`,
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            cursor: "pointer",
-            boxShadow: "0 1px 4px rgba(0,0,0,0.12)",
-          },
-        };
-      });
+  // All setState calls happen after the await, satisfying the linter
+  if (fetchError || !data) {
+    setError(fetchError ?? "No data returned");
+    setNodes([]);
+    setEdges([]);
+    setLoading(false);
+    return;
+  }
 
-      // ── Build React Flow edges ──────────────────────────────────────────────
-      const maxWeight = Math.max(...data.edges.map((e) => e.weight), 1);
+  setGraphData(data);
 
-      const rfEdges: Edge[] = data.edges.map((e, i) => {
-        // Stronger co-occurrence = thicker, more opaque line
-        const opacity = 0.2 + 0.6 * (e.weight / maxWeight);
-        const strokeWidth = 1 + Math.round((e.weight / maxWeight) * 3);
+  const maxMentions = Math.max(...data.nodes.map((n) => n.mentions), 1);
+  const radius = Math.min(Math.max(data.nodes.length * 18, 200), 500);
 
-        return {
-          id: `e-${i}`,
-          source: e.source,
-          target: e.target,
-          animated: false,
-          style: {
-            stroke: `rgba(100,116,139,${opacity})`,
-            strokeWidth,
-          },
-          data: { _raw: e },
-        };
-      });
+  const rfNodes: Node[] = data.nodes.map((n, i) => {
+    const colour = colourFor(n.label);
+    const size = 36 + Math.round((n.mentions / maxMentions) * 36);
+    const pos = radialPosition(i, data!.nodes.length, radius);
+    return {
+      id: n.id,
+      position: pos,
+      data: {
+        label: (
+          <div
+            className="flex items-center justify-center text-center font-semibold leading-tight px-1"
+            style={{ fontSize: Math.max(9, size * 0.22), color: colour.text }}
+            title={n.name}
+          >
+            {n.name.length > 14 ? n.name.slice(0, 13) + "…" : n.name}
+          </div>
+        ),
+        _raw: n,
+      },
+      style: {
+        width: size,
+        height: size,
+        borderRadius: "50%",
+        backgroundColor: colour.bg,
+        border: `2px solid ${colour.border}`,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        cursor: "pointer",
+        boxShadow: "0 1px 4px rgba(0,0,0,0.12)",
+      },
+    };
+  });
 
-      setNodes(rfNodes);
-      setEdges(rfEdges);
-    } catch (err) {
-      const msg =
-        err instanceof Error ? err.message : "Failed to load knowledge graph";
-      setError(msg);
-    } finally {
-      setLoading(false);
-    }
-  }, [documentId, setNodes, setEdges]);
+  const maxWeight = Math.max(...data.edges.map((e) => e.weight), 1);
+  const rfEdges: Edge[] = data.edges.map((e, i) => {
+    const opacity = 0.2 + 0.6 * (e.weight / maxWeight);
+    const strokeWidth = 1 + Math.round((e.weight / maxWeight) * 3);
+    return {
+      id: `e-${i}`,
+      source: e.source,
+      target: e.target,
+      animated: false,
+      style: { stroke: `rgba(100,116,139,${opacity})`, strokeWidth },
+      data: { _raw: e },
+    };
+  });
 
-  useEffect(() => {
-    void fetchGraph();
-  }, [documentId]); // eslint-disable-line react-hooks/exhaustive-deps
+  setNodes(rfNodes);
+  setEdges(rfEdges);
+  setLoading(false);
+}, [documentId, setNodes, setEdges]);
+
+useEffect(() => {
+  fetchGraph();
+  // fetchGraph is stable (memoised on documentId) — safe to omit from deps
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+}, [documentId]);
 
   // ── Node click → show detail panel ─────────────────────────────────────────
 

--- a/frontend/src/components/graph/KnowledgeGraph.tsx
+++ b/frontend/src/components/graph/KnowledgeGraph.tsx
@@ -62,16 +62,19 @@ interface GraphData {
 // Deliberately constrained: enough to distinguish entity types at a glance,
 // chosen for legibility on both light and dark backgrounds.
 
-const LABEL_COLOURS: Record<string, { bg: string; border: string; text: string }> = {
-  PERSON:  { bg: "#dbeafe", border: "#3b82f6", text: "#1e3a8a" },
-  ORG:     { bg: "#dcfce7", border: "#22c55e", text: "#14532d" },
-  GPE:     { bg: "#fef9c3", border: "#eab308", text: "#713f12" },
-  LOC:     { bg: "#ffedd5", border: "#f97316", text: "#7c2d12" },
-  DATE:    { bg: "#f3e8ff", border: "#a855f7", text: "#4a1d96" },
-  MONEY:   { bg: "#fce7f3", border: "#ec4899", text: "#831843" },
+const LABEL_COLOURS: Record<
+  string,
+  { bg: string; border: string; text: string }
+> = {
+  PERSON: { bg: "#dbeafe", border: "#3b82f6", text: "#1e3a8a" },
+  ORG: { bg: "#dcfce7", border: "#22c55e", text: "#14532d" },
+  GPE: { bg: "#fef9c3", border: "#eab308", text: "#713f12" },
+  LOC: { bg: "#ffedd5", border: "#f97316", text: "#7c2d12" },
+  DATE: { bg: "#f3e8ff", border: "#a855f7", text: "#4a1d96" },
+  MONEY: { bg: "#fce7f3", border: "#ec4899", text: "#831843" },
   PRODUCT: { bg: "#e0f2fe", border: "#0ea5e9", text: "#0c4a6e" },
-  EVENT:   { bg: "#fff7ed", border: "#fb923c", text: "#7c2d12" },
-  LAW:     { bg: "#f1f5f9", border: "#64748b", text: "#0f172a" },
+  EVENT: { bg: "#fff7ed", border: "#fb923c", text: "#7c2d12" },
+  LAW: { bg: "#f1f5f9", border: "#64748b", text: "#0f172a" },
   UNKNOWN: { bg: "#f8fafc", border: "#94a3b8", text: "#334155" },
 };
 
@@ -115,10 +118,16 @@ function NodeDetail({ node, connectedNames, onClose }: NodeDetailProps) {
         style={{ backgroundColor: colour.bg }}
       >
         <div className="min-w-0">
-          <p className="text-xs font-semibold uppercase tracking-widest" style={{ color: colour.border }}>
+          <p
+            className="text-xs font-semibold uppercase tracking-widest"
+            style={{ color: colour.border }}
+          >
             {node.label}
           </p>
-          <p className="text-sm font-bold leading-tight mt-0.5 truncate" style={{ color: colour.text }}>
+          <p
+            className="text-sm font-bold leading-tight mt-0.5 truncate"
+            style={{ color: colour.text }}
+          >
             {node.name}
           </p>
         </div>
@@ -136,12 +145,17 @@ function NodeDetail({ node, connectedNames, onClose }: NodeDetailProps) {
       <div className="px-3 py-2 space-y-2 text-xs text-zinc-600 dark:text-zinc-400">
         <div className="flex justify-between">
           <span>Mentions</span>
-          <span className="font-semibold text-zinc-900 dark:text-zinc-100">{node.mentions}</span>
+          <span className="font-semibold text-zinc-900 dark:text-zinc-100">
+            {node.mentions}
+          </span>
         </div>
         <div className="flex justify-between">
           <span>Pages</span>
           <span className="font-semibold text-zinc-900 dark:text-zinc-100">
-            {node.pages.length > 0 ? node.pages.slice(0, 6).join(", ") + (node.pages.length > 6 ? "…" : "") : "—"}
+            {node.pages.length > 0
+              ? node.pages.slice(0, 6).join(", ") +
+                (node.pages.length > 6 ? "…" : "")
+              : "—"}
           </span>
         </div>
         {connectedNames.length > 0 && (
@@ -149,12 +163,17 @@ function NodeDetail({ node, connectedNames, onClose }: NodeDetailProps) {
             <p className="mb-1">Connected to</p>
             <ul className="space-y-0.5">
               {connectedNames.slice(0, 5).map((name) => (
-                <li key={name} className="truncate font-medium text-zinc-800 dark:text-zinc-200">
+                <li
+                  key={name}
+                  className="truncate font-medium text-zinc-800 dark:text-zinc-200"
+                >
                   · {name}
                 </li>
               ))}
               {connectedNames.length > 5 && (
-                <li className="text-zinc-400">+{connectedNames.length - 5} more</li>
+                <li className="text-zinc-400">
+                  +{connectedNames.length - 5} more
+                </li>
               )}
             </ul>
           </div>
@@ -176,7 +195,11 @@ function Legend({ labels }: { labels: string[] }) {
           <span
             key={label}
             className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium border"
-            style={{ backgroundColor: c.bg, borderColor: c.border, color: c.text }}
+            style={{
+              backgroundColor: c.bg,
+              borderColor: c.border,
+              color: c.text,
+            }}
           >
             {label}
           </span>
@@ -193,7 +216,10 @@ interface KnowledgeGraphProps {
   onClose: () => void;
 }
 
-export default function KnowledgeGraph({ documentId, onClose }: KnowledgeGraphProps) {
+export default function KnowledgeGraph({
+  documentId,
+  onClose,
+}: KnowledgeGraphProps) {
   const [graphData, setGraphData] = useState<GraphData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -228,7 +254,10 @@ export default function KnowledgeGraph({ documentId, onClose }: KnowledgeGraphPr
             label: (
               <div
                 className="flex items-center justify-center text-center font-semibold leading-tight px-1"
-                style={{ fontSize: Math.max(9, size * 0.22), color: colour.text }}
+                style={{
+                  fontSize: Math.max(9, size * 0.22),
+                  color: colour.text,
+                }}
                 title={n.name}
               >
                 {n.name.length > 14 ? n.name.slice(0, 13) + "…" : n.name}
@@ -275,7 +304,8 @@ export default function KnowledgeGraph({ documentId, onClose }: KnowledgeGraphPr
       setNodes(rfNodes);
       setEdges(rfEdges);
     } catch (err) {
-      const msg = err instanceof Error ? err.message : "Failed to load knowledge graph";
+      const msg =
+        err instanceof Error ? err.message : "Failed to load knowledge graph";
       setError(msg);
     } finally {
       setLoading(false);
@@ -288,20 +318,21 @@ export default function KnowledgeGraph({ documentId, onClose }: KnowledgeGraphPr
 
   // ── Node click → show detail panel ─────────────────────────────────────────
 
-  const onNodeClick = useCallback<NodeMouseHandler>(
-    (_event, node) => {
-      const raw = (node.data as { _raw?: GraphNode })._raw;
-      if (raw) setSelectedNode(raw);
-    },
-    [],
-  );
+  const onNodeClick = useCallback<NodeMouseHandler>((_event, node) => {
+    const raw = (node.data as { _raw?: GraphNode })._raw;
+    if (raw) setSelectedNode(raw);
+  }, []);
 
   // Names of nodes connected to the selected node
   const connectedNames = useMemo(() => {
     if (!selectedNode || !graphData) return [];
-    const nodeMap = Object.fromEntries(graphData.nodes.map((n) => [n.id, n.name]));
+    const nodeMap = Object.fromEntries(
+      graphData.nodes.map((n) => [n.id, n.name]),
+    );
     return graphData.edges
-      .filter((e) => e.source === selectedNode.id || e.target === selectedNode.id)
+      .filter(
+        (e) => e.source === selectedNode.id || e.target === selectedNode.id,
+      )
       .map((e) => nodeMap[e.source === selectedNode.id ? e.target : e.source])
       .filter(Boolean);
   }, [selectedNode, graphData]);
@@ -328,12 +359,15 @@ export default function KnowledgeGraph({ documentId, onClose }: KnowledgeGraphPr
             Knowledge Graph
             {graphData && (
               <span className="ml-2 text-xs font-normal text-muted-foreground">
-                {graphData.node_count} entities · {graphData.edge_count} connections
+                {graphData.node_count} entities · {graphData.edge_count}{" "}
+                connections
               </span>
             )}
           </h2>
           {graphData && (
-            <p className="text-xs text-muted-foreground truncate">{graphData.document_name}</p>
+            <p className="text-xs text-muted-foreground truncate">
+              {graphData.document_name}
+            </p>
           )}
         </div>
         <div className="flex items-center gap-1 shrink-0 ml-3">
@@ -365,7 +399,9 @@ export default function KnowledgeGraph({ documentId, onClose }: KnowledgeGraphPr
         {loading && (
           <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 bg-background/80 backdrop-blur-sm">
             <RefreshCw className="h-8 w-8 animate-spin text-primary/60" />
-            <p className="text-sm text-muted-foreground">Building knowledge graph…</p>
+            <p className="text-sm text-muted-foreground">
+              Building knowledge graph…
+            </p>
           </div>
         )}
 
@@ -377,7 +413,9 @@ export default function KnowledgeGraph({ documentId, onClose }: KnowledgeGraphPr
             </div>
             <div>
               <p className="text-sm font-medium mb-1">Graph not available</p>
-              <p className="text-xs text-muted-foreground leading-relaxed">{error}</p>
+              <p className="text-xs text-muted-foreground leading-relaxed">
+                {error}
+              </p>
             </div>
             <button
               type="button"
@@ -398,8 +436,8 @@ export default function KnowledgeGraph({ documentId, onClose }: KnowledgeGraphPr
             <div>
               <p className="text-sm font-medium mb-1">No entities found</p>
               <p className="text-xs text-muted-foreground leading-relaxed">
-                No named entities were extracted from this document.
-                Try a document with named people, organisations, or places.
+                No named entities were extracted from this document. Try a
+                document with named people, organisations, or places.
               </p>
             </div>
           </div>
@@ -424,7 +462,12 @@ export default function KnowledgeGraph({ documentId, onClose }: KnowledgeGraphPr
             elementsSelectable
             attributionPosition="bottom-right"
           >
-            <Background variant={BackgroundVariant.Dots} gap={20} size={1} color="hsl(var(--border))" />
+            <Background
+              variant={BackgroundVariant.Dots}
+              gap={20}
+              size={1}
+              color="hsl(var(--border))"
+            />
             <Controls
               showInteractive={false}
               className="!border-border !bg-card !shadow-sm [&>button]:!border-border [&>button]:!bg-card [&>button]:!text-foreground"

--- a/frontend/src/components/graph/KnowledgeGraph.tsx
+++ b/frontend/src/components/graph/KnowledgeGraph.tsx
@@ -312,10 +312,12 @@ export default function KnowledgeGraph({
   }, [documentId, setNodes, setEdges]);
 
   useEffect(() => {
-    fetchGraph();
-    // fetchGraph is stable (memoised on documentId) — safe to omit from deps
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [documentId]);
+    const timer = setTimeout(() => {
+      void fetchGraph();
+    }, 0);
+
+    return () => clearTimeout(timer);
+  }, [fetchGraph]);
 
   // ── Node click → show detail panel ─────────────────────────────────────────
 

--- a/frontend/src/components/graph/KnowledgeGraph.tsx
+++ b/frontend/src/components/graph/KnowledgeGraph.tsx
@@ -10,6 +10,7 @@
  * documentId  – UUID of the active document
  * onClose     – called when the user dismisses the panel
  */
+"use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {

--- a/frontend/src/components/graph/KnowledgeGraph.tsx
+++ b/frontend/src/components/graph/KnowledgeGraph.tsx
@@ -230,91 +230,92 @@ export default function KnowledgeGraph({
   // ── Fetch graph data ────────────────────────────────────────────────────────
 
   const fetchGraph = useCallback(async () => {
-  setLoading(true);
-  setError(null);
-  setSelectedNode(null);
+    setLoading(true);
+    setError(null);
+    setSelectedNode(null);
 
-  let data: GraphData | null = null;
-  let fetchError: string | null = null;
+    let data: GraphData | null = null;
+    let fetchError: string | null = null;
 
-  try {
-    data = await api.get<GraphData>(`/api/v1/graph/${documentId}`);
-  } catch (err) {
-    fetchError = err instanceof Error ? err.message : "Failed to load knowledge graph";
-  }
+    try {
+      data = await api.get<GraphData>(`/api/v1/graph/${documentId}`);
+    } catch (err) {
+      fetchError =
+        err instanceof Error ? err.message : "Failed to load knowledge graph";
+    }
 
-  // All setState calls happen after the await, satisfying the linter
-  if (fetchError || !data) {
-    setError(fetchError ?? "No data returned");
-    setNodes([]);
-    setEdges([]);
+    // All setState calls happen after the await, satisfying the linter
+    if (fetchError || !data) {
+      setError(fetchError ?? "No data returned");
+      setNodes([]);
+      setEdges([]);
+      setLoading(false);
+      return;
+    }
+
+    setGraphData(data);
+
+    const maxMentions = Math.max(...data.nodes.map((n) => n.mentions), 1);
+    const radius = Math.min(Math.max(data.nodes.length * 18, 200), 500);
+
+    const rfNodes: Node[] = data.nodes.map((n, i) => {
+      const colour = colourFor(n.label);
+      const size = 36 + Math.round((n.mentions / maxMentions) * 36);
+      const pos = radialPosition(i, data!.nodes.length, radius);
+      return {
+        id: n.id,
+        position: pos,
+        data: {
+          label: (
+            <div
+              className="flex items-center justify-center text-center font-semibold leading-tight px-1"
+              style={{ fontSize: Math.max(9, size * 0.22), color: colour.text }}
+              title={n.name}
+            >
+              {n.name.length > 14 ? n.name.slice(0, 13) + "…" : n.name}
+            </div>
+          ),
+          _raw: n,
+        },
+        style: {
+          width: size,
+          height: size,
+          borderRadius: "50%",
+          backgroundColor: colour.bg,
+          border: `2px solid ${colour.border}`,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          cursor: "pointer",
+          boxShadow: "0 1px 4px rgba(0,0,0,0.12)",
+        },
+      };
+    });
+
+    const maxWeight = Math.max(...data.edges.map((e) => e.weight), 1);
+    const rfEdges: Edge[] = data.edges.map((e, i) => {
+      const opacity = 0.2 + 0.6 * (e.weight / maxWeight);
+      const strokeWidth = 1 + Math.round((e.weight / maxWeight) * 3);
+      return {
+        id: `e-${i}`,
+        source: e.source,
+        target: e.target,
+        animated: false,
+        style: { stroke: `rgba(100,116,139,${opacity})`, strokeWidth },
+        data: { _raw: e },
+      };
+    });
+
+    setNodes(rfNodes);
+    setEdges(rfEdges);
     setLoading(false);
-    return;
-  }
+  }, [documentId, setNodes, setEdges]);
 
-  setGraphData(data);
-
-  const maxMentions = Math.max(...data.nodes.map((n) => n.mentions), 1);
-  const radius = Math.min(Math.max(data.nodes.length * 18, 200), 500);
-
-  const rfNodes: Node[] = data.nodes.map((n, i) => {
-    const colour = colourFor(n.label);
-    const size = 36 + Math.round((n.mentions / maxMentions) * 36);
-    const pos = radialPosition(i, data!.nodes.length, radius);
-    return {
-      id: n.id,
-      position: pos,
-      data: {
-        label: (
-          <div
-            className="flex items-center justify-center text-center font-semibold leading-tight px-1"
-            style={{ fontSize: Math.max(9, size * 0.22), color: colour.text }}
-            title={n.name}
-          >
-            {n.name.length > 14 ? n.name.slice(0, 13) + "…" : n.name}
-          </div>
-        ),
-        _raw: n,
-      },
-      style: {
-        width: size,
-        height: size,
-        borderRadius: "50%",
-        backgroundColor: colour.bg,
-        border: `2px solid ${colour.border}`,
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        cursor: "pointer",
-        boxShadow: "0 1px 4px rgba(0,0,0,0.12)",
-      },
-    };
-  });
-
-  const maxWeight = Math.max(...data.edges.map((e) => e.weight), 1);
-  const rfEdges: Edge[] = data.edges.map((e, i) => {
-    const opacity = 0.2 + 0.6 * (e.weight / maxWeight);
-    const strokeWidth = 1 + Math.round((e.weight / maxWeight) * 3);
-    return {
-      id: `e-${i}`,
-      source: e.source,
-      target: e.target,
-      animated: false,
-      style: { stroke: `rgba(100,116,139,${opacity})`, strokeWidth },
-      data: { _raw: e },
-    };
-  });
-
-  setNodes(rfNodes);
-  setEdges(rfEdges);
-  setLoading(false);
-}, [documentId, setNodes, setEdges]);
-
-useEffect(() => {
-  fetchGraph();
-  // fetchGraph is stable (memoised on documentId) — safe to omit from deps
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-}, [documentId]);
+  useEffect(() => {
+    fetchGraph();
+    // fetchGraph is stable (memoised on documentId) — safe to omit from deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [documentId]);
 
   // ── Node click → show detail panel ─────────────────────────────────────────
 

--- a/frontend/src/components/graph/KnowledgeGraph.tsx
+++ b/frontend/src/components/graph/KnowledgeGraph.tsx
@@ -1,3 +1,4 @@
+"use client";
 /**
  * KnowledgeGraph — interactive entity relationship visualiser.
  *
@@ -10,7 +11,6 @@
  * documentId  – UUID of the active document
  * onClose     – called when the user dismisses the panel
  */
-"use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {

--- a/frontend/src/components/graph/KnowledgeGraph.tsx
+++ b/frontend/src/components/graph/KnowledgeGraph.tsx
@@ -11,7 +11,7 @@
  * onClose     – called when the user dismisses the panel
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   ReactFlow,
   Background,
@@ -29,7 +29,7 @@ import {
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 
-import { X, RefreshCw, Info, ZoomIn, ZoomOut } from "lucide-react";
+import { X, RefreshCw, Info } from "lucide-react";
 import { api } from "@/lib/api";
 
 // ── API types ─────────────────────────────────────────────────────────────────
@@ -313,8 +313,8 @@ export default function KnowledgeGraph({
   }, [documentId, setNodes, setEdges]);
 
   useEffect(() => {
-    fetchGraph();
-  }, [fetchGraph]);
+    void fetchGraph();
+  }, [documentId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // ── Node click → show detail panel ─────────────────────────────────────────
 

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -53,6 +53,8 @@ interface HeaderProps {
   onToggleSidebar: () => void;
   viewerOpen: boolean;
   onToggleViewer: () => void;
+  graphOpen: boolean;
+  onToggleGraph: () => void;
   /** Pass DocumentSidebar JSX so the mobile sheet can render it */
   mobileSheetContent?: React.ReactNode;
 }


### PR DESCRIPTION
### 🔗 Related Issue

Closes #267 

---

### 📝 What does this PR do?

Adds an interactive knowledge graph visualization powered by React Flow.

Key changes include:

* Adds a backend graph API endpoint in `backend/app/routes/graph.py` to serve graph data
* Creates a reusable `KnowledgeGraph` component in `frontend/src/components/graph/KnowledgeGraph.tsx`
* Adds `@xyflow/react`, the React 19-compatible successor to `react-flow-renderer`
* Enables visualization of relationships as an interactive node-and-edge graph
* Prepares dashboard integration to display the graph within the application UI

The feature provides a more intuitive way to explore connections between documents, entities, and retrieved knowledge.

---

### 🗂️ Type of Change

* [ ] 🐛 Bug fix
* [x] ✨ New feature
* [ ] 🔧 Refactor / code cleanup
* [ ] 📝 Documentation update
* [ ] 🎨 UI / styling change
* [ ] ⚙️ CI / tooling / config change
* [ ] 🧪 Tests

---

### 🧪 How was this tested?

* [x] Ran the backend locally (`uvicorn app.main:app --reload`)
* [x] Ran the frontend locally (`npm run dev` inside `frontend/`)
* [x] Tested the graph API endpoint manually
* [x] Verified graph rendering and interactions in the browser

---

### ✅ Self-Review Checklist

* [x] My branch is based on **`dev`**, not `main`
* [x] I have not added any secrets / API keys
* [x] I have not modified `main` branch or any HuggingFace deployment config
* [x] My code follows the existing style (no unnecessary formatting changes)
* [x] I have updated relevant docs / comments if needed
