### PR TITLE
fix: process_document Celery task is a no-op stub — wire it into the real ingestion pipeline

### DIFF
--- a/backend/app/tasks.py
+++ b/backend/app/tasks.py
@@ -1,15 +1,12 @@
-"""Celery tasks for document processing with Advanced Layout Parsing."""
+"""Celery tasks for document processing."""
 import logging
 import traceback
+from datetime import datetime, timezone
 
 from app.celery_app import celery_app
 from app.database import get_db_session
 from app.models import Document
-from app.services.layout_parser import AdvancedPDFParser
-
-# NOTE: If you need to map your extracted layouts to their existing embeddings logic,
-# retain their original ingest imports as fallback or utility helpers:
-# from app.services.document_ingestion import ingest_document 
+from app.services.document_ingestion import ingest_document as _ingest_document
 
 logger = logging.getLogger(__name__)
 
@@ -30,68 +27,40 @@ def process_document(
     original_name: str,
     user_id: str,
 ) -> dict[str, str]:
-    """Run the RAG ingestion pipeline for a stored document using Advanced Layout-Aware parsing."""
-    try:
-        # 1. Update Database Status to processing state
-        with get_db_session() as db:
-            doc = db.query(Document).filter(Document.id == document_id).first()
-            if doc:
-                doc.processing_started_at = __import__("datetime").datetime.now(__import__("datetime").timezone.utc)
-                doc.retry_count = (doc.retry_count or 0) + 1
-                doc.status = "processing"  # Set explicitly to show UI activity
-                db.commit()
+    """Run the RAG ingestion pipeline for a stored document.
 
-        logger.info("Starting Advanced Layout-Aware Ingestion for document: %s", original_name)
-
-        # 2. Trigger your advanced structural parser
-        parser = AdvancedPDFParser(filepath)
-        processed_chunks = parser.ingest_document()
-
-        # 3. Save chunks and upsert to Vector Storage (Pinecone Loop)
-        with get_db_session() as db:
-            doc = db.query(Document).filter(Document.id == document_id).first()
-            if not doc:
-                raise ValueError(f"Document record {document_id} disappeared during parsing.")
-
-            # --- VECTOR VECTORIZATION LOOP ---
-            # Loop through your layout-preserved structural objects
-            for idx, chunk in enumerate(processed_chunks):
-                text_content = chunk["text"]
-                page_num = chunk["page_number"]
-                chunk_type = chunk["type"]
-
-                # Logs the variables so Ruff marks them as "actively used"
-                logger.debug(
-                    f"Processing chunk {idx} (Type: {chunk_type}) on Page {page_num}: {text_content[:30]}..."
-                )
-                
-                # NOTE FOR GSSOC CONTRIBUTION: 
-                # Look inside 'app.services.document_ingestion' to see the exact name 
-                # of their embedding service/Pinecone client instance. 
-                # Hook it up here like this:
-                # 
-                # vector_id = f"{document_id}_chunk_{idx}"
-                # embedding = generate_vector_embeddings(text_content)
-                # pinecone_index.upsert(
-                #     vectors=[(vector_id, embedding, {
-                #         "text": text_content,
-                #         "page": page_num,
-                #         "type": chunk_type,
-                #         "document_id": document_id,
-                #         "user_id": user_id
-                #     })]
-                # )
-                pass
-
-            # 4. Mark document pipeline processing as completely successful
-            doc.status = "ready"
-            doc.processing_progress = 100
+    This task is a thin dispatch wrapper around
+    ``app.services.document_ingestion.ingest_document``, which is the single
+    source of truth for the ingestion state machine (status, progress,
+    chunk_count, page_count, summary, URL extraction, knowledge graph, and
+    vector storage). The task itself only records retry bookkeeping before
+    delegating; it does not open a second DB session that writes the same
+    Document row, since ingest_document manages its own SessionLocal()
+    session end-to-end and commits/rolls back independently.
+    """
+    with get_db_session() as db:
+        doc = db.query(Document).filter(Document.id == document_id).first()
+        if doc:
+            doc.processing_started_at = datetime.now(timezone.utc)
+            doc.retry_count = (doc.retry_count or 0) + 1
             db.commit()
 
-        return {"document_id": document_id, "status": "ready"}
+    logger.info("Dispatching ingestion pipeline for document: %s", original_name)
 
+    try:
+        _ingest_document(
+            document_id=document_id,
+            filepath=filepath,
+            original_name=original_name,
+            user_id=user_id,
+        )
     except Exception as exc:
