### PR TITLE
fix: reject chunk_settings re-chunk requests while document is still processing

### DIFF
--- a/backend/app/routes/documents.py
+++ b/backend/app/routes/documents.py
@@ -26,6 +26,7 @@ from app.exceptions import (
     ExternalServiceException,
     NotFoundException,
     ValidationException,
+    ConflictException,
     AppException,
     ForbiddenException,
 )
@@ -716,6 +717,7 @@ def update_chunk_settings(
 
     Raises:
         HTTPException: With status code 404 if the document is not found or does not belong to the authenticated user.
+        HTTPException: With status code 409 if the document is currently processing (re-chunking would race a concurrent ingestion run).
         HTTPException: With status code 400 if the provided chunk size or overlap values are invalid (e.g., chunk size less than 100, or overlap greater than or equal to chunk size).
     """
     # Validate if the document exists and belongs to the user
@@ -727,7 +729,17 @@ def update_chunk_settings(
 
     if not doc:
         raise NotFoundException("Document")
-    
+
+    # Guard against re-queuing ingestion while a prior run for this same document is still actively processing. Without this, two
+    # process_document runs can execute concurrently against the same document_id: store_chunks() in vectorstore.py performs a non-atomic
+    # delete-then-batch-insert sequence, so one run's delete can fire in between the other run's delete-then-insert steps, corrupting the
+    # vector store and leaving Postgres' chunk_count out of sync with whatever vectors actually survive.
+    if doc.status == "processing":
+        raise ConflictException(
+            "Document is still processing. Wait for the current run to "
+            "finish before changing chunk settings."
+        )
+
     if settings_update.chunk_size is not None:
         if settings_update.chunk_size < 100:
             raise ValidationException("Chunk size must be at least 100")

--- a/backend/tests/test_chunk_settings_concurrency.py
+++ b/backend/tests/test_chunk_settings_concurrency.py
@@ -1,0 +1,89 @@
+"""Regression tests for re-chunking a document while it is
+still processing must not queue a second concurrent ingestion run.
+
+update_chunk_settings previously reset doc.status to "pending" and
+re-queued process_document.delay(...) unconditionally, with no check on
+the document's current status. If a prior ingestion run for the same
+document_id was still "processing", this let two ingestion runs execute
+concurrently against the same document - and since store_chunks() in
+vectorstore.py performs a non-atomic delete-then-batch-insert sequence,
+the two runs could interleave and corrupt the vector store relative to
+whatever chunk_count ends up persisted in Postgres.
+"""
+from app.models import Document
+
+
+def test_update_chunk_settings_rejects_while_document_processing(
+    client, auth_headers, db_session, user, monkeypatch
+):
+    """A document mid-ingestion must reject a re-chunk request with 409,
+    not silently reset its status and re-queue a second concurrent run.
+    """
+    document = Document(
+        user_id=user.id,
+        filename="processing.pdf",
+        original_name="processing.pdf",
+        file_size=256,
+        status="processing",
+        chunk_count=0,
+        page_count=0,
+    )
+    db_session.add(document)
+    db_session.commit()
+    db_session.refresh(document)
+
+    def _delay_should_not_be_called(*args, **kwargs):
+        raise AssertionError(
+            "process_document.delay was called for a document still "
+            "processing - the concurrency guard did not reject the request"
+        )
+
+    monkeypatch.setattr(
+        "app.routes.documents.process_document.delay",
+        _delay_should_not_be_called,
+    )
+
+    response = client.post(
+        f"/api/v1/documents/{document.id}/chunk_settings",
+        json={"chunk_size": 500, "chunk_overlap": 50},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 409
+
+    refreshed = db_session.get(Document, document.id)
+    assert refreshed.status == "processing"
+    assert refreshed.chunk_count == 0
+    assert refreshed.page_count == 0
+
+
+def test_update_chunk_settings_allows_when_not_processing(
+    client, auth_headers, ready_document, db_session, monkeypatch
+):
+    """A document that is "ready" (i.e. not mid-ingestion) must still be
+    allowed to re-chunk - the guard should only block "processing".
+    """
+    queued = {}
+
+    class _FakeTask:
+        id = "fake-task-id"
+
+    def _fake_delay(**kwargs):
+        queued.update(kwargs)
+        return _FakeTask()
+
+    monkeypatch.setattr("app.routes.documents.process_document.delay", _fake_delay)
+
+    response = client.post(
+        f"/api/v1/documents/{ready_document.id}/chunk_settings",
+        json={"chunk_size": 500, "chunk_overlap": 50},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    assert queued["document_id"] == ready_document.id
+
+    refreshed = db_session.get(Document, ready_document.id)
+    assert refreshed.status == "pending"
+    assert refreshed.chunk_size == 500
+    assert refreshed.chunk_overlap == 50


### PR DESCRIPTION
Closes #637

## Problem
`update_chunk_settings` in `backend/app/routes/documents.py` validated only that the document existed and belonged to the calling user — it never checked `doc.status`. It unconditionally reset `doc.status = "pending"`, zeroed `chunk_count`/`page_count`, and re-queued `process_document.delay(...)` (or the in-process fallback). This is inconsistent with `retry_document_processing` in the same file, which already guards with `if doc.status != "failed": raise ValidationException(...)`.

If a client calls `POST /{document_id}/chunk_settings` while a prior ingestion task for the same `document_id` is still `"processing"`, two ingestion runs execute concurrently against the same document. `store_chunks()` in `vectorstore.py` performs a non-atomic delete-then-batch-insert sequence (`delete_document_chunks()` followed by `collection.add()` in batches of 50) — with two concurrent runs, one task's delete can fire between the other task's delete-then-insert steps, or both can write overlapping `chunk_index`-derived IDs, leaving ChromaDB/BM25 inconsistent with whatever `chunk_count` Postgres ends up with (whichever `db.commit()` lands last wins, independent of which vectors actually survived).

## Fix
Added the same status-transition guard `retry_document_processing` already uses, rejecting the request with **409 Conflict** (`ConflictException`, not `ValidationException` — this is a state-machine conflict, not a malformed-input error) when `doc.status == "processing"`. The document's row, chunk settings, and chunk/page counts are left completely untouched on rejection, and `process_document.delay` is never called.

### Scope note
The issue also proposes a secondary task-level defense (a `processing_lock_token`/version column, checked-and-set atomically, to guard against legitimate Celery redelivery races from `acks_late` + `reject_on_worker_lost`). That requires a schema migration, and the repo's only existing migration pattern (`migrations/add_keywords_column.py`) is SQLite-only/ad-hoc while production runs Postgres — so I scoped this PR to the route-level guard, which closes the concrete reproduction in the issue, and left the lock-token as a follow-up rather than ship a half-designed migration alongside it.

## Tests
Added `backend/tests/test_chunk_settings_concurrency.py`:
- `test_update_chunk_settings_rejects_while_document_processing` — creates a `"processing"` document, asserts the endpoint returns 409, asserts `process_document.delay` is never called (fails loudly via `monkeypatch` if it is), and asserts the document's status/counts are unchanged.
- `test_update_chunk_settings_allows_when_not_processing` — confirms a `"ready"` document can still be re-chunked normally, so the guard only blocks the `"processing"` state.

Verified locally: both pass against the fix, and the first test correctly fails against the original unguarded route (confirming it catches the regression).

## GSSoC'26