### PR TITLE
Batch 1: Fix IDOR, JWT-in-query, WS-Origin, SSRF-DNS-rebinding

### DIFF
--- a/backend/app/routes/chat.py
+++ b/backend/app/routes/chat.py
@@ -19,7 +19,6 @@ from app.cache import get_cached_response, set_cached_response
 from app.database import get_db
 from app.exceptions import (
     NotFoundException,
-    UnauthorizedException,
     ValidationException, )
 from app.metrics import record_query_response_time
 from app.models import User, ChatMessage, Document, SharedMessage, ChatSession
@@ -51,6 +50,13 @@ async def chat_ws(websocket: WebSocket, token: Optional[str] = Query(None)):
     Authenticate via `token` query param or expect first JSON message
     containing `{token, question, document_id?, session_id?}`.
     """
+    from app.config import get_settings as _get_settings
+    origin = websocket.headers.get("origin", "")
+    allowed = _get_settings().cors_origins
+    if origin and allowed and origin not in allowed:
+        await websocket.close(code=1008)
+        return
+
     await websocket.accept()
 
     # Simple DB-backed auth similar to get_current_user
@@ -946,26 +952,17 @@ def get_chat_history(
     summary="Export document chat history",
     description=(
         "Downloads one document's chat history as Markdown, plain text, or PDF. "
-        "The browser download flow authenticates with a query token."
+        "Uses standard authentication — no query tokens."
     ),
 )
 def export_chat_history(
     document_id: str,
     format: str = "md",
-    token: Optional[str] = None,
+    user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
     """Export the chat history for a document as a downloadable file."""
-    from app.auth import decode_token as _decode
-
-    resolved_user = None
-    if token:
-        user_id = _decode(token)
-        if user_id:
-            resolved_user = db.query(User).filter(User.id == user_id).first()
-
-    if resolved_user is None:
-        raise UnauthorizedException("Authentication required")
+    resolved_user = user
 
     if format not in ("md", "txt", "pdf"):
         raise ValidationException("Format must be 'md', 'txt', or 'pdf'")

--- a/backend/app/routes/documents.py
+++ b/backend/app/routes/documents.py
@@ -198,10 +198,22 @@ async def validate_upload(file: UploadFile):
         pass
 
 
-def _crawl_in_new_loop(url: str) -> str:
+def _crawl_in_new_loop(url: str, validated_hostname: str = "") -> str:
     """Run the async crawler in a fresh event loop on a worker thread.
-    On Windows this must be a ProactorEventLoop to support subprocesses.
+
+    Re-resolves the hostname to an IP immediately before crawling to
+    narrow the DNS-rebinding TOCTOU window. On Windows this must be a
+    ProactorEventLoop to support subprocesses.
     """
+    if validated_hostname:
+        try:
+            addr = socket.getaddrinfo(validated_hostname, 80)[0][4][0]
+            ip = ipaddress.ip_address(addr)
+            if ip.is_private or ip.is_loopback or ip.is_link_local:
+                raise ValidationException("URL resolves to an internal or private address")
+        except (socket.gaierror, ValueError, IndexError):
+            raise ValidationException("Could not resolve URL host")
+
     if sys.platform == "win32":
         loop = asyncio.ProactorEventLoop()
     else:
@@ -465,7 +477,7 @@ async def upload_document_url(
         # NotImplementedError on Windows (SelectorEventLoop can't spawn subprocesses)
         with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
             markdown = await asyncio.get_event_loop().run_in_executor(
-                pool, _crawl_in_new_loop, payload.url
+                pool, _crawl_in_new_loop, payload.url, hostname
             )
 
         if not markdown:
@@ -701,14 +713,12 @@ def update_document(
     """
     doc = db.query(Document).filter(
         Document.id == document_id,
+        Document.user_id == user.id,
         Document.is_deleted.is_(False),
     ).first()
 
     if not doc:
         raise NotFoundException("Document")
-
-    if str(doc.user_id) != str(user.id):
-        raise ForbiddenException("You do not have permission to update this document")
 
     if update.name is not None:
         doc.original_name = update.name


### PR DESCRIPTION
## Changes

This PR fixes 4 security/bug issues across `documents.py` and `chat.py`.

### #689 — IDOR: PUT /documents/{id} missing user_id filter
- Added `Document.user_id == user.id` to the query filter in `update_document`
- Removed brittle post-query string comparison and `ForbiddenException`
- Now consistent with `get_document`, `delete_document`, and other endpoints

### #690 — JWT token leaked in query parameter on export
- Removed `token: Optional[str]` query parameter from `export_chat_history`
- Replaced with standard `user: User = Depends(get_current_user)` authentication
- Prevents JWT leakage in server logs, browser history, referrer headers

### #692 — WebSocket missing Origin validation (CSWSH)
- Added `Origin` header validation before `websocket.accept()`
- Rejects connections from origins not in `settings.cors_origins` with close code 1008
- Prevents cross-site WebSocket hijacking

### #691 — SSRF DNS rebinding bypass in URL upload
- Added secondary DNS resolution check inside `_crawl_in_new_loop` immediately before crawling
- Passes validated `hostname` from the caller to narrow the TOCTOU window
- Rejects if the hostname resolves to a private/internal IP at crawl time

## Testing
- All fixes are self-contained and follow existing patterns in the codebase
- No new dependencies required
