### PR TITLE
fix: refactoring OCR imports to module level

### DIFF
--- a/backend/app/rag/vision.py
+++ b/backend/app/rag/vision.py
@@ -21,6 +21,25 @@ from app.config import get_settings
 logger = logging.getLogger(__name__)
 settings = get_settings()
 
+# ── Optional OCR backend (PIL + pytesseract) ─────────────────────────────────
+# Imported once at module load instead of inline on every _ocr_caption() call.
+# ``HAS_OCR`` records availability so the hot path (large batch caption loops in
+# generate_captions_for_chunks) can short-circuit with a cheap boolean check
+# rather than re-running an import + try/except on each image.
+try:
+    from PIL import Image
+    import pytesseract
+
+    HAS_OCR = True
+except ImportError:
+    Image = None  # type: ignore[assignment]
+    pytesseract = None  # type: ignore[assignment]
+    HAS_OCR = False
+    logger.info(
+        "OCR backend unavailable (PIL/pytesseract not installed); "
+        "image captioning will fall back to placeholders."
+    )
+
 # Minimum image area (px²) — smaller images are decorative and skipped.
 _MIN_IMAGE_AREA = 1_000
 
@@ -123,11 +142,12 @@ def extract_captions_from_pdf(filepath: str) -> List[Dict[str, Any]]:
 # ── 2. OCR fallback ──────────────────────────────────────────────────────────
 
 def _ocr_caption(image_bytes: bytes) -> str:
-    """Attempt OCR via pytesseract; returns empty string if unavailable."""
-    try:
-        from PIL import Image
-        import pytesseract
-    except Exception:
+    """Attempt OCR via pytesseract; returns empty string if unavailable.
+
+    The PIL/pytesseract import is resolved once at module load (see ``HAS_OCR``),
+    so this only does a boolean check before touching the image bytes.
+    """
+    if not HAS_OCR:
         return ""
 
     try:

--- a/backend/tests/test_vision_ocr_imports.py
+++ b/backend/tests/test_vision_ocr_imports.py
@@ -1,0 +1,128 @@
+"""Tests for issue #591 — module-level OCR imports with a global ``HAS_OCR`` flag.
+
+These verify that PIL/pytesseract are imported once at module load rather than
+inline on every ``_ocr_caption`` call, and that the hot path short-circuits on
+the boolean flag instead of re-running an import/try-except on each image.
+"""
+import builtins
+import importlib
+import inspect
+
+from app.rag import vision
+
+
+class _Boom:
+    """Any attribute access raises — proves the OCR backend is never touched."""
+
+    def __getattr__(self, _name):
+        raise AssertionError(
+            "OCR backend must not be accessed when HAS_OCR is False"
+        )
+
+
+def _fake_image(return_text):
+    """Build a stand-in ``PIL.Image`` whose pipeline yields ``return_text``."""
+
+    class _FakeImg:
+        def convert(self, mode):
+            assert mode == "RGB"
+            return self
+
+    return type("FakeImage", (), {"open": staticmethod(lambda _buf: _FakeImg())})
+
+
+def _fake_pytesseract(return_text):
+    return type(
+        "FakePytesseract",
+        (),
+        {"image_to_string": staticmethod(lambda _img: return_text)},
+    )
+
+
+# ── Module surface ───────────────────────────────────────────────────────────
+
+def test_module_exposes_boolean_has_ocr_flag():
+    assert hasattr(vision, "HAS_OCR")
+    assert isinstance(vision.HAS_OCR, bool)
+
+
+def test_image_and_pytesseract_are_module_level_symbols():
+    # Present as module globals regardless of availability (None when missing).
+    assert "Image" in vars(vision)
+    assert "pytesseract" in vars(vision)
+
+
+def test_ocr_caption_has_no_inline_imports():
+    """Regression guard: inline imports must not creep back into the hot path."""
+    src = inspect.getsource(vision._ocr_caption)
+    assert "import pytesseract" not in src
+    assert "from PIL" not in src
+    assert "HAS_OCR" in src  # the flag is what gates execution now
+
+
+# ── Runtime behaviour ─────────────────────────────────────────────────────────
+
+def test_ocr_caption_short_circuits_when_unavailable(monkeypatch):
+    """HAS_OCR False → returns '' without ever touching Image/pytesseract."""
+    monkeypatch.setattr(vision, "HAS_OCR", False)
+    monkeypatch.setattr(vision, "Image", _Boom(), raising=False)
+    monkeypatch.setattr(vision, "pytesseract", _Boom(), raising=False)
+    assert vision._ocr_caption(b"any-bytes") == ""
+
+
+def test_ocr_caption_uses_module_objects_when_available(monkeypatch):
+    monkeypatch.setattr(vision, "HAS_OCR", True)
+    monkeypatch.setattr(vision, "Image", _fake_image("  hello world  "))
+    monkeypatch.setattr(vision, "pytesseract", _fake_pytesseract("  hello world  "))
+    assert vision._ocr_caption(b"img-bytes") == "hello world"
+
+
+def test_ocr_caption_truncates_long_text(monkeypatch):
+    long_text = "x" * 600
+    monkeypatch.setattr(vision, "HAS_OCR", True)
+    monkeypatch.setattr(vision, "Image", _fake_image(long_text))
+    monkeypatch.setattr(vision, "pytesseract", _fake_pytesseract(long_text))
+    result = vision._ocr_caption(b"img")
+    assert result.endswith("...")
+    assert len(result) == 503  # 500 chars + "..."
+
+
+def test_ocr_caption_swallows_runtime_errors(monkeypatch):
+    """A pytesseract runtime error (e.g. missing tesseract binary) returns ''."""
+    def _boom(_img):
+        raise RuntimeError("tesseract is not installed or not in PATH")
+
+    monkeypatch.setattr(vision, "HAS_OCR", True)
+    monkeypatch.setattr(vision, "Image", _fake_image(""))
+    monkeypatch.setattr(
+        vision,
+        "pytesseract",
+        type("P", (), {"image_to_string": staticmethod(_boom)}),
+    )
+    assert vision._ocr_caption(b"img") == ""
+
+
+# ── Import-availability detection ─────────────────────────────────────────────
+
+def test_has_ocr_false_when_imports_missing(monkeypatch):
+    """Reloading with PIL/pytesseract blocked sets HAS_OCR=False and leaves the
+    backend symbols as None — and the hot path stays safe."""
+    real_import = builtins.__import__
+
+    def _blocked_import(name, *args, **kwargs):
+        if name == "pytesseract" or name.split(".")[0] == "PIL":
+            raise ImportError(f"blocked for test: {name}")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _blocked_import)
+    reloaded = importlib.reload(vision)
+    try:
+        assert reloaded.HAS_OCR is False
+        assert reloaded.Image is None
+        assert reloaded.pytesseract is None
+        assert reloaded._ocr_caption(b"bytes") == ""
+    finally:
+        # Restore real import machinery and the genuine module state so the
+        # reloaded module object other tests share is left healthy.
+        monkeypatch.undo()
+        importlib.reload(reloaded)


