### PR TITLE
fix: require and verify current password before allowing password change

### DIFF
--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -509,50 +509,58 @@ def update_user_info(payload:UserUpdate,
         raise ValidationException("Database error")
 
 @router.put("/password")
-def update_password(payload:UpdatePassword,
+def update_password(payload: UpdatePassword,
                     user: User = Depends(get_current_user),
-                    db: Session = Depends(get_db))-> UpdatePasswordResponse:
+                    db: Session = Depends(get_db)) -> UpdatePasswordResponse:
     """Update the authenticated user's password.
 
-    Validates that both the new password and confirmation are provided and
-    match each other. If valid, the password is hashed and stored. The user
-    record is then committed to the database.
+    Requires the user's current password to be supplied and verified
+    against the stored hash before allowing the change. This prevents
+    a stolen or leaked access token from being used to take over an
+    account by changing its password without knowing the original one.
 
     Args:
-        payload: UpdatePassword object containing `password` and `confirm_password` fields.
-        user: The currently authenticated user, obtained from the `get_current_user` dependency.
+        payload: UpdatePassword object containing `current_password`,
+            `password`, and `confirm_password` fields.
+        user: The currently authenticated user, obtained from the
+            `get_current_user` dependency.
         db: SQLAlchemy database session, obtained from the dependency.
 
     Returns:
-        UpdatePasswordResponse: The updated user object (typically containing 
-        user details excluding the password hash).
+        UpdatePasswordResponse: The updated user object.
 
     Raises:
         HTTPException: 400 if:
-            - Either `password` or `confirm_password` is missing or empty.
-            - The two password fields do not match.
+            - `current_password` does not match the stored hash.
+            - `password` or `confirm_password` is missing or empty.
+            - The two new password fields do not match.
             - A database error (SQLAlchemyError) occurs during commit.
-
-    Note:
-        The function hashes the password using `hash_password()` before
-        saving. Any `SQLAlchemyError` triggers a rollback and raises a 400
-        response.
     """
-    if not payload.password and not payload.confirm_password:
-        raise ValidationException("Password and confirm_password are required")
-    if len(payload.password) == 0 and len(payload.confirm_password) == 0:
-        raise ValidationException("Password and confirm_password are required")
+    if not payload.current_password:
+        raise HTTPException(status_code=400, detail="Current password is required")
+
+    if not verify_password(payload.current_password, user.hashed_password):
+        raise HTTPException(status_code=400, detail="Current password is incorrect")
+
+    if not payload.password or not payload.confirm_password:
+        raise HTTPException(status_code=400, detail="Password and confirm_password are required")
+
     if payload.password != payload.confirm_password:
-        raise ValidationException("Password and confirm_password are different")
+        raise HTTPException(status_code=400, detail="Password and confirm_password are different")
+
+    if payload.password == payload.current_password:
+        raise HTTPException(status_code=400, detail="New password must be different from the current password")
+
     try:
-        hashed_password = hash_password(payload.password)
-        user.hashed_password = hashed_password
+        user.hashed_password = hash_password(payload.password)
         db.commit()
         db.refresh(user)
         return user
+    except HTTPException:
+        raise
     except SQLAlchemyError:
         db.rollback()
-        raise ValidationException("Database error")
+        raise HTTPException(status_code=400, detail="Database error")
 
 
 @router.post("/change-password", response_model=MessageResponse)

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -517,7 +517,8 @@ def update_password(payload: UpdatePassword,
     Requires the user's current password to be supplied and verified
     against the stored hash before allowing the change. This prevents
     a stolen or leaked access token from being used to take over an
-    account by changing its password without knowing the original one.
+    account by changing its password without ever knowing the original
+    one.
 
     Args:
         payload: UpdatePassword object containing `current_password`,
@@ -530,37 +531,39 @@ def update_password(payload: UpdatePassword,
         UpdatePasswordResponse: The updated user object.
 
     Raises:
-        HTTPException: 400 if:
+        ValidationException: 400 if:
+            - `current_password` is missing.
             - `current_password` does not match the stored hash.
             - `password` or `confirm_password` is missing or empty.
             - The two new password fields do not match.
+            - The new password is the same as the current password.
             - A database error (SQLAlchemyError) occurs during commit.
     """
     if not payload.current_password:
-        raise HTTPException(status_code=400, detail="Current password is required")
+        raise ValidationException("Current password is required")
 
     if not verify_password(payload.current_password, user.hashed_password):
-        raise HTTPException(status_code=400, detail="Current password is incorrect")
+        raise ValidationException("Current password is incorrect")
 
     if not payload.password or not payload.confirm_password:
-        raise HTTPException(status_code=400, detail="Password and confirm_password are required")
+        raise ValidationException("Password and confirm_password are required")
 
     if payload.password != payload.confirm_password:
-        raise HTTPException(status_code=400, detail="Password and confirm_password are different")
+        raise ValidationException("Password and confirm_password are different")
 
     if payload.password == payload.current_password:
-        raise HTTPException(status_code=400, detail="New password must be different from the current password")
+        raise ValidationException("New password must be different from the current password")
 
     try:
         user.hashed_password = hash_password(payload.password)
         db.commit()
         db.refresh(user)
         return user
-    except HTTPException:
+    except ValidationException:
         raise
     except SQLAlchemyError:
         db.rollback()
-        raise HTTPException(status_code=400, detail="Database error")
+        raise ValidationException("Database error")
 
 
 @router.post("/change-password", response_model=MessageResponse)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -79,6 +79,7 @@ class UserUpdateResponse(BaseModel):
     email: EmailStr
 
 class UpdatePassword(BaseModel):
+    current_password: str
     password: str
     confirm_password: str
 


### PR DESCRIPTION
## 🔗 Related Issue
Closes #688 

---

## 📝 What does this PR do?
`PUT /auth/password` previously allowed a user to change their password using only a valid access token — the current password was never required or verified. This meant a stolen or leaked JWT (e.g. via XSS, or a session left open on a shared device) could be used to take over an account by changing its password without ever knowing the original one.

**Fix:**
- Added `current_password` field to the `UpdatePassword` 
  schema in `schemas.py`
- `update_password` now verifies `current_password` 
  against the stored hash using the existing 
  `verify_password()` helper before allowing any change
- Returns `400 Current password is incorrect` if it 
  doesn't match
- Returns `400 Current password is required` if the field 
  is missing/empty
- Added a guard so the new password must differ from the 
  current one (`400 New password must be different from 
  the current password`)
- Existing validation (password/confirm_password match, 
  non-empty, DB error handling) is preserved exactly as-is

No frontend currently calls this endpoint (the Settings page only has read-only account info, no password form 
yet), so this is a backend-only hardening fix with no breaking change to existing functionality.

---

## Type of Change
- [x] 🐛 Bug fix
- [x] 🔒 Security fix

---

## 🧪 How was this tested?
- [ ] Ran the backend locally (`uvicorn app.main:app --reload`)
- [x] Tested the affected API endpoint manually via 
      `/docs` (FastAPI Swagger UI):
  - Wrong `current_password` → 400 "Current password is 
    incorrect" ✅
  - Correct `current_password`, mismatched new 
    password/confirm → 400 "Password and confirm_password 
    are different" ✅
  - Correct `current_password`, matching new password → 
    200, password updated successfully ✅
  - New password same as current → 400 "New password must 
    be different from the current password" ✅
- [x] Reviewed full diff to confirm only `update_password` 
      and `UpdatePassword` schema were touched — no other 
      endpoints affected

---

## ⚠️ Anything to flag for reviewers?
This is a backend-only fix since no frontend "Change Password" form currently exists. If a frontend form is added later (e.g. in the Settings page), it will need to send `current_password` along with the new password — happy to follow up with that as a separate PR if useful.

---

## ✅ Self-Review Checklist
- [x] My branch is based on **`dev`**, not `main`
- [x] I have not added any secrets / API keys
- [x] I have not modified `main` branch or any 
      HuggingFace deployment config
- [x] My code follows the existing style 
      (no unnecessary formatting changes)
- [x] I have updated relevant docs / comments if needed