### PR TITLE
fix(profile): validate username uniqueness before profile updates

### DIFF
--- a/backend/app/routes/profile.py
+++ b/backend/app/routes/profile.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Depends, UploadFile, File
 from sqlalchemy.orm import Session
+from sqlalchemy.exc import IntegrityError
 from pathlib import Path
 import shutil
 import uuid
@@ -28,12 +29,27 @@ def update_profile(
     current_user: User = Depends(get_current_user),
 ):
     if payload.username:
+        existing_user = (
+            db.query(User)
+            .filter(
+                User.username == payload.username,
+                User.id != current_user.id,
+            )
+            .first()
+        )
+        if existing_user:
+            raise ValidationException("Username already exists")
         current_user.username = payload.username
 
     if payload.display_name:
         current_user.display_name = payload.display_name
 
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise ValidationException("Username already exists")
+
     db.refresh(current_user)
 
     return current_user

--- a/backend/tests/test_profile.py
+++ b/backend/tests/test_profile.py
@@ -1,0 +1,28 @@
+def test_profile_update_duplicate_username(client, auth_headers, other_user):
+    response = client.put(
+        "/profile/",
+        json={"username": "other"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 400
+    assert response.json()["error"]["message"] == "Username already exists"
+
+
+def test_profile_update_keep_username(client, auth_headers, user):
+    response = client.put(
+        "/profile/",
+        json={"username": "tester"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    assert response.json()["username"] == "tester"
+
+
+def test_profile_update_unique_username(client, auth_headers, user):
+    response = client.put(
+        "/profile/",
+        json={"username": "tester_new"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    assert response.json()["username"] == "tester_new"


### PR DESCRIPTION
## 📋 PR Checklist

### 🔗 Related Issue

Closes #673

---

### 📝 What does this PR do?

This PR fixes a bug in the `PUT /profile` endpoint where username updates bypassed application-level uniqueness validation.

Previously, if a user attempted to change their username to one already used by another account, the database unique constraint would trigger an unhandled `IntegrityError`, resulting in a `500 Internal Server Error`.

### Changes made:

* Added username uniqueness validation before updating the user record.
* Excluded the current user from duplicate username checks.
* Added `IntegrityError` handling with transaction rollback to safely handle race conditions.
* Returned a user-friendly validation error instead of exposing a database exception.
* Added regression tests covering duplicate, unchanged, and unique username update scenarios.

---

### 🗂️ Type of Change

* [x] 🐛 Bug fix
* [ ] ✨ New feature
* [ ] 🔧 Refactor / code cleanup
* [ ] 📝 Documentation update
* [ ] 🎨 UI / styling change
* [ ] ⚙️ CI / tooling / config change
* [x] 🧪 Tests

---

### 🧪 How was this tested?

* [x] Ran the backend locally (`uvicorn app.main:app --reload`)
* [ ] Ran the frontend locally (`npm run dev` inside `frontend/`)
* [x] Tested the affected API endpoints manually
* [x] Added / updated tests

#### Validation Performed

* Added regression tests for:

  * Duplicate username update attempt
  * Keeping the existing username
  * Updating to a new unique username
* Executed:

  ```bash
  backend/.venv/Scripts/pytest backend/tests/test_profile.py
  ```
* Executed full backend test suite:

  ```bash
  backend/.venv/Scripts/pytest
  ```

---

### 📸 Screenshots (if UI change)

N/A (Backend-only change)

---

### ⚠️ Anything to flag for reviewers?

* No schema or database migrations were required.
* The change is isolated to the profile update endpoint.
* Added defensive `IntegrityError` handling to protect against concurrent update race conditions.

---

### ✅ Self-Review Checklist

* [x] My branch is based on **`dev`**, not `main`
* [x] I have not added any secrets / API keys
* [x] I have not modified `main` branch or any HuggingFace deployment config
* [x] My code follows the existing style (no unnecessary formatting changes)
* [x] I have updated relevant docs / comments if needed
