### PR TITLE
fix: WebSocket missing Origin validation enables cross-site hijacking

### DIFF
--- a/backend/app/routes/chat.py
+++ b/backend/app/routes/chat.py
@@ -51,6 +51,13 @@ async def chat_ws(websocket: WebSocket, token: Optional[str] = Query(None)):
     Authenticate via `token` query param or expect first JSON message
     containing `{token, question, document_id?, session_id?}`.
     """
+    from app.config import get_settings as _get_settings
+    origin = websocket.headers.get("origin", "")
+    allowed = _get_settings().cors_origins
+    if origin and allowed and origin not in allowed:
+        await websocket.close(code=1008)
+        return
+
     await websocket.accept()
 
     # Simple DB-backed auth similar to get_current_user


### PR DESCRIPTION
## Description

Fixes #692 — WebSocket endpoint at `/chat/ws` accepts connections from any origin.

An attacker's website could open a WebSocket to the backend through an authenticated user's browser. No Origin validation existed since CORS middleware only covers HTTP routes, not WebSocket upgrades.

## Changes

- `backend/app/routes/chat.py`: Added `Origin` header validation before `websocket.accept()`
- Rejects connections from origins not in `settings.cors_origins` with WebSocket close code 1008 (Policy Violation)
- Empty origin is allowed (legitimate clients like browser extensions may not send it)
