### PR TITLE
fix: gracefully handle missing/invalid page metadata in SourceCard

### DIFF
--- a/frontend/src/components/chat/SourceCard.tsx
+++ b/frontend/src/components/chat/SourceCard.tsx
@@ -64,6 +64,14 @@ const getConfidenceBadgeMeta = (value?: number): ConfidenceBadgeMeta => {
 const getPrimarySourceMetric = (source: SourceChunk) =>
   source.confidence ?? source.score;
 
+// Returns true only when the source has a real, usable page number.
+// Some document types (e.g. .txt, .md) have no page concept, and the
+// backend may send page as undefined/null/NaN in those cases.
+const hasValidPage = (source: SourceChunk) =>
+  typeof source.page === "number" &&
+  Number.isFinite(source.page) &&
+  source.page >= 0;
+
 const MetricBadge = ({
   label,
   value,
@@ -134,27 +142,39 @@ export default function SourceCard({ sources = [], onPageClick }: Props) {
         <div className="px-3 pb-2 flex flex-wrap gap-1">
           {sources.map((src, i) => {
             const badgeMeta = getConfidenceBadgeMeta(
-              getPrimarySourceMetric(src)
+              getPrimarySourceMetric(src),
             );
+            const validPage = hasValidPage(src);
 
             return (
               <Tooltip key={i}>
                 <TooltipTrigger
                   type="button"
                   className="inline-flex"
-                  onClick={() =>
+                  disabled={!validPage}
+                  onClick={() => {
+                    if (!validPage) return;
                     onPageClick({
                       page: src.page + 1,
                       highlightRects: src.highlightRects,
-                    })
+                    });
+                  }}
+                  aria-label={
+                    validPage
+                      ? `Go to source page ${src.page + 1}. Confidence ${badgeMeta.label}`
+                      : `Source from ${src.filename}. Page unavailable. Confidence ${badgeMeta.label}`
                   }
-                  aria-label={`Go to source page ${src.page + 1}. Confidence ${badgeMeta.label}`}
                 >
                   <Badge
                     variant="outline"
-                    className={`text-[10px] h-5 cursor-pointer hover:bg-primary/20 transition-colors ${badgeMeta.className}`}
+                    className={`text-[10px] h-5 transition-colors ${badgeMeta.className} ${
+                      validPage
+                        ? "cursor-pointer hover:bg-primary/20"
+                        : "cursor-default opacity-70"
+                    }`}
                   >
-                    p.{src.page + 1} - {badgeMeta.label}
+                    {validPage ? `p.${src.page + 1}` : "Page N/A"} -{" "}
+                    {badgeMeta.label}
                   </Badge>
                 </TooltipTrigger>
                 <TooltipContent
@@ -178,58 +198,68 @@ export default function SourceCard({ sources = [], onPageClick }: Props) {
 
       {expanded && (
         <div id={sourceListId} className="border-t border-border/30">
-          {sources.map((src, i) => (
-            <div
-              key={i}
-              className="px-3 py-2.5 border-b border-border/20 last:border-b-0 hover:bg-accent/20 transition-colors"
-            >
-              <div className="flex items-center justify-between gap-2 mb-1.5">
-                <div className="flex min-w-0 flex-wrap items-center gap-2">
-                  <span className="truncate text-[10px] font-medium text-muted-foreground">
-                    {src.filename}
-                  </span>
-                  <Badge variant="outline" className="h-5 px-1.5 text-[9px]">
-                    Page {src.page + 1}
-                  </Badge>
-                  <MetricBadge label="Score" value={src.score} />
-                  <MetricBadge label="Confidence" value={src.confidence} />
-                </div>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-6 shrink-0 px-2 text-[10px]"
-                  onClick={() =>
-                    onPageClick({
-                      page: src.page + 1,
-                      highlightRects: src.highlightRects,
-                    })
-                  }
-                  aria-label={`View source page ${src.page + 1}`}
-                >
-                  <Eye className="w-3 h-3 mr-1" />
-                  View
-                </Button>
-              </div>
-              <p
-                className={`text-[11px] text-muted-foreground leading-relaxed ${
-                  excerptOpen.has(i) ? "" : "line-clamp-3"
-                }`}
+          {sources.map((src, i) => {
+            const validPage = hasValidPage(src);
+
+            return (
+              <div
+                key={i}
+                className="px-3 py-2.5 border-b border-border/20 last:border-b-0 hover:bg-accent/20 transition-colors"
               >
-                {src.text}
-              </p>
-              {src.text.length > EXCERPT_THRESHOLD && (
-                <button
-                  type="button"
-                  onClick={() => toggleExcerpt(i)}
-                  aria-expanded={excerptOpen.has(i)}
-                  className="mt-1.5 flex items-center gap-1 text-[10px] text-primary/70 hover:text-primary transition-colors"
+                <div className="flex items-center justify-between gap-2 mb-1.5">
+                  <div className="flex min-w-0 flex-wrap items-center gap-2">
+                    <span className="truncate text-[10px] font-medium text-muted-foreground">
+                      {src.filename}
+                    </span>
+                    <Badge variant="outline" className="h-5 px-1.5 text-[9px]">
+                      {validPage ? `Page ${src.page + 1}` : "Page N/A"}
+                    </Badge>
+                    <MetricBadge label="Score" value={src.score} />
+                    <MetricBadge label="Confidence" value={src.confidence} />
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 shrink-0 px-2 text-[10px]"
+                    disabled={!validPage}
+                    onClick={() => {
+                      if (!validPage) return;
+                      onPageClick({
+                        page: src.page + 1,
+                        highlightRects: src.highlightRects,
+                      });
+                    }}
+                    aria-label={
+                      validPage
+                        ? `View source page ${src.page + 1}`
+                        : "Page reference unavailable for this source"
+                    }
+                  >
+                    <Eye className="w-3 h-3 mr-1" />
+                    {validPage ? "View" : "N/A"}
+                  </Button>
+                </div>
+                <p
+                  className={`text-[11px] text-muted-foreground leading-relaxed ${
+                    excerptOpen.has(i) ? "" : "line-clamp-3"
+                  }`}
                 >
-                  <TextQuote className="w-3 h-3" />
-                  {excerptOpen.has(i) ? "Hide excerpt" : "Show excerpt"}
-                </button>
-              )}
-            </div>
-          ))}
+                  {src.text}
+                </p>
+                {src.text.length > EXCERPT_THRESHOLD && (
+                  <button
+                    type="button"
+                    onClick={() => toggleExcerpt(i)}
+                    aria-expanded={excerptOpen.has(i)}
+                    className="mt-1.5 flex items-center gap-1 text-[10px] text-primary/70 hover:text-primary transition-colors"
+                  >
+                    <TextQuote className="w-3 h-3" />
+                    {excerptOpen.has(i) ? "Hide excerpt" : "Show excerpt"}
+                  </button>
+                )}
+              </div>
+            );
+          })}
         </div>
       )}
     </div>


### PR DESCRIPTION
## 🔗 Related Issue
Closes #660

---
## 📝 What does this PR do?
Fixes a gap in the source citation feature where sources without a valid page number (e.g. from `.txt` or `.md` 
uploads, which have no real page concept) would render broken badges like "p.NaN" instead of failing gracefully.

This directly addresses the acceptance criteria from the 
issue:
> "Gracefully handle cases where page information is  unavailable."

**Root cause:**
src.page is undefined/null/NaN for non-paginated

document types (.txt, .md)
↓
SourceCard renders: src.page + 1 → NaN
↓
Badge shows "p.NaN" or "Page NaN"
↓
Clicking it calls onPageClick({ page: NaN })
↓
PDFViewer silently fails to navigate

**Fix:**
- Added a `hasValidPage()` helper that checks the page 
  is a finite, non-negative number
- When page is invalid: badge shows **"Page N/A"** instead 
  of "p.NaN"
- Badge/button becomes visually disabled (`cursor-default`, 
  reduced opacity) and the click handler returns early 
  instead of calling `onPageClick` with `NaN`
- Updated `aria-label`s so screen readers announce 
  "Page unavailable" instead of a broken page number
- Applied consistently in both the collapsed (badge) and 
  expanded (list) views

---

## 🗂️ Type of Change
- [x] 🐛 Bug fix
- [x] ♿ Accessibility improvement

---

## 🧪 How was this tested?
- [x] Ran the frontend locally (`npm run dev` inside `frontend/`)
- Uploaded a `.txt` document, asked a question, confirmed source badge shows "Page N/A" instead of "p.NaN" ✅
- Confirmed badge/button is non-interactive (no click, no navigation attempt) when page is unavailable ✅
- Uploaded a `.pdf` document and confirmed normal page  references and click-to-navigate still work exactly  as before (no regression) ✅
- Ran `npx prettier --write` on the changed file ✅
- TypeScript build passes ✅

--

1. This PR — fixes missing/invalid page metadata handling
2. A separate PR fixing zoom-scaling of highlight 
   rectangles in `PDFViewer.tsx` (`unit: "pdf"` rects 
   weren't multiplied by the current zoom scale)

The core feature (page badges, click-to-navigate, confidence scores) was already implemented prior to this issue being assigned to me. These two PRs close the remaining real gaps I found while verifying the acceptance criteria and test plan.

---

## ✅ Self-Review Checklist
- [x] My branch is based on **`dev`**, not `main`
- [x] I have not added any secrets / API keys
- [x] I have not modified `main` branch or any 
      HuggingFace deployment config
- [x] My code follows the existing style 
      (no unnecessary formatting changes)
- [x] I have updated relevant docs / comments if needed