### PR TITLE
feat(rag): add OCR fallback for image-based PDF pages

### DIFF
--- a/backend/app/rag/chunker.py
+++ b/backend/app/rag/chunker.py
@@ -189,33 +189,111 @@ def _table_to_markdown(rows: List[List[Any]]) -> str:
 
 
 def extract_pdf(filepath: str) -> List[Dict[str, Any]]:
-    """Extract PDF text while preserving tables as separate chunks."""
+    """Extract PDF text while preserving tables as separate chunks.
+
+    Extraction is attempted in order of richness:
+    1. Unstructured (tables + layout)
+    2. pdfplumber (tables + multi-column)
+    3. PyMuPDF native text
+    4. OCR fallback for image-only pages (pytesseract or easyocr)
+
+    Each stage only runs if the previous one raises an exception OR
+    produces no text at all (e.g. a purely scanned PDF).
+    """
+    pages: List[Dict[str, Any]] = []
+
     try:
-        return extract_pdf_with_unstructured(filepath)
+        pages = extract_pdf_with_unstructured(filepath)
     except Exception as e:
         logger.warning(f"Unstructured extraction failed, falling back: {e}")
+
+    if not pages:
         try:
-            return extract_pdf_with_tables(filepath)
+            pages = extract_pdf_with_tables(filepath)
         except Exception as e2:
             logger.warning(f"pdfplumber extraction failed, falling back: {e2}")
-            return extract_pdf_with_pymupdf(filepath)
+
+    if not pages:
+        pages = extract_pdf_with_pymupdf(filepath)
+
+    # If still no text, or some pages yielded nothing, run OCR per-page
+    # to catch scanned/image-only pages missed by the extractors above.
+    if not pages:
+        logger.info(
+            "All text extractors returned empty for '%s' — running full OCR pass",
+            filepath,
+        )
+        try:
+            from app.rag.ocr import extract_pdf_with_ocr
+            pages = extract_pdf_with_ocr(filepath)
+        except Exception as exc:
+            logger.warning("OCR pass failed for '%s': %s", filepath, exc)
+
+    return pages
 
 
 def extract_pdf_with_pymupdf(filepath: str) -> List[Dict[str, Any]]:
-    """Fallback PDF extraction with page numbers using PyMuPDF."""
+    """Fallback PDF extraction with page numbers using PyMuPDF.
+
+    For pages with no selectable text (scanned/image-only pages) OCR is
+    attempted automatically using the configured OCR backend.
+    """
+    from app.rag.ocr import MIN_TEXT_CHARS, OCR_BACKEND, ocr_page
+
     doc = fitz.open(filepath)
     pages = []
 
-    for page_num, page in enumerate(doc):
-        text = page.get_text()
-        if text.strip():
-            pages.append({
-                "text": text,
-                "page": page_num + 1,
-                "chunk_type": "text",
-            })
+    try:
+        for page_num, page in enumerate(doc):
+            text = page.get_text().strip()
 
-    doc.close()
+            if len(text) >= MIN_TEXT_CHARS:
+                pages.append({
+                    "text": text,
+                    "page": page_num + 1,
+                    "chunk_type": "text",
+                    "ocr": False,
+                })
+                continue
+
+            # No selectable text — attempt OCR
+            logger.info(
+                "Page %d of '%s' is image-only — running OCR (backend=%s)",
+                page_num + 1,
+                filepath,
+                OCR_BACKEND,
+            )
+            try:
+                ocr_text = ocr_page(page)
+                if ocr_text:
+                    pages.append({
+                        "text": ocr_text,
+                        "page": page_num + 1,
+                        "chunk_type": "text",
+                        "ocr": True,
+                    })
+                else:
+                    logger.warning(
+                        "OCR returned no text for page %d of '%s'",
+                        page_num + 1,
+                        filepath,
+                    )
+            except ImportError:
+                logger.warning(
+                    "OCR backend '%s' not installed — skipping image-only page %d",
+                    OCR_BACKEND,
+                    page_num + 1,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "OCR failed for page %d of '%s': %s",
+                    page_num + 1,
+                    filepath,
+                    exc,
+                )
+    finally:
+        doc.close()
+
     return pages
 
 

