### PR TITLE
fix: #477 Add defensive error handling for malformed LLM response choices

### DIFF
--- a/backend/app/rag/summarizer.py
+++ b/backend/app/rag/summarizer.py
@@ -50,7 +50,15 @@ def generate_document_summary(filePath: str, max_sentences: int = 3) -> str | No
             max_tokens=settings.SUMMARY_MAX_TOKENS,
             temperature=settings.LLM_TEMPERATURE,
         )
-        summary = response.choices[0].message.content.strip() if response.choices else None
+        
+        # Defensive check for malformed or empty response structures
+        summary = None
+        if response and getattr(response, "choices", None):
+            first_choice = response.choices[0]
+            message = getattr(first_choice, "message", None)
+            content = getattr(message, "content", None)
+            if content:
+                summary = content.strip()
 
         return summary if summary else None
 


### PR DESCRIPTION
## 📋 PR Checklist

> Thank you for contributing to **PDF-Assistant-RAG**! 🎉  
> Please fill out this template before submitting. PRs without it filled in will be closed.

---

### 🔗 Related Issue
Closes #477

---

### 📝 What does this PR do?
Adds defensive attribute retrieval using `getattr` when parsing the LLM client's chat completion choices. Previously, the logic assumed that if `response.choices` was populated, the nested `.message` and `.content` attributes were guaranteed to exist, causing an unhandled `AttributeError` on unexpected schemas or partial API responses. This fix ensures the application safely falls back to returning `None` without crashing.

---

### 🗂️ Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔧 Refactor / code cleanup
- [ ] 📝 Documentation update
- [ ] 🎨 UI / styling change
- [ ] ⚙️ CI / tooling / config change
- [ ] 🧪 Tests

---

### 🧪 How was this tested?
- [x] Tested the affected API endpoints manually
- [x] Verified that the code changes cleanly replace only the target fallback block without touching unrelated application logic.

---

### 📸 Screenshots (if UI change)
*N/A - Backend logic fix only.*

---

### ⚠️ Anything to flag for reviewers?
No major concerns. The change is isolated strictly inside `generate_document_summary` and builds upon the existing default return patterns.

---

### ✅ Self-Review Checklist
- [x] My branch is based on **`dev`**, not `main`
- [x] I have not added any secrets / API keys
- [x] I have not modified `main` branch or any HuggingFace deployment config
- [x] My code follows the existing style (no unnecessary formatting changes)
- [x] I have updated relevant docs / comments if needed