### PR DESCRIPTION
## PR Checklist

### Related Issue
Closes #591 
 
### What this PR does
 
`_ocr_caption` in `backend/app/rag/vision.py` imported `PIL` and `pytesseract` inline inside a `try/except` on **every** call. Because `generate_captions_for_chunks` calls it in a loop over image chunks, the same import was re-resolved once per image, and the OCR dependency stayed invisible until runtime.
 
This PR moves those imports to module level and records availability in a global `HAS_OCR` boolean, exactly as suggested in the issue description:
 
```python
try:
    from PIL import Image
    import pytesseract
    HAS_OCR = True
except ImportError:
    Image = None
    pytesseract = None
    HAS_OCR = False
```
 
`_ocr_caption` now short-circuits on the flag (`if not HAS_OCR: return ""`) before touching any image bytes, so the batch loop does a cheap boolean check instead of an import + `try/except` per image. 
Behaviour is otherwise unchanged: when OCR is available the same `Image.open(...).convert("RGB")` -> `pytesseract.image_to_string(...)` path runs, with the same 500-char truncation and the same "return '' on failure" semantics (e.g. when the tesseract binary is missing). When the libraries aren't installed, captioning falls back to placeholders as before: now with a single informative log line at load time.
 
### Type of Change
- [x] Refactor / code cleanup
- [x] Tests
---
 
### Testing
- [x] Added / updated tests
New file `backend/tests/test_vision_ocr_imports.py` (8 tests, all passing):
- `HAS_OCR` exists and is a `bool`; `Image`/`pytesseract` are module-level symbols.
- Regression guard asserting no inline `import pytesseract` / `from PIL` remains inside `_ocr_caption` and that it references `HAS_OCR`.
- Short-circuit path: with `HAS_OCR=False`, returns `""` without touching the OCR backend (the stand-ins raise `AssertionError` if accessed).
- Available path: with stubbed `Image`/`pytesseract`, returns the stripped text.
- Long text is truncated to 500 chars + `"..."`.
- A runtime error from `image_to_string` (e.g. missing binary) returns `""`.
- Reloading the module with `PIL`/`pytesseract` blocked sets `HAS_OCR=False` and leaves the symbols as `None`.

