### PR TITLE
fix: return overall health status in health endpoint

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -228,9 +228,15 @@ def db_health():
     except Exception:
         chroma_status = "down"
 
-    overall_status = "ok" if db_status == "up" and chroma_status == "up" else "degraded"
-    return{
-        "status": db_status,
+    if db_status == "up" and chroma_status == "up":
+        overall_status = "healthy"
+    elif db_status == "down" and chroma_status == "down":
+        overall_status = "unhealthy"
+    else:
+        overall_status = "degraded"
+
+    return {
+        "status": overall_status,
         "chroma": chroma_status,
         "db": db_status
     }

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -13,3 +13,74 @@ async def test_health_check_route():
 
     assert response.status_code == 200
     # Add more assertions based on expected JSON response
+
+
+async def test_health_check_db_healthy_chroma_healthy(monkeypatch):
+    # Case 1: DB healthy, Chroma healthy -> status = healthy
+    # Both are healthy by default in test env (get_db yields test db, get_chroma_client works)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://testserver") as ac:
+        response = await ac.get("/health")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "healthy"
+    assert data["db"] == "up"
+    assert data["chroma"] == "up"
+
+
+async def test_health_check_db_healthy_chroma_unhealthy(monkeypatch):
+    # Case 2: DB healthy, Chroma unhealthy -> status = degraded
+    def mock_get_chroma_client_down():
+        raise Exception("Chroma connection refused")
+
+    monkeypatch.setattr("app.main.get_chroma_client", mock_get_chroma_client_down)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://testserver") as ac:
+        response = await ac.get("/health")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "degraded"
+    assert data["db"] == "up"
+    assert data["chroma"] == "down"
+
+
+async def test_health_check_db_unhealthy_chroma_healthy(monkeypatch):
+    # Case 3: DB unhealthy, Chroma healthy -> status = degraded
+    from sqlalchemy.exc import SQLAlchemyError
+
+    def mock_get_db_down():
+        raise SQLAlchemyError("DB Connection refused")
+        yield
+
+    monkeypatch.setattr("app.main.get_db", mock_get_db_down)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://testserver") as ac:
+        response = await ac.get("/health")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "degraded"
+    assert data["db"] == "down"
+    assert data["chroma"] == "up"
+
+
+async def test_health_check_db_unhealthy_chroma_unhealthy(monkeypatch):
+    # Case 4: DB unhealthy, Chroma unhealthy -> status = unhealthy
+    from sqlalchemy.exc import SQLAlchemyError
+
+    def mock_get_db_down():
+        raise SQLAlchemyError("DB Connection refused")
+        yield
+
+    def mock_get_chroma_client_down():
+        raise Exception("Chroma connection refused")
+
+    monkeypatch.setattr("app.main.get_db", mock_get_db_down)
+    monkeypatch.setattr("app.main.get_chroma_client", mock_get_chroma_client_down)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://testserver") as ac:
+        response = await ac.get("/health")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "unhealthy"
+    assert data["db"] == "down"
+    assert data["chroma"] == "down"
+


### PR DESCRIPTION
## 📋 PR Checklist

### 🔗 Related Issue

Closes #630

---

### 📝 What does this PR do?

Fixes an issue where the `/health` endpoint exposed the database health status as the top-level `status` field instead of the computed overall system health status.

Previously, when ChromaDB became unavailable while the database remained healthy, the endpoint incorrectly reported the application as healthy, causing monitoring systems to misinterpret the application's actual state.

This PR:

* Updates the health endpoint to return the computed overall system status.
* Ensures degraded states are correctly reported when either dependency is unavailable.
* Adds regression tests covering all database and ChromaDB health-state combinations.
* Prevents future regressions in health monitoring behavior.

---

### 🗂️ Type of Change

* [x] 🐛 Bug fix
* [ ] ✨ New feature
* [ ] 🔧 Refactor / code cleanup
* [ ] 📝 Documentation update
* [ ] 🎨 UI / styling change
* [ ] ⚙️ CI / tooling / config change
* [x] 🧪 Tests

---

### 🧪 How was this tested?

* [ ] Ran the backend locally (`uvicorn app.main:app --reload`)
* [ ] Ran the frontend locally (`npm run dev` inside `frontend/`)
* [ ] Tested the affected API endpoints manually
* [x] Added / updated tests

Additional verification:

* Added regression tests for:

  * DB healthy + ChromaDB healthy
  * DB healthy + ChromaDB unhealthy
  * DB unhealthy + ChromaDB healthy
  * DB unhealthy + ChromaDB unhealthy
* Verified tests fail on the previous implementation and pass with the fix.
* Ran targeted API tests.
* Ran the full backend test suite.

Test Results:

```bash
pytest tests/test_api.py
```

Passed: 5 tests

```bash
pytest
```

Passed: 236 tests

---

### 📸 Screenshots (if UI change)

N/A (Backend-only bug fix)

---

### ⚠️ Anything to flag for reviewers?

This is a focused fix for Issue #630.

The change is limited to health status reporting and regression tests. No unrelated functionality, API endpoints, database schema, or application behavior was modified.

---

### ✅ Self-Review Checklist

* [x] My branch is based on **`dev`**, not `main`
* [x] I have not added any secrets / API keys
* [x] I have not modified `main` branch or any HuggingFace deployment config
* [x] My code follows the existing style (no unnecessary formatting changes)
* [ ] I have updated relevant docs / comments if needed
