### PR TITLE
fix: pickle.load RCE in BM25 index deserialization

### DIFF
--- a/backend/app/rag/bm25.py
+++ b/backend/app/rag/bm25.py
@@ -2,9 +2,9 @@
 BM25 Keyword Search implementation using rank_bm25.
 Stores a BM25 index per document to allow easy updates and deletions.
 """
+import json
 import os
 import glob
-import pickle
 import logging
 import re
 from typing import List, Dict, Any, Optional
@@ -19,6 +19,35 @@ except ImportError:
 logger = logging.getLogger(__name__)
 settings = get_settings()
 
+
+def _bm25_to_dict(bm25: BM25Okapi) -> dict:
+    """Serialize BM25Okapi internals to a JSON-safe dict."""
+    return {
+        "corpus_size": bm25.corpus_size,
+        "avgdl": bm25.avgdl,
+        "doc_freqs": [{str(k): v for k, v in doc.items()} for doc in bm25.doc_freqs],
+        "idf": {str(k): v for k, v in bm25.idf.items()},
+        "doc_len": bm25.doc_len,
+        "k1": bm25.k1,
+        "b": bm25.b,
+        "epsilon": bm25.epsilon,
+    }
+
+
+def _dict_to_bm25(data: dict) -> BM25Okapi:
+    """Reconstruct a BM25Okapi instance from a dict saved by _bm25_to_dict."""
+    bm25 = object.__new__(BM25Okapi)
+    bm25.corpus_size = data["corpus_size"]
+    bm25.avgdl = data["avgdl"]
+    bm25.doc_freqs = [{int(k): v for k, v in doc.items()} for doc in data["doc_freqs"]]
+    bm25.idf = {int(k): v for k, v in data["idf"].items()}
+    bm25.doc_len = data["doc_len"]
+    bm25.k1 = data["k1"]
+    bm25.b = data["b"]
+    bm25.epsilon = data["epsilon"]
+    return bm25
+
+
 def get_bm25_dir(user_id: str) -> str:
     """Get the directory path for a user's BM25 indexes."""
     clean_id = user_id.replace("-", "_")
@@ -26,13 +55,16 @@ def get_bm25_dir(user_id: str) -> str:
     os.makedirs(path, exist_ok=True)
     return path
 
+
 def get_bm25_path(user_id: str, document_id: str) -> str:
     """Get the file path for a specific document's BM25 index."""
-    return os.path.join(get_bm25_dir(user_id), f"{document_id}.pkl")
+    return os.path.join(get_bm25_dir(user_id), f"{document_id}.json")
+
 
 def tokenize(text: str) -> List[str]:
     """Tokenize by converting to lowercase and extracting all alphanumeric words."""
     return re.findall(r'\w+', text.lower())
