### PR TITLE
fix: add rate limiting to auth endpoints (#678)

### DIFF
--- a/backend/app/rate_limit.py
+++ b/backend/app/rate_limit.py
@@ -7,11 +7,13 @@ from limits.storage import storage_from_string
 from limits.strategies import FixedWindowRateLimiter
 from slowapi import Limiter
 from slowapi.util import get_remote_address
- 
- 
+
+
 CHAT_QUERY_RATE_LIMIT = "15/minute"
- 
- 
+LOGIN_RATE_LIMIT = "5/minute"
+REGISTER_RATE_LIMIT = "3/minute"
+
+
 def rate_limit_key_func(request: Request) -> str:
     """Use authenticated user id when available, otherwise fall back to client IP."""
     authorization = request.headers.get("authorization", "")
@@ -23,7 +25,7 @@ def rate_limit_key_func(request: Request) -> str:
             if user_id:
                 return f"user:{user_id}"
         except Exception:
-           pass
+            pass
     return f"ip:{get_remote_address(request)}"
 
 

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -11,7 +11,7 @@ from datetime import datetime, timedelta, timezone
 
 import httpx
 import jwt
-from fastapi import APIRouter, Depends, Query, status, Cookie, Response, Body
+from fastapi import APIRouter, Depends, Query, Request, status, Cookie, Response, Body
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi_mail import ConnectionConfig, FastMail, MessageSchema, MessageType
 from google_auth_oauthlib.flow import Flow
@@ -21,6 +21,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy import select
 from app.config import get_settings
 from app.database import get_db
+from app.rate_limit import limiter, LOGIN_RATE_LIMIT, REGISTER_RATE_LIMIT
 from app.exceptions import (
     AppException,
     ConflictException,
@@ -179,7 +180,8 @@ def _unique_google_username(email: str, db: Session) -> str:
 
 
 @router.post("/register", response_model=RegistrationResponse, status_code=status.HTTP_201_CREATED)
-async def register(payload: UserRegister, db: Session = Depends(get_db)):
+@limiter.limit(REGISTER_RATE_LIMIT)
+async def register(request: Request, payload: UserRegister, db: Session = Depends(get_db)):
     """
     Register a new user account and send a verification email.
 
@@ -236,7 +238,8 @@ async def register(payload: UserRegister, db: Session = Depends(get_db)):
 
 
 @router.post("/login", response_model=TokenResponse)
-def login(payload: UserLogin, db: Session = Depends(get_db)):
+@limiter.limit(LOGIN_RATE_LIMIT)
+def login(request: Request, payload: UserLogin, db: Session = Depends(get_db)):
     """
     Authenticate a user with email and password.
 
@@ -292,7 +295,8 @@ def login(payload: UserLogin, db: Session = Depends(get_db)):
 
 
 @router.post("/google", response_model=TokenResponse)
-def login_with_google(payload: GoogleLoginRequest, db: Session = Depends(get_db)):
+@limiter.limit(LOGIN_RATE_LIMIT)
+def login_with_google(request: Request, payload: GoogleLoginRequest, db: Session = Depends(get_db)):
     """
     Authenticate with a Google Identity Services ID token.
 

--- a/backend/tests/test_rate_limit.py
+++ b/backend/tests/test_rate_limit.py
@@ -14,6 +14,8 @@ from slowapi.errors import RateLimitExceeded
 from app.auth import create_access_token
 from app.rate_limit import CHAT_QUERY_RATE_LIMIT, rate_limit_key_func
 from app.routes.chat import ask_question, ask_question_stream
+from app.rate_limit import LOGIN_RATE_LIMIT, REGISTER_RATE_LIMIT
+from app.routes.auth import login, register, login_with_google
 from app.main import app
 
 
@@ -46,6 +48,12 @@ def test_chat_endpoints_use_required_rate_limit():
     assert ask_question.__rate_limits__ == [CHAT_QUERY_RATE_LIMIT]
     assert ask_question_stream.__rate_limits__ == [CHAT_QUERY_RATE_LIMIT]
 
+def test_auth_endpoints_use_required_rate_limit():
+    assert LOGIN_RATE_LIMIT == "5/minute"
+    assert REGISTER_RATE_LIMIT == "3/minute"
+    assert login.__rate_limits__ == [LOGIN_RATE_LIMIT]
+    assert register.__rate_limits__ == [REGISTER_RATE_LIMIT]
+    assert login_with_google.__rate_limits__ == [LOGIN_RATE_LIMIT]
 
 # ── Middleware 429 Response Verification ──────────────────────────────────────
 


### PR DESCRIPTION
## 📋 PR Checklist
 
### 🔗 Related Issue
Closes #678
 
---
 
### 📝 What does this PR do?
 
The SlowAPI limiter in `app/rate_limit.py` was already configured and wired into the app (middleware + exception handler in `main.py`) and used on the chat routes, but it was never applied to the auth endpoints. That left `/auth/login`, `/auth/register`, and `/auth/google` with no brute-force or credential-stuffing protection.
 
This adds two limits to `rate_limit.py` (`LOGIN_RATE_LIMIT = "5/minute"`, `REGISTER_RATE_LIMIT = "3/minute"`) and decorates the three endpoints with `@limiter.limit(...)`, adding the `request: Request` parameter SlowAPI requires. Login and Google login share the login limit since both are credential entry points; register gets the stricter 3/minute.
 
---
 
### 🗂️ Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔧 Refactor / code cleanup
- [ ] 📝 Documentation update
- [ ] 🎨 UI / styling change
- [ ] ⚙️ CI / tooling / config change
- [x] 🧪 Tests
---
 
### 🧪 How was this tested?
- [ ] Ran the backend locally (`uvicorn app.main:app --reload`)
- [ ] Ran the frontend locally (`npm run dev` inside `frontend/`)
- [ ] Tested the affected API endpoints manually
- [x] Added / updated tests
Added a test in `tests/test_rate_limit.py` that asserts the three auth endpoints carry the right limits, matching the existing `test_chat_endpoints_use_required_rate_limit` pattern. All 8 tests in that file pass locally.
 
---
 
### ⚠️ Anything to flag for reviewers?
 
I scoped this to the three endpoints the issue named. The HuggingFace OAuth callback also creates sessions, but it isn't a password/credential entry point in the same way, so I left it out to keep the change focused. Can add it if you'd prefer.
 
---
 
### ✅ Self-Review Checklist
- [x] My branch is based on **`dev`**, not `main`
- [x] I have not added any secrets / API keys
- [x] I have not modified `main` branch or any HuggingFace deployment config
- [x] My code follows the existing style (no unnecessary formatting changes)
- [x] I have updated relevant docs / comments if needed