### PR TITLE
fix: JWT token leaked in export endpoint query parameter

### DIFF
--- a/backend/app/routes/chat.py
+++ b/backend/app/routes/chat.py
@@ -19,7 +19,6 @@ from app.cache import get_cached_response, set_cached_response
 from app.database import get_db
 from app.exceptions import (
     NotFoundException,
-    UnauthorizedException,
     ValidationException, )
 from app.metrics import record_query_response_time
 from app.models import User, ChatMessage, Document, SharedMessage, ChatSession
@@ -946,26 +945,17 @@ def get_chat_history(
     summary="Export document chat history",
     description=(
         "Downloads one document's chat history as Markdown, plain text, or PDF. "
-        "The browser download flow authenticates with a query token."
+        "Uses standard authentication — no query tokens."
     ),
 )
 def export_chat_history(
     document_id: str,
     format: str = "md",
-    token: Optional[str] = None,
+    user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
     """Export the chat history for a document as a downloadable file."""
-    from app.auth import decode_token as _decode
-
-    resolved_user = None
-    if token:
-        user_id = _decode(token)
-        if user_id:
-            resolved_user = db.query(User).filter(User.id == user_id).first()
-
-    if resolved_user is None:
-        raise UnauthorizedException("Authentication required")
+    resolved_user = user
 
     if format not in ("md", "txt", "pdf"):
         raise ValidationException("Format must be 'md', 'txt', or 'pdf'")


### PR DESCRIPTION
## Description

Fixes #690 — JWT token accepted as query parameter in `export_chat_history`.

The `token` query parameter caused JWT leakage in server logs, browser history, referrer headers, and proxy logs. Replaced with standard `get_current_user` dependency matching all other authenticated endpoints.

## Changes

- `backend/app/routes/chat.py`: Removed `token` query parameter, replaced with `user: User = Depends(get_current_user)`
- Removed unused `UnauthorizedException` import