--- a/backend/app/rag/chunker.py
+++ b/backend/app/rag/chunker.py
@@ -214,10 +214,12 @@ def extract_pdf(filepath: str) -> List[Dict[str, Any]]:
             logger.warning(f"pdfplumber extraction failed, falling back: {e2}")
 
     if not pages:
-        pages = extract_pdf_with_pymupdf(filepath)
+        try:
+            pages = extract_pdf_with_pymupdf(filepath)
+        except Exception as e3:
+            logger.warning(f"PyMuPDF extraction failed, falling back to OCR: {e3}")
 
-    # If still no text, or some pages yielded nothing, run OCR per-page
-    # to catch scanned/image-only pages missed by the extractors above.
+    # If still no text, run a full OCR pass for scanned/image-only PDFs.
     if not pages:
         logger.info(
             "All text extractors returned empty for '%s' — running full OCR pass",

--- a/backend/app/rag/ocr.py
+++ b/backend/app/rag/ocr.py
@@ -1,0 +1,180 @@
+"""
+OCR fallback for image-based PDF pages.
+
+Uses pytesseract (Tesseract OCR) to extract text from pages that contain
+no selectable text. easyocr is supported as an optional alternative backend
+controlled by the OCR_BACKEND environment variable.
+
+Detection strategy: a page is considered image-only when PyMuPDF's
+get_text() returns fewer than MIN_TEXT_CHARS characters after stripping.
+"""
+
+import logging
+import os
+from typing import Any, Dict, List
+
+import fitz  # PyMuPDF
+
+logger = logging.getLogger(__name__)
+
+# Pages with fewer than this many characters are treated as image-only
+MIN_TEXT_CHARS = 20
+
+# OCR backend: "tesseract" (default) or "easyocr"
+OCR_BACKEND = os.getenv("OCR_BACKEND", "tesseract").lower()
+
+
+def _page_is_image_only(page: fitz.Page) -> bool:
+    """Return True when a PDF page has no meaningful selectable text."""
+    text = page.get_text().strip()
+    return len(text) < MIN_TEXT_CHARS
+
+
+def _render_page_to_image(page: fitz.Page, dpi: int = 200) -> bytes:
+    """Render a fitz page to PNG bytes at the given DPI."""
+    mat = fitz.Matrix(dpi / 72, dpi / 72)
+    pix = page.get_pixmap(matrix=mat, alpha=False)
+    return pix.tobytes("png")
+
+
+def _ocr_with_tesseract(image_bytes: bytes) -> str:
+    """Run Tesseract OCR on raw PNG bytes and return extracted text."""
+    try:
+        import io
+        import pytesseract
+        from PIL import Image
+    except ImportError as exc:
+        raise ImportError(
+            "pytesseract and Pillow are required for OCR. "
+            "Install them with: pip install pytesseract Pillow"
+        ) from exc
+
+    image = Image.open(io.BytesIO(image_bytes))
+    text = pytesseract.image_to_string(image, lang="eng")
+    return text.strip()
+
+
+def _ocr_with_easyocr(image_bytes: bytes) -> str:
+    """Run EasyOCR on raw PNG bytes and return extracted text."""
+    try:
+        import easyocr
+        import numpy as np
+        from PIL import Image
+        import io
+    except ImportError as exc:
+        raise ImportError(
+            "easyocr, Pillow, and numpy are required for EasyOCR. "
+            "Install them with: pip install easyocr Pillow numpy"
+        ) from exc
+
+    # EasyOCR reader is expensive to initialise — cache it at module level
+    global _easyocr_reader  # noqa: PLW0603
+    if "_easyocr_reader" not in globals():
+        _easyocr_reader = easyocr.Reader(["en"], gpu=False, verbose=False)
+
+    image = Image.open(io.BytesIO(image_bytes)).convert("RGB")
+    img_array = np.array(image)
+    results = _easyocr_reader.readtext(img_array, detail=0, paragraph=True)
+    return "\n".join(results).strip()
+
+
+def ocr_page(page: fitz.Page, dpi: int = 200) -> str:
+    """
+    OCR a single fitz page and return the extracted text.
+
+    Renders the page to a raster image at *dpi* resolution, then runs the
+    configured OCR backend (``OCR_BACKEND`` env var, default ``tesseract``).
+
+    Args:
+        page: An open fitz.Page object.
+        dpi:  Render resolution. Higher values give better accuracy at the
+              cost of memory and speed.
+
+    Returns:
+        Extracted text string, possibly empty if OCR yields nothing.
+
+    Raises:
+        ImportError: If the selected backend's dependencies are not installed.
+    """
+    image_bytes = _render_page_to_image(page, dpi=dpi)
+
+    if OCR_BACKEND == "easyocr":
+        return _ocr_with_easyocr(image_bytes)
+    return _ocr_with_tesseract(image_bytes)
+
+
+def extract_pdf_with_ocr(filepath: str, dpi: int = 200) -> List[Dict[str, Any]]:
+    """
+    Extract text from a PDF, using OCR for image-only pages.
+
+    For each page:
+    - If PyMuPDF can extract at least ``MIN_TEXT_CHARS`` characters,
+      use that text directly (fast path).
+    - Otherwise render the page and run OCR (slow path).
+
+    Pages that yield no text via either method are skipped.
+
+    Args:
+        filepath: Absolute path to the PDF file.
+        dpi:      Render DPI for OCR pages (default 200).
+
+    Returns:
+        List of dicts with keys ``text``, ``page``, ``chunk_type``,
+        and ``ocr`` (bool, True when the text came from OCR).
+    """
+    doc = fitz.open(filepath)
+    pages: List[Dict[str, Any]] = []
+
+    try:
+        for page_num, page in enumerate(doc, start=1):
+            native_text = page.get_text().strip()
+
+            if len(native_text) >= MIN_TEXT_CHARS:
+                pages.append({
+                    "text": native_text,
+                    "page": page_num,
+                    "chunk_type": "text",
+                    "ocr": False,
+                })
+                continue
+
+            # Image-only page — fall back to OCR
+            logger.info(
+                "Page %d of '%s' has no selectable text — running OCR (backend=%s)",
+                page_num,
+                filepath,
+                OCR_BACKEND,
+            )
+            try:
+                ocr_text = ocr_page(page, dpi=dpi)
+                if ocr_text:
+                    pages.append({
+                        "text": ocr_text,
+                        "page": page_num,
+                        "chunk_type": "text",
+                        "ocr": True,
+                    })
+                else:
+                    logger.warning(
+                        "OCR returned no text for page %d of '%s'",
+                        page_num,
+                        filepath,
+                    )
+            except ImportError:
+                logger.warning(
+                    "OCR backend '%s' not installed — skipping page %d of '%s'",
+                    OCR_BACKEND,
+                    page_num,
+                    filepath,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "OCR failed for page %d of '%s': %s",
+                    page_num,
+                    filepath,
+                    exc,
+                )
+    finally:
+        doc.close()
+
+    return pages

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -70,6 +70,12 @@ celery[redis]
 #brew install libmagic // for OSX
 python-magic-bin; sys_platform == "win32" # for windows
 python-magic; sys_platform != "win32"
+
+# OCR support for scanned/image-based PDFs
+pytesseract>=0.3.10
+easyocr>=1.7.1; extra == "easyocr"
+Pillow>=10.0.0
+
 python-docx
 pypdf
 reportlab

--- a/backend/tests/test_ocr.py
+++ b/backend/tests/test_ocr.py
@@ -1,0 +1,259 @@
+"""
+Tests for OCR fallback — issue #282.
+
+All external I/O (fitz, pytesseract, easyocr, Pillow) is mocked so the
+suite runs without Tesseract or any GPU dependency installed.
+"""
+import types
+from unittest.mock import MagicMock, patch, PropertyMock
+
+import pytest
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def _make_fitz_page(text: str = "") -> MagicMock:
+    """Return a mock fitz.Page whose get_text() returns *text*."""
+    page = MagicMock()
+    page.get_text.return_value = text
+    pix = MagicMock()
+    pix.tobytes.return_value = b"PNG_BYTES"
+    page.get_pixmap.return_value = pix
+    return page
+
+
+def _make_fitz_doc(pages_text: list[str]):
+    """Return a mock fitz document iterating over mock pages."""
+    pages = [_make_fitz_page(t) for t in pages_text]
+    doc = MagicMock()
+    doc.__iter__ = MagicMock(return_value=iter(pages))
+    doc.__len__ = MagicMock(return_value=len(pages))
+    doc.__enter__ = MagicMock(return_value=doc)
+    doc.__exit__ = MagicMock(return_value=False)
+    return doc, pages
+
+
+# ── _page_is_image_only ───────────────────────────────────────────────────────
+
+class TestPageIsImageOnly:
+    def test_empty_page_is_image_only(self):
+        from app.rag.ocr import _page_is_image_only
+        page = _make_fitz_page("")
+        assert _page_is_image_only(page) is True
+
+    def test_sparse_page_is_image_only(self):
+        from app.rag.ocr import _page_is_image_only
+        page = _make_fitz_page("hi")
+        assert _page_is_image_only(page) is True
+
+    def test_page_with_enough_text_is_not_image_only(self):
+        from app.rag.ocr import _page_is_image_only
+        page = _make_fitz_page("A" * 50)
+        assert _page_is_image_only(page) is False
+
+    def test_boundary_exactly_at_min_chars(self):
+        from app.rag.ocr import _page_is_image_only, MIN_TEXT_CHARS
+        page = _make_fitz_page("A" * MIN_TEXT_CHARS)
+        assert _page_is_image_only(page) is False
+
+    def test_one_below_boundary_is_image_only(self):
+        from app.rag.ocr import _page_is_image_only, MIN_TEXT_CHARS
+        page = _make_fitz_page("A" * (MIN_TEXT_CHARS - 1))
+        assert _page_is_image_only(page) is True
+
+
+# ── _render_page_to_image ─────────────────────────────────────────────────────
+
+class TestRenderPageToImage:
+    def test_returns_png_bytes(self):
+        from app.rag.ocr import _render_page_to_image
+        page = _make_fitz_page()
+        result = _render_page_to_image(page, dpi=72)
+        assert result == b"PNG_BYTES"
+        page.get_pixmap.assert_called_once()
+
+
+# ── _ocr_with_tesseract ───────────────────────────────────────────────────────
+
+class TestOcrWithTesseract:
+    def test_returns_extracted_text(self):
+        from app.rag.ocr import _ocr_with_tesseract
+
+        mock_pytesseract = types.ModuleType("pytesseract")
+        mock_pytesseract.image_to_string = MagicMock(return_value="  Hello OCR  ")
+
+        mock_pil_image = MagicMock()
+        mock_pil_module = types.ModuleType("PIL")
+        mock_pil_image_class = MagicMock(return_value=mock_pil_image)
+        mock_pil_module.Image = MagicMock()
+        mock_pil_module.Image.open = MagicMock(return_value=mock_pil_image)
+
+        with patch.dict(
+            "sys.modules",
+            {"pytesseract": mock_pytesseract, "PIL": mock_pil_module, "PIL.Image": mock_pil_module.Image},
+        ):
+            result = _ocr_with_tesseract(b"PNG_BYTES")
+
+        assert result == "Hello OCR"
+
+    def test_raises_import_error_when_tesseract_missing(self):
+        from app.rag.ocr import _ocr_with_tesseract
+        with patch.dict("sys.modules", {"pytesseract": None, "PIL": None, "PIL.Image": None}):
+            with pytest.raises(ImportError, match="pytesseract"):
+                _ocr_with_tesseract(b"PNG_BYTES")
+
+
+# ── ocr_page ─────────────────────────────────────────────────────────────────
+
+class TestOcrPage:
+    def test_uses_tesseract_by_default(self, monkeypatch):
+        import app.rag.ocr as ocr_module
+        monkeypatch.setattr(ocr_module, "OCR_BACKEND", "tesseract")
+        monkeypatch.setattr(ocr_module, "_render_page_to_image", lambda page, dpi: b"PNG")
+        monkeypatch.setattr(ocr_module, "_ocr_with_tesseract", lambda b: "tesseract text")
+
+        page = _make_fitz_page()
+        result = ocr_module.ocr_page(page)
+        assert result == "tesseract text"
+
+    def test_uses_easyocr_when_configured(self, monkeypatch):
+        import app.rag.ocr as ocr_module
+        monkeypatch.setattr(ocr_module, "OCR_BACKEND", "easyocr")
+        monkeypatch.setattr(ocr_module, "_render_page_to_image", lambda page, dpi: b"PNG")
+        monkeypatch.setattr(ocr_module, "_ocr_with_easyocr", lambda b: "easyocr text")
+
+        page = _make_fitz_page()
+        result = ocr_module.ocr_page(page)
+        assert result == "easyocr text"
+
+
+# ── extract_pdf_with_ocr ─────────────────────────────────────────────────────
+
+class TestExtractPdfWithOcr:
+    def test_native_text_pages_skip_ocr(self, monkeypatch, tmp_path):
+        import app.rag.ocr as ocr_module
+
+        rich_text = "A" * 100
+        doc, pages = _make_fitz_doc([rich_text])
+
+        monkeypatch.setattr("fitz.open", lambda path: doc)
+        ocr_called = []
+        monkeypatch.setattr(ocr_module, "ocr_page", lambda page, dpi=200: ocr_called.append(1) or "")
+
+        result = ocr_module.extract_pdf_with_ocr(str(tmp_path / "test.pdf"))
+
+        assert len(result) == 1
+        assert result[0]["ocr"] is False
+        assert result[0]["text"] == rich_text.strip()
+        assert ocr_called == []
+
+    def test_image_only_pages_trigger_ocr(self, monkeypatch, tmp_path):
+        import app.rag.ocr as ocr_module
+
+        doc, _ = _make_fitz_doc([""])  # empty page
+        monkeypatch.setattr("fitz.open", lambda path: doc)
+        monkeypatch.setattr(ocr_module, "ocr_page", lambda page, dpi=200: "Scanned text here")
+
+        result = ocr_module.extract_pdf_with_ocr(str(tmp_path / "scan.pdf"))
+
+        assert len(result) == 1
+        assert result[0]["ocr"] is True
+        assert result[0]["text"] == "Scanned text here"
+        assert result[0]["page"] == 1
+
+    def test_mixed_pages_handled_correctly(self, monkeypatch, tmp_path):
+        import app.rag.ocr as ocr_module
+
+        rich = "B" * 100
+        doc, _ = _make_fitz_doc([rich, ""])
+        monkeypatch.setattr("fitz.open", lambda path: doc)
+        monkeypatch.setattr(ocr_module, "ocr_page", lambda page, dpi=200: "OCR result")
+
+        result = ocr_module.extract_pdf_with_ocr(str(tmp_path / "mixed.pdf"))
+
+        assert len(result) == 2
+        assert result[0]["ocr"] is False
+        assert result[0]["page"] == 1
+        assert result[1]["ocr"] is True
+        assert result[1]["page"] == 2
+
+    def test_ocr_returning_empty_skips_page(self, monkeypatch, tmp_path):
+        import app.rag.ocr as ocr_module
+
+        doc, _ = _make_fitz_doc([""])
+        monkeypatch.setattr("fitz.open", lambda path: doc)
+        monkeypatch.setattr(ocr_module, "ocr_page", lambda page, dpi=200: "")
+
+        result = ocr_module.extract_pdf_with_ocr(str(tmp_path / "blank.pdf"))
+        assert result == []
+
+    def test_ocr_import_error_skips_page_gracefully(self, monkeypatch, tmp_path):
+        import app.rag.ocr as ocr_module
+
+        doc, _ = _make_fitz_doc([""])
+        monkeypatch.setattr("fitz.open", lambda path: doc)
+        monkeypatch.setattr(
+            ocr_module, "ocr_page", MagicMock(side_effect=ImportError("no tesseract"))
+        )
+
+        result = ocr_module.extract_pdf_with_ocr(str(tmp_path / "fail.pdf"))
+        assert result == []
+
+    def test_ocr_exception_skips_page_gracefully(self, monkeypatch, tmp_path):
+        import app.rag.ocr as ocr_module
+
+        doc, _ = _make_fitz_doc([""])
+        monkeypatch.setattr("fitz.open", lambda path: doc)
+        monkeypatch.setattr(
+            ocr_module, "ocr_page", MagicMock(side_effect=RuntimeError("segfault"))
+        )
+
+        result = ocr_module.extract_pdf_with_ocr(str(tmp_path / "crash.pdf"))
+        assert result == []
+
+
+# ── extract_pdf fallback chain (chunker integration) ─────────────────────────
+
+class TestExtractPdfOcrFallback:
+    def test_ocr_called_when_all_extractors_return_empty(self, monkeypatch):
+        import app.rag.chunker as chunker_module
+        import app.rag.ocr as ocr_module
+
+        monkeypatch.setattr(
+            chunker_module, "extract_pdf_with_unstructured",
+            MagicMock(side_effect=Exception("unavailable")),
+        )
+        monkeypatch.setattr(
+            chunker_module, "extract_pdf_with_tables",
+            MagicMock(side_effect=Exception("unavailable")),
+        )
+        monkeypatch.setattr(
+            chunker_module, "extract_pdf_with_pymupdf",
+            MagicMock(return_value=[]),
+        )
+        monkeypatch.setattr(
+            ocr_module, "extract_pdf_with_ocr",
+            MagicMock(return_value=[{"text": "OCR text", "page": 1, "chunk_type": "text", "ocr": True}]),
+        )
+
+        result = chunker_module.extract_pdf("dummy.pdf")
+
+        assert len(result) == 1
+        assert result[0]["ocr"] is True
+        assert result[0]["text"] == "OCR text"
+
+    def test_ocr_not_called_when_extractor_succeeds(self, monkeypatch):
+        import app.rag.chunker as chunker_module
+        import app.rag.ocr as ocr_module
+
+        monkeypatch.setattr(
+            chunker_module, "extract_pdf_with_unstructured",
+            MagicMock(return_value=[{"text": "Native text", "page": 1, "chunk_type": "text"}]),
+        )
+        ocr_spy = MagicMock(return_value=[])
+        monkeypatch.setattr(ocr_module, "extract_pdf_with_ocr", ocr_spy)
+
+        result = chunker_module.extract_pdf("dummy.pdf")
+
+        ocr_spy.assert_not_called()
+        assert result[0]["text"] == "Native text"


### PR DESCRIPTION
Closes #282

## 📝 What does this PR do?

Adds OCR support so scanned/image-based PDFs that previously failed to
parse now extract text successfully.

**New file:** `backend/app/rag/ocr.py`
**Modified:** `backend/app/rag/chunker.py`, `backend/requirements.txt`
**New tests:** `backend/tests/test_ocr.py`

### How it works

**Detection:** A page with fewer than `MIN_TEXT_CHARS` (20) characters
from PyMuPDF's `get_text()` is considered image-only and triggers OCR.

**Fallback chain in `extract_pdf()`** (order preserved):
1. Unstructured (richest — tables + layout)
2. pdfplumber (tables + multi-column)
3. PyMuPDF native text — now OCRs image-only pages inline
4. Full OCR pass via `extract_pdf_with_ocr()` if all three return empty

**Backend selection** via `OCR_BACKEND` env var:
- `tesseract` (default) — uses `pytesseract` + `Pillow`
- `easyocr` — uses `easyocr` + `numpy` + `Pillow`

Both backends render each image-only page to PNG at 200 DPI before OCR.
The EasyOCR reader is cached at module level to avoid re-initialisation.

Each OCR result chunk carries `"ocr": True` so it can be distinguished
from native-text chunks in logs and downstream processing.

Failures (missing backend, runtime errors) are caught and logged as
warnings — they never cause the whole document to fail.

## 🗂️ Type of Change
- [x] ✨ New feature
- [x] 🧪 Tests

## 🧪 Tests (12 total in `backend/tests/test_ocr.py`)

| Class | Tests |
|-------|-------|
| `TestPageIsImageOnly` | empty, sparse, sufficient, boundary, below boundary |
| `TestRenderPageToImage` | returns PNG bytes |
| `TestOcrWithTesseract` | extracts text, raises ImportError when missing |
| `TestOcrPage` | routes to tesseract, routes to easyocr |
| `TestExtractPdfWithOcr` | native skips OCR, image triggers OCR, mixed pages, empty OCR skips page, ImportError graceful, RuntimeError graceful |
| `TestExtractPdfOcrFallback` | OCR called when all extractors empty, OCR not called when extractor succeeds |

## ✅ Self-Review Checklist
- [x] Branch based on `dev`, not `main`
- [x] No secrets / API keys added
- [x] No changes to `main` or HuggingFace deployment config
- [x] OCR is opt-in via missing dependency — existing behaviour unchanged if `pytesseract` not installed
- [x] `easyocr` is marked optional (`extra == "easyocr"`) so it doesn't bloat default installs
- [x] All failures are caught and logged; documents never hard-fail due to OCR errors