```bash
PS C:\Users\madhu\Documents\PDF-Assistant-RAG\backend> pytest tests/test_vision_ocr_imports.py -v
================================================= test session starts =================================================
platform win32 -- Python 3.11.7, pytest-9.0.3, pluggy-1.6.0 -- C:\Program Files\Python311\python.exe
cachedir: .pytest_cache
rootdir: C:\Users\madhu\Documents\PDF-Assistant-RAG\backend
plugins: anyio-4.13.0, deepeval-4.0.5, Faker-40.19.1, langsmith-0.8.8, asyncio-1.4.0, cov-4.1.0, mock-3.15.1, repeat-0.9.4, rerunfailures-16.3, xdist-3.8.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 8 items

tests/test_vision_ocr_imports.py::test_module_exposes_boolean_has_ocr_flag PASSED                                [ 12%]
tests/test_vision_ocr_imports.py::test_image_and_pytesseract_are_module_level_symbols PASSED                     [ 25%]
tests/test_vision_ocr_imports.py::test_ocr_caption_has_no_inline_imports PASSED                                  [ 37%]
tests/test_vision_ocr_imports.py::test_ocr_caption_short_circuits_when_unavailable PASSED                        [ 50%]
tests/test_vision_ocr_imports.py::test_ocr_caption_uses_module_objects_when_available PASSED                     [ 62%]
tests/test_vision_ocr_imports.py::test_ocr_caption_truncates_long_text PASSED                                    [ 75%]
tests/test_vision_ocr_imports.py::test_ocr_caption_swallows_runtime_errors PASSED                                [ 87%]
tests/test_vision_ocr_imports.py::test_has_ocr_false_when_imports_missing PASSED                                 [100%]Running teardown with pytest sessionfinish...


================================================== warnings summary ===================================================
..\..\..\AppData\Roaming\Python\Python311\site-packages\fastapi\testclient.py:1
  C:\Users\madhu\AppData\Roaming\Python\Python311\site-packages\fastapi\testclient.py:1: StarletteDeprecationWarning: Using `httpx` with `starlette.testclient` is deprecated; install `httpx2` instead.
    from starlette.testclient import TestClient as TestClient  # noqa

app\config.py:10
  C:\Users\madhu\Documents\PDF-Assistant-RAG\backend\app\config.py:10: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.13/migration/
    class Settings(BaseSettings):

..\..\..\AppData\Roaming\Python\Python311\site-packages\langchain_classic\chains\api\base.py:57
  C:\Users\madhu\AppData\Roaming\Python\Python311\site-packages\langchain_classic\chains\api\base.py:57: DeprecationWarning: `langchain-community` is being sunset and is no longer actively maintained. See https://github.com/langchain-ai/langchain-community/issues/674 for details and migration guidance toward standalone integration packages.
    from langchain_community.utilities.requests import TextRequestsWrapper

app\schemas.py:144
  C:\Users\madhu\Documents\PDF-Assistant-RAG\backend\app\schemas.py:144: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.13/migration/
    class ApiKeyResponse(BaseModel):

app\schemas.py:154
  C:\Users\madhu\Documents\PDF-Assistant-RAG\backend\app\schemas.py:154: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.13/migration/
    class ApiKeyCreateResponse(BaseModel):

app\schemas.py:165
  C:\Users\madhu\Documents\PDF-Assistant-RAG\backend\app\schemas.py:165: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.13/migration/
    class UserResponse(BaseModel):

app\schemas.py:183
  C:\Users\madhu\Documents\PDF-Assistant-RAG\backend\app\schemas.py:183: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.13/migration/
    class DocumentResponse(BaseModel):

app\schemas.py:244
  C:\Users\madhu\Documents\PDF-Assistant-RAG\backend\app\schemas.py:244: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.13/migration/
    class DocumentStatusResponse(BaseModel):

app\schemas.py:321
  C:\Users\madhu\Documents\PDF-Assistant-RAG\backend\app\schemas.py:321: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.13/migration/
    class ChatMessageResponse(BaseModel):

app\schemas.py:377
  C:\Users\madhu\Documents\PDF-Assistant-RAG\backend\app\schemas.py:377: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.13/migration/
    class ChatSessionResponse(BaseModel):

app\schemas.py:392
  C:\Users\madhu\Documents\PDF-Assistant-RAG\backend\app\schemas.py:392: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.13/migration/
    class WorkspaceMemberResponse(BaseModel):

app\schemas.py:403
  C:\Users\madhu\Documents\PDF-Assistant-RAG\backend\app\schemas.py:403: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.13/migration/
    class WorkspaceResponse(BaseModel):

app\schemas.py:413
  C:\Users\madhu\Documents\PDF-Assistant-RAG\backend\app\schemas.py:413: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.13/migration/
    class WorkspaceDetailResponse(BaseModel):

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================== 8 passed, 13 warnings in 0.33s ============================================
```
 
### Flagged for reviewers
- Scope is intentionally limited to the OCR import handling. The pre-existing duplicate `def caption_image(...)` (the first definition is shadowed by the second) is left untouched to keep this PR atomic and scope-relevant: happy to open a separate cleanup PR if you'd like.
- `ImportError` is caught at import (it covers `ModuleNotFoundError`); the tesseract *binary* is still validated lazily inside the `try/except` in `_ocr_caption`, since that can't be detected at import time.


### Self-Review Checklist
- [x] My branch is based on **`dev`**, not `main`
- [x] I have not added any secrets / API keys
- [x] I have not modified `main` branch or any HuggingFace deployment config
- [x] My code follows the existing style (no unnecessary formatting changes)
- [x] I have updated relevant docs / comments if needed