+
 
 def store_bm25_index(chunks: List[Dict[str, Any]], document_id: str, filename: str, user_id: str):
     """
@@ -49,7 +81,6 @@ def store_bm25_index(chunks: List[Dict[str, Any]], document_id: str, filename: s
     tokenized_texts = [tokenize(text) for text in texts]
     bm25 = BM25Okapi(tokenized_texts)
 
-    # Format chunks to match vectorstore output
     formatted_chunks = []
     for chunk in chunks:
         chunk_idx = chunk.get("chunk_index")
@@ -63,17 +94,18 @@ def store_bm25_index(chunks: List[Dict[str, Any]], document_id: str, filename: s
         })
 
     data = {
-        "bm25": bm25,
-        "chunks": formatted_chunks
+        "bm25": _bm25_to_dict(bm25),
+        "chunks": formatted_chunks,
     }
 
     path = get_bm25_path(user_id, document_id)
     try:
-        with open(path, "wb") as f:
-            pickle.dump(data, f)
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False)
         logger.info(f"Stored BM25 index for document {document_id}")
     except Exception as e:
         logger.error(f"Failed to store BM25 index for {document_id}: {e}")
+
 
 def _query_single_index(path: str, tokenized_query: List[str], top_k: int) -> List[Dict[str, Any]]:
     """Query a single BM25 index file."""
@@ -81,31 +113,28 @@ def _query_single_index(path: str, tokenized_query: List[str], top_k: int) -> Li
         return []
 
     try:
-        with open(path, "rb") as f:
-            data = pickle.load(f)
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
     except Exception as e:
         logger.error(f"Failed to load BM25 index from {path}: {e}")
         return []
 
-    bm25 = data["bm25"]
+    bm25 = _dict_to_bm25(data["bm25"])
     chunks = data["chunks"]
 
     scores = bm25.get_scores(tokenized_query)
-    
-    # Get top_k indices sorted by score
+
     top_indices = sorted(range(len(scores)), key=lambda i: scores[i], reverse=True)[:top_k]
 
     results = []
     for i in top_indices:
         if scores[i] > 0:
             chunk = chunks[i].copy()
-            # Normalize BM25 score to 0-1 range roughly, or just keep raw.
-            # BM25 scores are usually > 0, often 1-10.
-            # We keep the raw score for now, RRF will handle the ranking.
             chunk["score"] = float(scores[i])
             results.append(chunk)
 
     return results
+
 
 def query_bm25(
     query: str,
@@ -121,11 +150,11 @@ def query_bm25(
         return []
 
     tokenized_query = tokenize(query)
-    
+
     if document_id:
         path = get_bm25_path(user_id, document_id)
         return _query_single_index(path, tokenized_query, top_k)
-    
+
     if document_ids:
         all_results = []
         for doc_id in document_ids:
@@ -135,18 +164,17 @@ def query_bm25(
                 all_results.extend(results)
         all_results.sort(key=lambda x: x["score"], reverse=True)
         return all_results[:top_k]
-    
-    # If no document_id and no document_ids, query all documents for this user
+
     user_dir = get_bm25_dir(user_id)
     all_results = []
-    
-    for path in glob.glob(os.path.join(user_dir, "*.pkl")):
+
+    for path in glob.glob(os.path.join(user_dir, "*.json")):
         results = _query_single_index(path, tokenized_query, top_k)
         all_results.extend(results)
-        
-    # Sort all results by score and take top_k
+
     all_results.sort(key=lambda x: x["score"], reverse=True)
     return all_results[:top_k]
+
 
 def delete_bm25_index(document_id: str, user_id: str):
     """Delete a specific document's BM25 index."""
@@ -158,12 +186,13 @@ def delete_bm25_index(document_id: str, user_id: str):
         except Exception as e:
             logger.warning(f"Error deleting BM25 index: {e}")
 
+
 def delete_user_bm25_indexes(user_id: str):
     """Delete all BM25 indexes for a user."""
     user_dir = get_bm25_dir(user_id)
     if os.path.exists(user_dir):
         try:
-            for path in glob.glob(os.path.join(user_dir, "*.pkl")):
+            for path in glob.glob(os.path.join(user_dir, "*.json")):
                 os.remove(path)
             os.rmdir(user_dir)
             logger.info(f"Deleted BM25 directory for user {user_id}")


### PR DESCRIPTION
## Description

Fixes #693 — `pickle.load` in BM25 index deserialization enables potential RCE.

Replaced unsafe `pickle` serialization with JSON. BM25Okapi internals are serialized to JSON-safe dicts and reconstructed via `object.__new__` + attribute assignment on load.

## Changes

- `backend/app/rag/bm25.py`:
  - Replaced `pickle.dump`/`pickle.load` with `json.dump`/`json.load`
  - Added `_bm25_to_dict()` helper for safe serialization of BM25Okapi internals
  - Added `_dict_to_bm25()` helper for safe reconstruction
  - Changed file extension from `.pkl` to `.json`
  - Updated all glob patterns from `*.pkl` to `*.json`
