### PR TITLE
feat(ui): multi-select bulk delete and restore for documents

### DIFF
--- a/frontend/src/components/document/BulkActionBar.tsx
+++ b/frontend/src/components/document/BulkActionBar.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { Trash2, X, RotateCcw, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface BulkActionBarProps {
+  selectedCount: number;
+  onDelete: () => void;
+  onRestore?: () => void;
+  onClear: () => void;
+  deleting: boolean;
+  restoring?: boolean;
+  mode?: "active" | "trash";
+}
+
+export default function BulkActionBar({
+  selectedCount,
+  onDelete,
+  onRestore,
+  onClear,
+  deleting,
+  restoring = false,
+  mode = "active",
+}: BulkActionBarProps) {
+  if (selectedCount === 0) return null;
+
+  return (
+    <div
+      role="toolbar"
+      aria-label="Bulk document actions"
+      className="flex items-center justify-between gap-2 px-3 py-2 bg-primary/10 border-b border-primary/20 animate-in slide-in-from-top-1 duration-150"
+    >
+      <span className="text-xs font-medium text-primary">
+        {selectedCount} selected
+      </span>
+
+      <div className="flex items-center gap-1">
+        {mode === "trash" && onRestore && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 text-xs gap-1.5 text-primary hover:text-primary hover:bg-primary/10"
+            onClick={onRestore}
+            disabled={restoring || deleting}
+            aria-label={`Restore ${selectedCount} selected documents`}
+          >
+            {restoring ? (
+              <Loader2 className="w-3 h-3 animate-spin" />
+            ) : (
+              <RotateCcw className="w-3 h-3" />
+            )}
+            Restore
+          </Button>
+        )}
+
+        {mode === "active" && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 text-xs gap-1.5 text-destructive hover:text-destructive hover:bg-destructive/10"
+            onClick={onDelete}
+            disabled={deleting || restoring}
+            aria-label={`Delete ${selectedCount} selected documents`}
+          >
+            {deleting ? (
+              <Loader2 className="w-3 h-3 animate-spin" />
+            ) : (
+              <Trash2 className="w-3 h-3" />
+            )}
+            Delete
+          </Button>
+        )}
+
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7"
+          onClick={onClear}
+          disabled={deleting || restoring}
+          aria-label="Clear selection"
+        >
+          <X className="w-3 h-3" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/document/DocumentSidebar.tsx
+++ b/frontend/src/components/document/DocumentSidebar.tsx
@@ -28,6 +28,7 @@ import { useDropzone } from "react-dropzone";
 import { Settings } from "lucide-react";
 import DocumentSettings from "./DocumentSettings";
 import DocumentCard from "./DocumentCard";
+import BulkActionBar from "./BulkActionBar";
 import { toast } from "sonner";
 
 interface Props {
@@ -89,6 +90,99 @@ export default function DocumentSidebar({
   const [driveConnecting, setDriveConnecting] = useState(false);
   const [driveError, setDriveError] = useState("");
 
+  // ── Multi-select state ───────────────────────────────────────────────────
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [bulkDeleting, setBulkDeleting] = useState(false);
+  const [bulkRestoring, setBulkRestoring] = useState(false);
+
+  // Clear selection when switching tabs
+  const handleTabChange = (value: string) => {
+    setActiveTab(value);
+    setSelectedIds(new Set());
+    if (value === "trash") {
+      void fetchTrash();
+    }
+  };
+
+  const toggleSelect = (
+    docId: string,
+    e: React.MouseEvent | React.ChangeEvent,
+  ) => {
+    e.stopPropagation();
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(docId)) {
+        next.delete(docId);
+      } else {
+        next.add(docId);
+      }
+      return next;
+    });
+  };
+
+  const clearSelection = () => setSelectedIds(new Set());
+
+  // ── Bulk delete (active tab) ─────────────────────────────────────────────
+  const handleBulkDelete = async () => {
+    if (selectedIds.size === 0) return;
+    if (
+      !confirm(
+        `Delete ${selectedIds.size} document${selectedIds.size > 1 ? "s" : ""}? They will be moved to trash.`,
+      )
+    )
+      return;
+
+    setBulkDeleting(true);
+    const ids = Array.from(selectedIds);
+    const results = await Promise.allSettled(
+      ids.map((id) => api.delete(`/api/v1/documents/${id}`)),
+    );
+
+    const failed = results.filter((r) => r.status === "rejected").length;
+    const succeeded = results.length - failed;
+
+    if (succeeded > 0) {
+      toast.success(
+        `${succeeded} document${succeeded > 1 ? "s" : ""} moved to trash`,
+      );
+    }
+    if (failed > 0) {
+      toast.error(`${failed} document${failed > 1 ? "s" : ""} could not be deleted`);
+    }
+
+    clearSelection();
+    setBulkDeleting(false);
+    await onDocumentsChange();
+  };
+
+  // ── Bulk restore (trash tab) ─────────────────────────────────────────────
+  const handleBulkRestore = async () => {
+    if (selectedIds.size === 0) return;
+
+    setBulkRestoring(true);
+    const ids = Array.from(selectedIds);
+    const results = await Promise.allSettled(
+      ids.map((id) => api.post(`/api/v1/documents/${id}/restore`)),
+    );
+
+    const failed = results.filter((r) => r.status === "rejected").length;
+    const succeeded = results.length - failed;
+
+    if (succeeded > 0) {
+      toast.success(
+        `${succeeded} document${succeeded > 1 ? "s" : ""} restored`,
+      );
+    }
+    if (failed > 0) {
+      toast.error(`${failed} document${failed > 1 ? "s" : ""} could not be restored`);
+    }
+
+    clearSelection();
+    setBulkRestoring(false);
+    void fetchTrash();
+    await onDocumentsChange();
+  };
+
   const fetchTrash = useCallback(async () => {
     setLoadingTrash(true);
     try {
@@ -102,13 +196,6 @@ export default function DocumentSidebar({
       setLoadingTrash(false);
     }
   }, []);
-
-  const handleTabChange = (value: string) => {
-    setActiveTab(value);
-    if (value === "trash") {
-      void fetchTrash();
-    }
-  };
 
   useEffect(() => {
     let cancelled = false;
@@ -209,7 +296,7 @@ export default function DocumentSidebar({
   };
 
   const handleSettingsClick = (doc: DocInfo, e: React.MouseEvent) => {
-    e.stopPropagation(); // Prevent triggering document selection
+    e.stopPropagation();
     setSettingsDoc(doc);
   };
 
@@ -445,6 +532,17 @@ export default function DocumentSidebar({
           </TabsList>
         </div>
 
+        {/* ── Bulk Action Bar ──────────────────────── */}
+        <BulkActionBar
+          selectedCount={selectedIds.size}
+          onDelete={handleBulkDelete}
+          onRestore={handleBulkRestore}
+          onClear={clearSelection}
+          deleting={bulkDeleting}
+          restoring={bulkRestoring}
+          mode={activeTab as "active" | "trash"}
+        />
+
         <TabsContent
           value="active"
           className="flex-1 min-h-0 m-0 data-[state=active]:flex flex-col"
@@ -467,6 +565,7 @@ export default function DocumentSidebar({
                 {documents.map((doc) => {
                   const isEditing = editingDocId === doc.id;
                   const isRenaming = renamingDocId === doc.id;
+                  const isSelected = selectedIds.has(doc.id);
 
                   return (
                     <div
@@ -483,14 +582,27 @@ export default function DocumentSidebar({
                       }
                       onKeyDown={(e) => handleDocumentKeyDown(doc, e)}
                       className={`w-full text-left p-2.5 rounded-lg transition-all duration-200 group
-                    ${
-                      activeDoc?.id === doc.id
-                        ? "bg-primary/15 border border-primary/30"
-                        : "hover:bg-sidebar-accent border border-transparent"
-                    }
-                    ${doc.status !== "ready" ? "opacity-60 cursor-default" : "cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"}`}
+                        ${
+                          activeDoc?.id === doc.id
+                            ? "bg-primary/15 border border-primary/30"
+                            : isSelected
+                              ? "bg-primary/8 border border-primary/20"
+                              : "hover:bg-sidebar-accent border border-transparent"
+                        }
+                        ${doc.status !== "ready" ? "opacity-60 cursor-default" : "cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"}`}
                     >
                       <div className="flex items-start gap-2.5">
+                        {/* ── Checkbox ── */}
+                        <input
+                          type="checkbox"
+                          aria-label={`Select ${doc.original_name}`}
+                          checked={isSelected}
+                          onChange={(e) => toggleSelect(doc.id, e)}
+                          onClick={(e) => e.stopPropagation()}
+                          className="mt-0.5 h-3.5 w-3.5 shrink-0 rounded-sm border border-muted-foreground/40 accent-primary cursor-pointer opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity"
+                          style={isSelected ? { opacity: 1 } : undefined}
+                        />
+
                         {statusIcon(doc.status)}
                         <div className="flex-1 min-w-0">
                           {isEditing ? (
@@ -560,7 +672,6 @@ export default function DocumentSidebar({
                           <DocumentCard document={doc} />
                         </div>
                         <div className="flex items-center gap-1 shrink-0">
-                          {/* Action buttons (Settings and Delete) are only visible on hover and when the document is ready. The settings button is disabled if the document is not ready, and the delete button shows a loader when the document is being deleted. */}
                           <Button
                             variant="ghost"
                             size="icon"
@@ -614,56 +725,71 @@ export default function DocumentSidebar({
               </div>
             ) : (
               <div className="space-y-1 pb-3">
-                {trashDocuments.map((doc) => (
-                  <div
-                    key={doc.id}
-                    className="w-full text-left p-2.5 rounded-lg border border-transparent hover:bg-sidebar-accent transition-all duration-200 group"
-                  >
-                    <div className="flex items-start gap-2.5">
-                      {statusIcon(doc.status)}
-                      <div className="flex-1 min-w-0">
-                        <p className="text-sm font-medium truncate leading-tight opacity-60">
-                          {doc.original_name}
-                        </p>
-                        <div className="flex items-center gap-2 mt-1">
-                          <span className="text-[10px] text-muted-foreground">
-                            {formatSize(doc.file_size)}
-                          </span>
+                {trashDocuments.map((doc) => {
+                  const isSelected = selectedIds.has(doc.id);
+
+                  return (
+                    <div
+                      key={doc.id}
+                      className={`w-full text-left p-2.5 rounded-lg border transition-all duration-200 group
+                        ${isSelected ? "bg-primary/8 border-primary/20" : "border-transparent hover:bg-sidebar-accent"}`}
+                    >
+                      <div className="flex items-start gap-2.5">
+                        {/* ── Checkbox ── */}
+                        <input
+                          type="checkbox"
+                          aria-label={`Select ${doc.original_name}`}
+                          checked={isSelected}
+                          onChange={(e) => toggleSelect(doc.id, e)}
+                          onClick={(e) => e.stopPropagation()}
+                          className="mt-0.5 h-3.5 w-3.5 shrink-0 rounded-sm border border-muted-foreground/40 accent-primary cursor-pointer opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity"
+                          style={isSelected ? { opacity: 1 } : undefined}
+                        />
+
+                        {statusIcon(doc.status)}
+                        <div className="flex-1 min-w-0">
+                          <p className="text-sm font-medium truncate leading-tight opacity-60">
+                            {doc.original_name}
+                          </p>
+                          <div className="flex items-center gap-2 mt-1">
+                            <span className="text-[10px] text-muted-foreground">
+                              {formatSize(doc.file_size)}
+                            </span>
+                          </div>
+                        </div>
+                        <div className="flex items-center gap-1 shrink-0">
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-6 w-6 opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer"
+                            onClick={(e) => handleRestore(doc.id, e)}
+                            title={`Restore ${doc.original_name}`}
+                            aria-label={`Restore ${doc.original_name}`}
+                          >
+                            <RefreshCw className="w-3 h-3 text-primary" />
+                          </Button>
                         </div>
                       </div>
-                      <div className="flex items-center gap-1 shrink-0">
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className="h-6 w-6 opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer"
-                          onClick={(e) => handleRestore(doc.id, e)}
-                          title={`Restore ${doc.original_name}`}
-                        >
-                          <RefreshCw className="w-3 h-3 text-primary" />
-                        </Button>
-                      </div>
                     </div>
-                  </div>
-                ))}
+                  );
+                })}
               </div>
             )}
           </ScrollArea>
         </TabsContent>
       </Tabs>
-      {/* Settings Modal */}
-      {/* The DocumentSettings component is rendered here and controlled by the settingsDoc state. When a user clicks the settings button for a document, it sets that document in settingsDoc, which opens the modal. The modal can then call onDocumentsChange to refresh the list after saving settings. */}
+
+      {/* ── Settings Modal ───────────────────────────── */}
       {settingsDoc && (
         <DocumentSettings
-          document={settingsDoc} // Pass the selected document to the document settings component
-          open={!!settingsDoc} // Open when settingsDoc is not null
+          document={settingsDoc}
+          open={!!settingsDoc}
           onOpenChange={(open) => {
-            // Close the modal when open is false
-            if (!open) setSettingsDoc(null); // Clear the settingsDoc state to close the modal
+            if (!open) setSettingsDoc(null);
           }}
           onSettingsSaved={() => {
-            // Refresh documents after saving settings
-            onDocumentsChange(); // Refresh the document list to reflect any changes
-            setSettingsDoc(null); // Close the settings modal after saving
+            onDocumentsChange();
+            setSettingsDoc(null);
           }}
         />
       )}

--- a/frontend/src/components/document/DocumentSidebar.tsx
+++ b/frontend/src/components/document/DocumentSidebar.tsx
@@ -147,7 +147,9 @@ export default function DocumentSidebar({
       );
     }
     if (failed > 0) {
-      toast.error(`${failed} document${failed > 1 ? "s" : ""} could not be deleted`);
+      toast.error(
+        `${failed} document${failed > 1 ? "s" : ""} could not be deleted`,
+      );
     }
 
     clearSelection();
@@ -174,7 +176,9 @@ export default function DocumentSidebar({
       );
     }
     if (failed > 0) {
-      toast.error(`${failed} document${failed > 1 ? "s" : ""} could not be restored`);
+      toast.error(
+        `${failed} document${failed > 1 ? "s" : ""} could not be restored`,
+      );
     }
 
     clearSelection();


### PR DESCRIPTION
Closes #422

## 📝 What does this PR do?

Adds multi-select checkboxes to document items in the sidebar, a
contextual bulk action bar, and bulk restore support in the Trash tab.

**New file:** `frontend/src/components/document/BulkActionBar.tsx`
**Modified:** `frontend/src/components/document/DocumentSidebar.tsx`

**Changes:**
- Checkboxes appear on hover (or stay visible when checked) next to
  every document in both the Active and Trash tabs
- Selecting one or more documents shows a `BulkActionBar` below the
  tab headers with a count, action button, and clear (×) button
- Active tab: bulk action bar shows **Delete** — calls
  `DELETE /api/v1/documents/:id` in parallel via `Promise.allSettled`,
  so partial failures are reported without blocking succeeded deletes
- Trash tab: bulk action bar shows **Restore** — calls
  `POST /api/v1/documents/:id/restore` in parallel
- Selection is cleared when switching tabs or after any bulk operation
- Single-item delete and single-item restore buttons are unchanged

## 🗂️ Type of Change
- [x] ✨ New feature

## ✅ Self-Review Checklist
- [x] Branch based on `dev`, not `main`
- [x] No secrets / API keys added
- [x] No changes to `main` or HuggingFace deployment config
- [x] Follows existing code style and component patterns
- [x] Accessible — checkboxes have `aria-label`, action bar has
  `role="toolbar"` and `aria-label`
- [x] Uses `Promise.allSettled` so one failing delete/restore doesn't
  block the rest