-        logger.error("Document %s processing failed (attempt %s): %s", document_id, self.request.retries + 1, exc)
+        logger.error(
+            "Document %s processing failed (attempt %s): %s",
+            document_id,
+            self.request.retries + 1,
+            exc,
+        )
         with get_db_session() as db:
             doc = db.query(Document).filter(Document.id == document_id).first()
             if doc and self.request.retries >= (self.max_retries or 3) - 1:
@@ -100,3 +69,14 @@ def process_document(
                 doc.processing_progress = 0
                 db.commit()
         raise
+
+    with get_db_session() as db:
+        doc = db.query(Document).filter(Document.id == document_id).first()
+        final_status = doc.status if doc else "unknown"
+
+    if final_status == "failed":
+        raise RuntimeError(
+            f"Ingestion pipeline marked document {document_id} as failed"
+        )
+
+    return {"document_id": document_id, "status": final_status}

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -41,6 +41,12 @@ fake_vectorstore.get_chroma_client = lambda: _FakeChromaClient()
 fake_vectorstore.store_chunks = lambda chunks, document_id, filename, user_id: len(chunks)
 fake_vectorstore.delete_document_chunks = lambda document_id, user_id: None
 fake_vectorstore.query_chunks = lambda query_embedding, user_id, document_id=None, top_k=10: []
+
+if "sentence_transformers" not in sys.modules:
+    fake_sentence_transformers = types.ModuleType("sentence_transformers")
+    fake_sentence_transformers.CrossEncoder = lambda *args, **kwargs: None
+    sys.modules["sentence_transformers"] = fake_sentence_transformers
+    
 sys.modules.setdefault("app.rag.vectorstore", fake_vectorstore)
 
 slowapi_module = types.ModuleType("slowapi")

--- a/backend/tests/test_celery_ingestion.py
+++ b/backend/tests/test_celery_ingestion.py
@@ -1,37 +1,67 @@
+"""Regression tests for the process_document Celery task.
+
+These guard against the task body becoming a no-op stub again (see issue
+#635): process_document must actually drive the real ingestion pipeline in
+app.services.document_ingestion, not just flip the document's status to
+"ready" without storing any chunks/vectors.
+"""
 import pytest
 from unittest.mock import patch, MagicMock
 
-# Core app imports
 from app.models import Document
 from app.tasks import process_document
 
-def test_process_document_ingestion_pipeline(db_session):
-    """
-    Test that the Celery task updates document status from pending to ready
-    by executing the ingestion engine inside the active test database session.
-    """
 
-    # 1. SETUP: Create a mock document that starts as 'pending'
+def _make_pending_document(db_session, doc_id="test-doc-123", user_id="user-456"):
     test_doc = Document(
-        id="test-doc-123",
+        id=doc_id,
         filename="sample.pdf",
         original_name="sample.pdf",
         status="pending",
-        user_id="user-456"
+        user_id=user_id,
     )
     db_session.add(test_doc)
     db_session.commit()
+    return test_doc
 
-    # 2. ACT: Create a mock engine session factory context that yields our test db_session
-    mock_session_factory = MagicMock()
-    mock_session_factory.return_value.__enter__.return_value = db_session
-    mock_session_factory.return_value = db_session
 
-    with patch("app.tasks.get_db_session", return_value=db_session), \
-         patch("app.tasks.AdvancedPDFParser") as mock_parser_class:
-         
-        mock_parser = mock_parser_class.return_value
-        mock_parser.ingest_document.return_value = [{"text": "dummy", "page_number": 1, "type": "text"}]
+@pytest.fixture()
+def patched_session_factory(db_session, monkeypatch):
+    """Route both app.tasks (get_db_session) and document_ingestion
+    (SessionLocal) onto the same test db_session, so the task and the
+    pipeline it dispatches into observe a single consistent view of the row.
+    """
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _fake_get_db_session():
+        yield db_session
+
+    monkeypatch.setattr("app.tasks.get_db_session", _fake_get_db_session)
+    monkeypatch.setattr("app.database.SessionLocal", lambda: db_session)
+    monkeypatch.setattr(db_session, "close", lambda: None)
+
+    return db_session
+
+
+def test_process_document_runs_real_ingestion_pipeline(patched_session_factory):
+    """process_document must delegate into ingest_document and persist real
+    chunk/vector results - not silently no-op and mark the doc 'ready' with
+    zero chunks (the bug in #635).
+    """
+    db_session = patched_session_factory
+    _make_pending_document(db_session)
+
+    fake_chunks = [
+        {"text": "first chunk", "page": 1, "type": "text"},
+        {"text": "second chunk", "page": 1, "type": "text"},
+        {"text": "third chunk", "page": 2, "type": "text"},
+    ]
+
+    with patch("app.services.document_ingestion.get_page_count", return_value=2), \
+         patch("app.services.document_ingestion.chunk_document", return_value=fake_chunks), \
+         patch("app.services.document_ingestion.store_chunks", return_value=len(fake_chunks)) as mock_store, \
+         patch("app.services.document_ingestion.persist_document_keywords"):
 
         task_result = process_document.apply(
             kwargs={
@@ -42,10 +72,45 @@ def test_process_document_ingestion_pipeline(db_session):
             }
         )
 
-        # 3. ASSERT: Verify the task metrics and status changes inside the session context
-        assert task_result.status == "SUCCESS"
-        
-        # Query the database to verify the state update
-        updated_doc = db_session.query(Document).filter_by(id="test-doc-123").first()
-        assert updated_doc is not None
-        assert updated_doc.status == "ready"
+    assert task_result.status == "SUCCESS"
+    assert task_result.result == {"document_id": "test-doc-123", "status": "ready"}
+
+    mock_store.assert_called_once()
+    call_kwargs = mock_store.call_args.kwargs
+    assert call_kwargs["chunks"] == fake_chunks
+    assert call_kwargs["document_id"] == "test-doc-123"
+
+    updated_doc = db_session.query(Document).filter_by(id="test-doc-123").first()
+    assert updated_doc is not None
+    assert updated_doc.status == "ready"
+    assert updated_doc.chunk_count == 3
+    assert updated_doc.page_count == 2
+    assert updated_doc.retry_count == 1
+
+
+def test_process_document_marks_failed_when_no_text_extracted(patched_session_factory):
+    """If ingestion legitimately fails (e.g. no extractable text),
+    process_document must surface that as a failed task/status rather than
+    reporting 'ready' regardless of pipeline outcome.
+    """
+    db_session = patched_session_factory
+    _make_pending_document(db_session, doc_id="test-doc-empty")
+
+    with patch("app.services.document_ingestion.get_page_count", return_value=1), \
+         patch("app.services.document_ingestion.chunk_document", return_value=[]):
+
+        task_result = process_document.apply(
+            kwargs={
+                "document_id": "test-doc-empty",
+                "filepath": "/tmp/empty.pdf",
+                "original_name": "empty.pdf",
+                "user_id": "user-456",
+            }
+        )
+
+    assert task_result.status == "FAILURE"
+
+    updated_doc = db_session.query(Document).filter_by(id="test-doc-empty").first()
+    assert updated_doc is not None
+    assert updated_doc.status == "failed"
+    assert updated_doc.chunk_count == 0


### PR DESCRIPTION
Closes #635

## Problem
`process_document` in `backend/app/tasks.py` (the dispatch path used by every upload/retry/re-chunk endpoint whenever Celery is reachable) looped over parsed chunks and executed `pass` instead of calling `store_chunks()`, building the knowledge graph, generating a summary, or extracting URLs. It then unconditionally set `status="ready"` / `processing_progress=100` and committed. Because the task never raised, the real pipeline in `app/services/document_ingestion.py::ingest_document` — only invoked as a fallback when `process_document.delay(...)` itself raises — was effectively dead code in any environment where the Celery broker is up.

Net effect: every uploaded document was silently marked "ready" with `chunk_count=0`/`page_count=0` and zero vectors written, so all RAG queries against it returned nothing, with no error surfaced anywhere.

## Fix
`process_document` now delegates directly to `ingest_document`, passing through `document_id`, `filepath`, `original_name`, `user_id`. The duplicated status-transition logic in `tasks.py` was removed in favor of letting `ingest_document` — which already owns its own `SessionLocal()` session, commits, and failure handling — be the single source of truth for the ingestion state machine. `tasks.py` now only records retry bookkeeping before dispatch, wraps the call to catch exceptions raised before `ingest_document` opens its session, and re-reads the row afterward to raise if `ingest_document` marked it `failed` (so Celery's existing `autoretry_for`/`max_retries` behavior is preserved).

## Tests
Replaced the existing `test_celery_ingestion.py`, which only asserted `status == "ready"` and would have passed against the stub. The new tests run `process_document.apply(...)` end-to-end into the real `ingest_document` and assert:
- `store_chunks` is actually called with the produced chunks
- `chunk_count` and `page_count` are populated on the row (the actual regression)
- a zero-chunk document is correctly marked `failed`, not `ready`

Also added a lightweight `sentence_transformers` fake in `conftest.py` (same pattern already used there for `app.rag.embeddings`/`app.rag.vectorstore`) since `app.main` transitively imports `app.rag.reranker`, which only needs `CrossEncoder` for type construction and isn't exercised by this test path.

## GSSoC'26