### PR TITLE
fix: temp file leak in validate_upload when upload_document fails after validation

### DIFF
--- a/backend/app/routes/documents.py
+++ b/backend/app/routes/documents.py
@@ -255,14 +255,18 @@ async def upload_document(
 
     # ── Validate and save file to disk ───────────────
     temp_path = await validate_upload(file)
+    try:
+        user_dir = os.path.join(settings.UPLOAD_DIR, user.id)
+        os.makedirs(user_dir, exist_ok=True)
 
-    user_dir = os.path.join(settings.UPLOAD_DIR, user.id)
-    os.makedirs(user_dir, exist_ok=True)
+        stored_filename = f"{uuid.uuid4().hex}.{ext}"
+        filepath = os.path.join(user_dir, stored_filename)
 
-    stored_filename = f"{uuid.uuid4().hex}.{ext}"
-    filepath = os.path.join(user_dir, stored_filename)
+        shutil.move(temp_path, filepath)
+    except Exception:
+        Path(temp_path).unlink(missing_ok=True)
+        raise
 
-    shutil.move(temp_path, filepath)
     file_size = Path(filepath).stat().st_size
 
     # ── Create database record ───────────────────────
@@ -359,10 +363,13 @@ async def batch_upload_documents(
                 )
 
             temp_path = await validate_upload(file)
-
-            stored_filename = f"{uuid.uuid4().hex}.{ext}"
-            filepath = os.path.join(user_dir, stored_filename)
-            shutil.move(temp_path, filepath)
+            try:
+                stored_filename = f"{uuid.uuid4().hex}.{ext}"
+                filepath = os.path.join(user_dir, stored_filename)
+                shutil.move(temp_path, filepath)
+            except Exception:
+                Path(temp_path).unlink(missing_ok=True)
+                raise
             file_size = Path(filepath).stat().st_size
 
             document = Document(


### PR DESCRIPTION
## Description

Fixes #696 — Temp file leak in `validate_upload` when `upload_document` or `batch_upload_documents` fails after validation succeeds.

If `os.makedirs` or `shutil.move` fails after `validate_upload` returns a temp path, the temp file was never cleaned up, causing disk space leaks.

## Changes

- `backend/app/routes/documents.py`:
  - `upload_document`: Wrapped temp file usage in try/except that unlinks temp on any failure
  - `batch_upload_documents`: Same pattern for the per-file processing loop
